### PR TITLE
fix(kotoba-runtime): bump wasmtime 22→25 to run componentize-py WASM agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -1226,21 +1226,32 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.109.1"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad7096c10a285583f2ed620c0c85d7baf745922e33415290f2900b73319f1e0"
+checksum = "69792bd40d21be8059f7c709f44200ded3bbd073df7eb3fa3c282b387c7ffa5b"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
-name = "cranelift-codegen"
-version = "0.109.1"
+name = "cranelift-bitset"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd0d5b0dcd4a4e18c6352304d76f1c63258b5b2c248fc261b89c3a02952d51ff"
+checksum = "38da1eb6f7d8cdfa92f05acfae63c9a1d7a337e49ce7a2d0769c7fa03a2613a5"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "cranelift-codegen"
+version = "0.112.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709f5567a2bff9f06edf911a7cb5ebb091e4c81701714dc6ab574d08b4a69a0d"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
+ "cranelift-bitset",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
  "cranelift-control",
@@ -1250,50 +1261,51 @@ dependencies = [
  "hashbrown 0.14.5",
  "log",
  "regalloc2",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.2",
  "smallvec",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.109.1"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d14aa8551924931235a4eec42d561a8415d5a758267a549575a3fe0e13ba84f"
+checksum = "72d39a6b194c069fd091ca1f17b9d86ff1a4627ccad8806095828f61989a691f"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.109.1"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "315a326e9f63b996f55e93b73a9a239b55f2de1211fcfbcc99d9423f44dc6ded"
+checksum = "18f81aefad1f80ed4132ae33f40b92779eeb57edeb1e28bb24424a4098c963a2"
 
 [[package]]
 name = "cranelift-control"
-version = "0.109.1"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806ca69ca5aa8422035543444e1dc936f8f3e7f6854d562ef31db9fe30355c5c"
+checksum = "6adbaac785ad4683c4f199686f9e15c1471f52ae2f4c013a3be039b4719db754"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.109.1"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9778487136bf37f9007920d9cb332a020e5d7259c1fbf35e625368eb88c7bfe"
+checksum = "70b85ed43567e13782cd1b25baf42a8167ee57169a60dfd3d7307c6ca3839da0"
 dependencies = [
+ "cranelift-bitset",
  "serde",
  "serde_derive",
 ]
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.109.1"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55326cb3b61ca368210899a35892bca66aea4d75e8ceb5464e0539906c2ffb61"
+checksum = "8349f71373bb69c6f73992c6c1606236a66c8134e7a60e04e03fbd64b1aa7dcf"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1303,15 +1315,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.109.1"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4807df8ebad0106f207bcdc1f38199200ed175066b4122689e7f18e33ec8548c"
+checksum = "464a6b958ce05e0c237c8b25508012b6c644e8c37348213a8c786ba29e28cfdb"
 
 [[package]]
 name = "cranelift-native"
-version = "0.109.1"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c24c076002cb6a926a3f7220040278c7178878cd9142a418ddef9ee5b84963"
+checksum = "ffc4acaf6894ee323ff4e9ce786bec09f0ebbe49941e8012f1c1052f1d965034"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1320,9 +1332,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.109.1"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66ba3e8a666222d2df5a79a1279282c04545c4ca9712b7d85f4f54937617a533"
+checksum = "b878860895cca97454ef8d8b12bfda9d0889dd49efee175dba78d54ff8363ec2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1330,7 +1342,7 @@ dependencies = [
  "itertools 0.12.1",
  "log",
  "smallvec",
- "wasmparser 0.209.1",
+ "wasmparser 0.217.1",
  "wasmtime-types",
 ]
 
