### PR TITLE
fix(net): set idle_connection_timeout so GossipSub mesh persists

### DIFF
--- a/crates/kotoba-net/src/swarm.rs
+++ b/crates/kotoba-net/src/swarm.rs
@@ -96,6 +96,13 @@ impl KotobaSwarm {
             .with_tokio()
             .with_quic()
             .with_behaviour(|_| Ok(behaviour))?
+            // libp2p defaults idle_connection_timeout to 0 → idle connections close
+            // immediately (KeepAliveTimeout) before GossipSub can graft them into a
+            // mesh, so the firehose relay never propagates. Hold idle connections
+            // long enough for the mesh to stabilise.
+            .with_swarm_config(|cfg| {
+                cfg.with_idle_connection_timeout(std::time::Duration::from_secs(60))
+            })
             .build();
 
         swarm.listen_on(listen_addr)?;


### PR DESCRIPTION
## Summary
The `SwarmBuilder` never set `idle_connection_timeout`, which defaults to **0** in libp2p 0.53+. Idle QUIC connections therefore close immediately with `KeepAliveTimeout` — before GossipSub can graft a peer into the mesh — so the firehose relay (`NodeRole::Relay`, the E half of the D+E surface) cannot propagate. Sets a 60s idle timeout.

## How found
2-node localhost mesh verification of the firehose relay: nodes connected (`ConnectionEstablished`) then immediately dropped (`KeepAliveTimeout`); `peer_count` stayed 0 and 0 firehose events reached the second node.

## Verification (honest)
- ✅ Compiles (`--features p2p`).
- ✅ With this change the `KeepAliveTimeout` connection-close events drop from **1 → 0** in the 2-node test.
- ⚠️ **Necessary but not yet shown sufficient.** End-to-end firehose propagation across the 2-node mesh was still NOT confirmed — connection establishment over Kademlia-only peering is flaky run-to-run on localhost, and GossipSub graft of the `kotoba/firehose` topic wasn't observed propagating. Full mesh verification needs further dial/discovery + graft debugging (and likely mDNS or explicit-peer GossipSub config for reliable local peering).

Keeping E classified as **build + unit + static verified, not runtime-mesh verified** until propagation is demonstrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)