### PR TITLE
feat(formula): pin to v0.1.0 stable tarball + drop --HEAD requirement

### DIFF
--- a/Formula/kotoba.rb
+++ b/Formula/kotoba.rb
@@ -1,10 +1,9 @@
 class Kotoba < Formula
   desc "Content-addressed distributed Datalog database with native CACAO auth"
   homepage "https://github.com/etzhayyim/kotoba"
+  url "https://github.com/etzhayyim/kotoba/archive/refs/tags/v0.1.0.tar.gz"
+  sha256 "cdf1099d970aa6e5be0e88099fc58bcefea58cadec63392863c3b7538a883655"
   license "Apache-2.0"
-
-  # Track the upstream main branch.  Once tagged releases exist, swap the
-  # head-only block for `url "…vN.tar.gz"` + sha256.
   head "https://github.com/etzhayyim/kotoba.git", branch: "main"
 
   depends_on "rust" => :build

--- a/README.md
+++ b/README.md
@@ -19,16 +19,20 @@ storage, native CACAO authentication, and WASM Component Model execution.
 ```bash
 # Tap the kotoba formula
 brew tap etzhayyim/kotoba          # one-time
-brew install --HEAD kotoba         # installs the `kotoba` binary (HEAD-only)
+brew install kotoba                # installs the `kotoba` binary
 ```
 
-`--HEAD` is required while the formula tracks `main` (no tagged release
-yet); once a stable tag exists, plain `brew install kotoba` will work.
+To track the upstream `main` branch instead of the latest tagged release,
+add `--HEAD`:
+
+```bash
+brew install --HEAD kotoba
+```
 
 Or, install the formula directly from this repo without tapping:
 
 ```bash
-brew install --HEAD --build-from-source ./Formula/kotoba.rb
+brew install --build-from-source ./Formula/kotoba.rb
 ```
 
 ### From source (any platform)


### PR DESCRIPTION
## Summary

This repo cut its first tagged release [`v0.1.0`](https://github.com/etzhayyim/kotoba/releases/tag/v0.1.0) (commit `a5a86740b9`, the post-README-fix tip of main, created in the same flow as this PR).  Switch the in-repo `Formula/kotoba.rb` mirror from head-only to a stable `url` + `sha256` so plain `brew install kotoba` (and `brew install --build-from-source ./Formula/kotoba.rb`) work without `--HEAD`.

```
url    https://github.com/etzhayyim/kotoba/archive/refs/tags/v0.1.0.tar.gz
sha256 cdf1099d970aa6e5be0e88099fc58bcefea58cadec63392863c3b7538a883655
```

The `head` block is retained so users tracking upstream main can still `brew install --HEAD kotoba`.

README updated:
- restore the tap install snippet to plain `brew install kotoba`
- move `--HEAD` to an optional "track main" section
- drop the now-stale `--HEAD` flag from the local-formula fallback

Sibling PR on the tap (same formula change): https://github.com/etzhayyim/homebrew-kotoba/pull/2 (number TBD).

## Verification

```
$ brew style etzhayyim/kotoba/kotoba
1 file inspected, no offenses detected

$ brew fetch --formula etzhayyim/kotoba/kotoba
==> Fetching kotoba from etzhayyim/kotoba
✔︎ Formula kotoba (0.1.0)
```

`brew audit --strict` is currently blocked by my host's outdated Xcode (16.4 vs brew's required 26.3) — that's a host environment issue, not a formula issue.  CI on a current macOS runner would clear it.

## Test plan

- [x] `brew style` — no offenses (`url` placed before `license` per ComponentsOrder)
- [x] `brew fetch` — tarball downloads and sha256 matches
- [x] Formula `test do` block previously verified against cargo-built binary from `3d93fec7` (parent of v0.1.0 release commit)
- [ ] End-to-end `brew install kotoba` on a host with current Xcode/CLT (deferred to merger or CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)