@@ -1552,7 +1564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2549,9 +2561,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 dependencies = [
  "fallible-iterator",
  "indexmap",
@@ -2703,15 +2715,6 @@ dependencies = [
  "rand 0.9.4",
  "rand_distr",
  "zerocopy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
 ]
 
 [[package]]
@@ -3055,7 +3058,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.58.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4710,15 +4713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "metal"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6035,13 +6029,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.9.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
+checksum = "12908dbeb234370af84d0579b9f68258a0f67e201412dd9a2814e6f45b2fc0f0"
 dependencies = [
- "hashbrown 0.13.2",
+ "hashbrown 0.14.5",
  "log",
- "rustc-hash 1.1.0",
+ "rustc-hash 2.1.2",
  "slice-group-by",
  "smallvec",
 ]
@@ -6476,6 +6470,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "seq-macro"
@@ -7924,9 +7922,9 @@ checksum = "684365b586a9a6256c1cc3544eee8680de48d6041142f581776ec7b139622ae9"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.209.1"
+version = "0.217.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a05336882dae732ce6bd48b7e11fe597293cb72c13da4f35d7d5f8d53b2a7"
+checksum = "10961fd76db420582926af70816dd205019d8152d9e51e1b939125dd1639f854"
 dependencies = [
  "leb128",
 ]
@@ -8004,9 +8002,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.209.1"
+version = "0.217.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07035cc9a9b41e62d3bb3a3815a66ab87c993c06fe1cf6b2a3f2a18499d937db"
+checksum = "65a5a0689975b9fd93c02f5400cfd9669858b99607e54e7b892c6080cba598bb"
 dependencies = [
  "ahash",
  "bitflags 2.11.1",
@@ -8054,23 +8052,25 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.209.1"
+version = "0.217.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceca8ae6eaa8c7c87b33c25c53bdf299f8c2a764aee1179402ff7652ef3a6859"
+checksum = "324c6782d7b81c01625335d252653b26ea68e835ddb4aef4cb1ed3ea40ae3a49"
 dependencies = [
  "anyhow",
- "wasmparser 0.209.1",
+ "termcolor",
+ "wasmparser 0.217.1",
 ]
 
 [[package]]
 name = "wasmtime"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9de397b45aa057cbadd8fbef22227779ef05121d9f47ac55c9a1ff77e0c29695"
+checksum = "f38dbf42dc56a6fe41ccd77211ea8ec90855de05e52cd00df5a0a3bca87d6147"
 dependencies = [
  "addr2line",
  "anyhow",
  "async-trait",
+ "bitflags 2.11.1",
  "bumpalo",
  "cc",
  "cfg-if",
@@ -8085,7 +8085,6 @@ dependencies = [
  "log",
  "mach2",
  "memfd",
- "memoffset",
  "object 0.36.7",
  "once_cell",
  "paste",
@@ -8100,8 +8099,8 @@ dependencies = [
  "smallvec",
  "sptr",
  "target-lexicon",
- "wasm-encoder 0.209.1",
- "wasmparser 0.209.1",
+ "wasm-encoder 0.217.1",
+ "wasmparser 0.217.1",
  "wasmtime-asm-macros",
  "wasmtime-cache",
  "wasmtime-component-macro",
@@ -8120,18 +8119,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379c81227d624024d8b950a9eb7fc48671f77fff368e021d9b6f16c83a650369"
+checksum = "30e0c7f9983c2d60109a939d9ab0e0df301901085c3608e1c22c27c98390a027"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0263fb2e1174e72a69766f2d38bf02060d4a240fc732cc0c7a6eed2d10f3d6c5"
+checksum = "e52eaa50abc14a9a2550d05e99e5e72d43ba75ea99cac1a440b61f1b9b87cd11"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -8149,9 +8148,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f579efa3807fc05078939d001e9295f3ab65613345fa7fe0c19875129aabae4"
+checksum = "0929ffffaca32dd8770b56848c94056036963ca05de25fb47cac644e20262168"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -8159,20 +8158,20 @@ dependencies = [
  "syn 2.0.117",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.209.1",
+ "wit-parser 0.217.1",
 ]
 
 [[package]]
 name = "wasmtime-component-util"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e935348dec39c79e895f80dd9ea7726b0c9059ef6210deae0c58e7e327422adc"
+checksum = "fdc29d2b56629d66d2fd791d1b46471d0016e0d684ed2dc299e870d127082268"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8ec68af53f896a8c98ce7c540762686239b6b81f83d95ef2a074d8b0d67443"
+checksum = "f8c8af1197703f4de556a274384adf5db36a146f9892bc9607bad16881e75c80"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8185,21 +8184,23 @@ dependencies = [
  "gimli",
  "log",
  "object 0.36.7",
+ "smallvec",
  "target-lexicon",
  "thiserror 1.0.69",
- "wasmparser 0.209.1",
+ "wasmparser 0.217.1",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e41bba8b753ccb9426986b106fa03820bc04e097f02e09f28ce85ca0191d7db0"
+checksum = "3f1b5af7bac868c5bce3b78a366a10677caacf6e6467c156301297e36ed31f3e"
 dependencies = [
  "anyhow",
  "cpp_demangle",
+ "cranelift-bitset",
  "cranelift-entity",
  "gimli",
  "indexmap",
@@ -8207,11 +8208,12 @@ dependencies = [
  "object 0.36.7",
  "postcard",
  "rustc-demangle",
+ "semver",
  "serde",
  "serde_derive",
  "target-lexicon",
- "wasm-encoder 0.209.1",
- "wasmparser 0.209.1",
+ "wasm-encoder 0.217.1",
+ "wasmparser 0.217.1",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -8219,9 +8221,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "347ca97a2b4d5f957ab29a0b128b4c58b420bbd5f34f04bf288ed2908a26f494"
+checksum = "665ccc1bb0f28496e6fa02e94c575ee9ad6e3202c7df8591e5dda78106d5aa4a"
 dependencies = [
  "anyhow",
  "cc",
@@ -8234,9 +8236,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb2b7545bf13c125d007fd1808cf4c6fb4688258e47f7a3ea96ffc04d173a15"
+checksum = "106731c6ebe1d551362ee8c876d450bdc2d517988b20eb3653dc4837b1949437"
 dependencies = [
  "object 0.36.7",
  "once_cell",
@@ -8246,9 +8248,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e7ccd55d5dfff4fb7abc889137c5af6531ad57bbd5890651f7e22533a61c7d"
+checksum = "5d7314e32c624f645ad7d6b9fc3ac89eb7d2b9aa06695d6445cec087958ec27d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8258,28 +8260,29 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df4e5141e11e6f12330450d97f289ccc8f7de2d3c2db7c46252ccd95d78f093"
+checksum = "f75cba1a8cc327839f493cfc3036c9de3d077d59ab76296bc710ee5f95be5391"
 
 [[package]]
 name = "wasmtime-types"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2017ea47e7a91440f94cc29f5f41d303e80f979a5384bf560d4b0afdabe32d0"
+checksum = "c6d83a7816947a4974e2380c311eacb1db009b8bad86081dc726b705603c93c7"
 dependencies = [
+ "anyhow",
  "cranelift-entity",
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser 0.209.1",
+ "wasmparser 0.217.1",
 ]
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455fc30062a08ba6a9c2ccc6e8c76ea2759d01324d3548324f5d38257d0e8d96"
+checksum = "6879a8e168aef3fe07335343b7fbede12fa494215e83322e173d4018e124a846"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8288,9 +8291,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a444e11ad3e76b56e8ce0413ffa7ddd29a662d97eeec6ce4f5cc61273405cbe"
+checksum = "d042ea66b2834fb03b8a6968ef1a99a4b537211b00f7502a4d6a37f4eb2049b2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8319,16 +8322,16 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de67dfca76c725b17179185c6ce2d78766656e150b86773b4ddbd2257240ef57"
+checksum = "6baca2a919a288df653246069868b4de80f07e9679a8ef9b78ad79fc658ffd12"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
  "gimli",
  "object 0.36.7",
  "target-lexicon",
- "wasmparser 0.209.1",
+ "wasmparser 0.217.1",
  "wasmtime-cranelift",
  "wasmtime-environ",
  "winch-codegen",
@@ -8336,14 +8339,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b893eec1dbf19e20beb6f2821ddd9672978db0e7c00ab8bb628afaad823783"
+checksum = "3f571f63ac1d532e986eb3973bbef3a45e4ae83de521a8d573b0fe0594dc9608"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
  "indexmap",
- "wit-parser 0.209.1",
+ "wit-parser 0.217.1",
 ]
 
 [[package]]
@@ -8532,9 +8535,9 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
 name = "wiggle"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "295be9884e59f55bb5073bb1076b464e7b966c618721406318b23b38dcb68245"
+checksum = "4c8fdcd81702e0f46a8ab2ed28a5bf824aabf4a1af1673af496a020aacd0b6f9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8547,9 +8550,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a164f3ec354726e58b88e008d7b3e1f04fe157ab60e8b3e3c1433ceab2e97041"
+checksum = "14f745361f0a9071aaabd05de1bb2b782d9f0597f30d9c0f20326224902e64d5"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -8562,9 +8565,9 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "22.0.1"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b99d96cf58ead37d095314e8d47a34b995bb50495c4866ec03fa468e0075d2"
+checksum = "bfbdae3574621921ed3c13325edc910388487759d10fb330f656cfc69bee38db"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8605,9 +8608,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.20.1"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51d823bdea98f7ce9db47909f1c543b5ae253d3df1aebf7ba3c0f25444daef2"
+checksum = "01cd1dc56c5a45d509ff06e7ca8817eaa9ec3240096f07e71915d5d528658e8a"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -8615,7 +8618,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.209.1",
+ "wasmparser 0.217.1",
  "wasmtime-cranelift",
  "wasmtime-environ",
 ]
@@ -9232,9 +9235,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.209.1"
+version = "0.217.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e79b9e3c0b6bb589dec46317e645851e0db2734c44e2be5e251b03ff4a51269"
+checksum = "e5aaf02882453eaeec4fe30f1e4263cfd8b8ea36dd00e1fe7d902d9cb498bccd"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -9245,7 +9248,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.209.1",
+ "wasmparser 0.217.1",
 ]
 
 [[package]]

--- a/crates/kotoba-runtime/Cargo.toml
+++ b/crates/kotoba-runtime/Cargo.toml
@@ -22,8 +22,8 @@ ciborium.workspace    = true
 bytes.workspace       = true
 
 # WASM component model runtime
-wasmtime        = { version = "22", features = ["component-model"] }
-wasmtime-wasi   = { version = "22" }
+wasmtime        = { version = "25", features = ["component-model"] }
+wasmtime-wasi   = { version = "25" }
 
 # Caching compiled WASM components
 dashmap = "5"

--- a/crates/kotoba-runtime/src/host.rs
+++ b/crates/kotoba-runtime/src/host.rs
@@ -204,11 +204,12 @@ impl KotobaEngine {
     pub fn new() -> Result<Self> {
         let mut config = Config::new();
         config.wasm_component_model(true);
-        // TODO(wasmtime-upgrade): componentize-py 0.23 emits extended-const expressions
-        // (i32.add in global initializers). wasmtime 22 disables this proposal by default
-        // and has no public Config API to re-enable it. Upgrade the wasmtime pin in
-        // Cargo.toml to "24" or later and add `config.wasm_extended_const(true)` here.
-        // Until then, Python-compiled WASM agents fail with CompileFailed on first load.
+        // componentize-py 0.23 emits extended-const expressions (i32.add in global
+        // initializers). wasmtime <25 rejected these with CompileFailed and had no
+        // Config toggle; wasmtime 25 implements the extended-const proposal (enabled
+        // explicitly here for intent). Without it, Python-compiled WASM agents fail
+        // to load.
+        config.wasm_extended_const(true);
         let engine = Engine::new(&config)?;
         Ok(Self(engine))
     }

--- a/crates/kotoba-vm/src/agent.rs
+++ b/crates/kotoba-vm/src/agent.rs
@@ -48,7 +48,7 @@ use kotoba_kqe::{
     arrangement::Arrangement,
     datom::{Datom, Value as DatomValue},
     delta::Delta,
-    quad::{Quad, QuadObject},
+    quad::{LegacyQuad as Quad, LegacyQuadObject as QuadObject},
 };
 use kotoba_runtime::host::InferenceFn;
 use std::collections::HashMap;

--- a/crates/kotoba-vm/src/auth_actor.rs
+++ b/crates/kotoba-vm/src/auth_actor.rs
@@ -1,6 +1,6 @@
 use kotoba_auth::{cacao::Cacao, delegation::DelegationChain};
 use kotoba_core::{cid::KotobaCid, policy::DataPolicy};
-use kotoba_kqe::quad::LegacyQuad;
+use kotoba_kqe::quad::LegacyQuad as Quad;
 /// Actor-first, crypto-aware Pregel types.
 ///
 /// The PRE proxy in kotoba-server decrypts all inbound messages and encrypts

--- a/examples/kotoba-langgraph-hello/aria_kotoba.py
+++ b/examples/kotoba-langgraph-hello/aria_kotoba.py
@@ -1,0 +1,119 @@
+"""aria (kotoba-native port) — 6-signal parallel ingest + Von Neumann minimax.
+
+Faithful port of magatama's ARIA actor
+(`20-actors/magatama/py/src/pymagatama/agents/aria.py`) onto the WASM-native
+`kotoba_langgraph` API so it compiles to a kotoba-node component and runs on a
+live kotoba server via invoke.run / kotoba_wasm_run.
+
+Graph (identical to upstream):
+    START → ingest_all → compute_area → minimax_select → witness → END
+
+The only change vs. upstream: `_ingest_all` reads the six signal dicts directly
+from the invocation context (`state["context"]`) instead of calling
+`pymagatama.primitives.aria_signal.*`, since those primitives merely project the
+six signals out of the same context.  The decision logic
+(compute_area / minimax_select / witness) is byte-for-byte the upstream logic.
+
+Build:
+    ../../scripts/build-pywasm.sh aria_kotoba.py -o aria_kotoba.wasm
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+import wit_world
+
+from kotoba_langgraph import StateGraph, KotobaCheckpointer, START, END, handle_invoke
+# Force-bundle submodules that kotoba_langgraph imports lazily at runtime
+# (_entry.handle_invoke does `from kotoba_langgraph._cbor import loads` inside
+# the function body, which componentize-py's static analysis does not follow).
+import kotoba_langgraph._cbor  # noqa: F401
+import kotoba_langgraph._entry  # noqa: F401
+
+
+# ── State ──────────────────────────────────────────────────────────────────
+
+class AriaState(TypedDict, total=False):
+    context: dict
+    threadId: str
+    budgetMs: int
+    emotion: dict
+    attention: dict
+    request: dict
+    market: dict
+    money: dict
+    influence: dict
+    area_integral: float
+    eta_global: float
+    minimax_result: dict
+    witnessed: bool
+    audit_cid: str
+
+
+_SIGNAL_KEYS = ("emotion", "attention", "request", "market", "money", "influence")
+
+
+# ── Nodes (decision logic identical to upstream aria.py) ────────────────────
+
+def _ingest_all(state: AriaState) -> dict:
+    """Project the six signals out of the invocation context.
+
+    Upstream calls aria_signal.task_aria_*_ingest(ctx); each primitive returns
+    ctx[<signal>] (a {"intensity": float, ...} dict). We inline that here so the
+    component is self-contained — no pymagatama dependency in the WASM bundle.
+    """
+    ctx = state.get("context", {}) or {}
+    return {k: ctx.get(k, {}) for k in _SIGNAL_KEYS}
+
+
+def _compute_area(state: AriaState) -> dict:
+    """Information-area integral + global decay (eta) — upstream logic."""
+    signals = [state.get(k, {}) for k in _SIGNAL_KEYS]
+    area = 0.0
+    for s in signals:
+        v = s.get("intensity", 0.0) if isinstance(s, dict) else 0.0
+        area += float(v)
+    eta = area / (len(signals) or 1)
+    return {"area_integral": area, "eta_global": eta}
+
+
+def _minimax_select(state: AriaState) -> dict:
+    """Von Neumann minimax over the signal payoff vector — upstream logic."""
+    signals = {k: state.get(k, {}) for k in _SIGNAL_KEYS}
+    scored = {
+        k: float(v.get("intensity", 0.0)) if isinstance(v, dict) else 0.0
+        for k, v in signals.items()
+    }
+    best = max(scored, key=scored.get) if scored else None
+    worst = min(scored, key=scored.get) if scored else None
+    return {"minimax_result": {"action": best, "hedge": worst, "scores": scored}}
+
+
+def _witness(state: AriaState) -> dict:
+    """Witness attestation — emit audit record — upstream logic."""
+    mr = state.get("minimax_result", {})
+    return {"witnessed": True, "audit_cid": "aria:" + str(mr.get("action", "none"))}
+
+
+# ── Graph (identical topology to upstream) ──────────────────────────────────
+
+_g = StateGraph(AriaState)
+_g.add_node("ingest_all", _ingest_all)
+_g.add_node("compute_area", _compute_area)
+_g.add_node("minimax_select", _minimax_select)
+_g.add_node("witness", _witness)
+_g.add_edge(START, "ingest_all")
+_g.add_edge("ingest_all", "compute_area")
+_g.add_edge("compute_area", "minimax_select")
+_g.add_edge("minimax_select", "witness")
+_g.add_edge("witness", END)
+
+compiled = _g.compile(checkpointer=KotobaCheckpointer())
+
+
+# ── kotoba-node WIT export (boilerplate) ────────────────────────────────────
+
+class WitWorld(wit_world.WitWorld):
+    def run(self, ctx_cbor: bytes) -> bytes:
+        return handle_invoke(ctx_cbor, compiled)


### PR DESCRIPTION
## Problem

Python LangGraph actors compiled with `componentize-py` ≥0.23 fail to load on the kotoba server — `invoke.run` / `kotoba_wasm_run` return:

```
CompileFailed(failed to parse WebAssembly module
Caused by: constant expression required: non-constant operator: i32.add (at offset 0x...))
```

componentize-py emits **extended-const** expressions (`i32.add` in WASM global initialisers). wasmtime 22 rejects them and has no `Config` toggle.

## Fix

Bump the wasmtime pin `22 → 25`. The extended-const proposal was **implemented and enabled by default in wasmtime 25** (wasmtime 24 still hard-disables it — `config.rs`: *"Not yet implemented in Wasmtime"*, no setter). With 25 we also call `config.wasm_extended_const(true)` for explicit intent. `WasmExecutor` (`executor.rs`) builds its engine via `KotobaEngine::new()` in `host.rs`, so this single toggle covers the `kotoba_wasm_run` / `invoke.run` paths.

- `crates/kotoba-runtime/Cargo.toml`: `wasmtime` / `wasmtime-wasi` `"22"` → `"25"`
- `crates/kotoba-runtime/src/host.rs`: `config.wasm_extended_const(true)` (replaces the stale TODO)
- `examples/kotoba-langgraph-hello/aria_kotoba.py`: regression actor (see note)

## Verification (end-to-end, live wasmtime-25 build, `wasm_executor: ready`)

| check | result |
|---|---|
| Rust WASM `kotoba-hello` (regression) | ✅ loads + runs unchanged, `gas_used=1030`, real eth balance |
| Python LangGraph `aria` (componentize-py 0.23, 18 MB) | ✅ runs in-WASM → `area_integral=3.3, eta_global=0.55, minimax action=emotion, hedge=money, witnessed=true, audit_cid=aria:emotion` |

The aria in-WASM output is byte-identical to a host-Python run of the same graph. `cargo build -p kotoba-cli --features kotoba-server/wasm-runtime` is green.

**aria** is a 6-signal parallel-ingest + Von Neumann minimax actor ported from magatama to the WASM-native `kotoba_langgraph` API.

### Note on the example's explicit imports

`aria_kotoba.py` explicitly `import kotoba_langgraph._cbor` / `._entry`. `_entry.handle_invoke` does `from kotoba_langgraph._cbor import loads` **inside a function body**, which componentize-py's static module analysis does not follow — without the explicit import the component compiles but traps at call time with `ModuleNotFoundError: No module named 'kotoba_langgraph._cbor'`. Worth considering hoisting that import to module scope in `_entry.py` so every Python agent gets it for free (left out of this PR to keep it minimal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)