### PR TITLE
docs(readme): require --HEAD for brew install while formula is HEAD-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,13 @@ storage, native CACAO authentication, and WASM Component Model execution.
 ```bash
 # Tap the kotoba formula
 brew tap etzhayyim/kotoba          # one-time
-brew install kotoba                # installs the `kotoba` binary
+brew install --HEAD kotoba         # installs the `kotoba` binary (HEAD-only)
 ```
 
-Or, until the tap is published, install the formula directly from this repo:
+`--HEAD` is required while the formula tracks `main` (no tagged release
+yet); once a stable tag exists, plain `brew install kotoba` will work.
+
+Or, install the formula directly from this repo without tapping:
 
 ```bash
 brew install --HEAD --build-from-source ./Formula/kotoba.rb


### PR DESCRIPTION
## Summary

- The Homebrew snippet in README says `brew install kotoba`, but `Formula/kotoba.rb` is head-only (no stable `url` + `sha256`). Modern Homebrew rejects it with `Error: ... HEAD-only formula. run: brew install --HEAD etzhayyim/kotoba/kotoba`.
- Switch to `brew install --HEAD kotoba` and reword the fallback section (the tap **is** published — the local-formula install is just an alternative, not a workaround).

Sibling PR on the tap: https://github.com/etzhayyim/homebrew-kotoba/pull/1 (will be assigned PR number on open).

## Reproduction

```
$ brew tap etzhayyim/kotoba
Tapped 1 formula.
$ brew install kotoba
Error: etzhayyim/kotoba/kotoba is a HEAD-only formula.
To install it, run:
  brew install --HEAD etzhayyim/kotoba/kotoba
```

## Test plan

- [x] Confirmed `brew install kotoba` (no flag) fails with HEAD-only error
- [x] `cargo install --locked --git https://github.com/etzhayyim/kotoba.git kotoba-cli --bin kotoba` (the same path the formula uses) succeeds: 2m01s on aarch64-darwin, 41 MB binary at `~/.cargo/bin/kotoba`
- [x] Formula `test do` block verified against the cargo-installed binary:
  - `kotoba --help` lists 14 subcommands incl. `serve`, `sparql`, `did-derive`, `cacao-sign`, `commit`, `bench`
  - `kotoba did-derive 00…01` → `did:key:z6MkjchhfUsD6mmvni8mCdXHw216Xrm9bQe2mBH1P5RDjVJG`
- [ ] Future: cut a `v0.1.0` tag + GH Release and switch the formula to `url` + `sha256` so plain `brew install kotoba` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)