### PR TITLE
kotoba: operator-trusted PRE×CACAO content-encryption (wire + verify + revoke) + HTTP host import + enterprise SQL

### DIFF
--- a/crates/kotoba-crypto/src/agent_crypto.rs
+++ b/crates/kotoba-crypto/src/agent_crypto.rs
@@ -37,6 +37,20 @@ pub trait AgentCrypto: Send + Sync + 'static {
         ciphertext: &[u8],
     ) -> Result<Zeroizing<Vec<u8>>, CryptoError>;
 
+    /// Derive a deterministic 32-byte wrapping key bound to this node's vault
+    /// key and `owner_did`.
+    ///
+    /// Used by the operator-trusted PRE layer (ADR-2605240001 §28.4(a)) as the
+    /// `owner_enc_key` argument to `PreKeyRegistry::grant`/`get_rekey_authed`.
+    /// Only the node (the Consensys/Infura-layer operator) can derive this key,
+    /// because it is bound to the node's opaque vault key; external or
+    /// other-tenant principals cannot reconstruct it. Deterministic (no nonce)
+    /// so the same `(node, owner_did)` pair always wraps and unwraps the same
+    /// grants. This is intentionally NOT zero-knowledge from the operator —
+    /// that property belongs to the kotoba/etzhayyim protocol layer, not this
+    /// vendor-hosted (Infura-equivalent) service.
+    fn derive_wrapping_key(&self, owner_did: &[u8]) -> Zeroizing<[u8; 32]>;
+
     /// Encrypt a UTF-8 text field and return a `signal:v1:<base64>` envelope.
     async fn seal_field(&self, scope: &[u8], text: &str) -> Result<String, CryptoError> {
         let ct = self.encrypt(scope, text.as_bytes()).await?;
@@ -100,6 +114,16 @@ impl AgentCrypto for VaultKeyedCrypto {
         let sk = self.scope_key(scope);
         open(&sk, ciphertext)
     }
+
+    fn derive_wrapping_key(&self, owner_did: &[u8]) -> Zeroizing<[u8; 32]> {
+        // Distinct `info` from scope_key so a PRE wrapping key never collides
+        // with a field-encryption scope key derived for the same label.
+        Zeroizing::new(derive_key_with_salt(
+            self.vault_key.as_ref(),
+            owner_did,
+            b"kotoba/pre-wrap/v1",
+        ))
+    }
 }
 
 #[cfg(test)]
@@ -119,6 +143,39 @@ mod tests {
         let ct = c.encrypt(scope, msg).await.unwrap();
         let pt = c.decrypt(scope, &ct).await.unwrap();
         assert_eq!(pt.as_slice(), msg);
+    }
+
+    #[test]
+    fn derive_wrapping_key_is_deterministic_and_owner_bound() {
+        let c = test_crypto();
+        let k1 = c.derive_wrapping_key(b"did:plc:alice");
+        let k2 = c.derive_wrapping_key(b"did:plc:alice");
+        let k_other = c.derive_wrapping_key(b"did:plc:bob");
+        // Deterministic: same (node, owner) → same wrapping key (wrap/unwrap parity).
+        assert_eq!(k1.as_ref(), k2.as_ref());
+        // Owner-bound: different owner → different key.
+        assert_ne!(k1.as_ref(), k_other.as_ref());
+    }
+
+    #[test]
+    fn derive_wrapping_key_is_bound_to_vault_key() {
+        let a = VaultKeyedCrypto::new(Zeroizing::new([0x11u8; 32]));
+        let b = VaultKeyedCrypto::new(Zeroizing::new([0x22u8; 32]));
+        // Different node vault keys → different wrapping key for the same owner.
+        // (External principals cannot reconstruct the node's wrapping key.)
+        assert_ne!(
+            a.derive_wrapping_key(b"did:plc:alice").as_ref(),
+            b.derive_wrapping_key(b"did:plc:alice").as_ref()
+        );
+    }
+
+    #[test]
+    fn derive_wrapping_key_differs_from_scope_key_same_label() {
+        // Distinct HKDF `info` must keep a PRE wrapping key separate from a
+        // field-encryption scope key derived for the same label.
+        let c = test_crypto();
+        let label = b"did:plc:alice";
+        assert_ne!(c.derive_wrapping_key(label).as_ref(), &c.scope_key(label));
     }
 
     #[tokio::test]

--- a/crates/kotoba-kqe/src/datalog.rs
+++ b/crates/kotoba-kqe/src/datalog.rs
@@ -91,6 +91,17 @@ fn value_to_cid(value: &Value) -> Option<KotobaCid> {
     }
 }
 
+/// The object CID a `Value` normalises to in the datalog fact base — the same
+/// mapping `evaluate_delta` uses internally. Returns `None` for variants that
+/// are not indexed as objects (e.g. `Float`, `Bytes`, `VectorF32`).
+///
+/// Public so callers can build a reverse index (object CID → source value) and
+/// resolve derived object CIDs back to their original values, which the engine
+/// itself does not carry (derived facts store only the CID).
+pub fn object_value_cid(value: &Value) -> Option<KotobaCid> {
+    value_to_cid(value)
+}
+
 // ---------------------------------------------------------------------------
 // DatalogProgram implementation
 // ---------------------------------------------------------------------------

--- a/crates/kotoba-kqe/src/enterprise/mod.rs
+++ b/crates/kotoba-kqe/src/enterprise/mod.rs
@@ -19,13 +19,17 @@
 //! | Presto / Trino       | presto      | GenericDialect + rewrite |
 //! | MDX (OLAP)           | mdx         | hand-written parser     |
 //! | HiveQL               | hiveql      | HiveDialect             |
+//! | MySQL / MariaDB      | mysql       | MySqlDialect            |
+//! | PostgreSQL           | postgresql  | PostgreSqlDialect       |
 
 pub mod bigquery;
 pub mod db2;
 pub mod hana;
 pub mod hiveql;
 pub mod mdx;
+pub mod mysql;
 pub mod oracle;
+pub mod postgresql;
 pub mod presto;
 pub mod snowflake;
 pub mod sql_base;
@@ -37,7 +41,9 @@ pub use db2::Db2Dialect;
 pub use hana::HanaDialect;
 pub use hiveql::HiveQlDialect;
 pub use mdx::MdxDialect;
+pub use mysql::MySqlDialect;
 pub use oracle::OracleDialect;
+pub use postgresql::PostgreSqlDialect;
 pub use presto::PrestoDialect;
 pub use snowflake::SnowflakeDialect;
 pub use teradata::TeradataDialect;
@@ -107,9 +113,85 @@ pub trait EnterpriseDialect {
     ) -> anyhow::Result<CompiledEnterpriseQuery>;
 }
 
+// ── Name → dialect resolver ───────────────────────────────────────────────────
+
+/// Canonical names of every supported enterprise dialect, matching each
+/// dialect's `dialect_name()`. Stable order for introspection / docs.
+pub const ENTERPRISE_DIALECT_NAMES: &[&str] = &[
+    "oracle",
+    "tsql",
+    "hana",
+    "db2",
+    "teradata",
+    "snowflake",
+    "bigquery",
+    "presto",
+    "mdx",
+    "hiveql",
+    "mysql",
+    "postgresql",
+];
+
+/// Resolve an enterprise SQL dialect by name. Returns `None` for unknown names.
+///
+/// Accepts each dialect's canonical `dialect_name()` plus a few common aliases
+/// (`trino`→presto, `hive`→hiveql, `mariadb`→mysql, `postgres`/`pg`→postgresql).
+/// This is the single name-based entry point so callers (XRPC / MCP) can route a
+/// `lang` string to a compiler without enumerating concrete types.
+pub fn dialect_by_name(name: &str) -> Option<Box<dyn EnterpriseDialect>> {
+    match name {
+        "oracle" => Some(Box::new(OracleDialect)),
+        "tsql" => Some(Box::new(TSqlDialect)),
+        "hana" => Some(Box::new(HanaDialect)),
+        "db2" => Some(Box::new(Db2Dialect)),
+        "teradata" => Some(Box::new(TeradataDialect)),
+        "snowflake" => Some(Box::new(SnowflakeDialect)),
+        "bigquery" => Some(Box::new(BigQueryDialect)),
+        "presto" | "trino" => Some(Box::new(PrestoDialect)),
+        "mdx" => Some(Box::new(MdxDialect)),
+        "hiveql" | "hive" => Some(Box::new(HiveQlDialect)),
+        "mysql" | "mariadb" => Some(Box::new(MySqlDialect)),
+        "postgresql" | "postgres" | "pg" => Some(Box::new(PostgreSqlDialect)),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dialect_by_name_resolves_all_canonical_names() {
+        for name in ENTERPRISE_DIALECT_NAMES {
+            let d = dialect_by_name(name)
+                .unwrap_or_else(|| panic!("canonical name {name} should resolve"));
+            assert_eq!(
+                &d.dialect_name(),
+                name,
+                "dialect_name() must round-trip its canonical name"
+            );
+        }
+        assert_eq!(ENTERPRISE_DIALECT_NAMES.len(), 12);
+    }
+
+    #[test]
+    fn dialect_by_name_resolves_aliases() {
+        assert_eq!(dialect_by_name("trino").unwrap().dialect_name(), "presto");
+        assert_eq!(dialect_by_name("hive").unwrap().dialect_name(), "hiveql");
+        assert_eq!(dialect_by_name("mariadb").unwrap().dialect_name(), "mysql");
+        assert_eq!(
+            dialect_by_name("postgres").unwrap().dialect_name(),
+            "postgresql"
+        );
+        assert_eq!(dialect_by_name("pg").unwrap().dialect_name(), "postgresql");
+    }
+
+    #[test]
+    fn dialect_by_name_unknown_returns_none() {
+        assert!(dialect_by_name("sqlite").is_none());
+        assert!(dialect_by_name("sparql").is_none());
+        assert!(dialect_by_name("").is_none());
+    }
 
     #[test]
     fn post_process_default_all_none() {

--- a/crates/kotoba-kqe/src/enterprise/mysql.rs
+++ b/crates/kotoba-kqe/src/enterprise/mysql.rs
@@ -1,0 +1,210 @@
+//! MySQL / MariaDB SQL dialect compiler.
+//!
+//! Uses `sqlparser::dialect::MySqlDialect`, which natively handles
+//! backtick-quoted identifiers, the `LIMIT offset, count` comma form, and
+//! `# ...` line comments — so the preprocessor stays minimal.
+//!
+//! `LIMIT` / `OFFSET` / `ORDER BY` are extracted into `PostProcess` by
+//! `SchemaBasedSqlCompiler` (shared with every other dialect).
+//!
+//! # Supported MySQL-specific features
+//!
+//! | Feature | Handling |
+//! |---------|----------|
+//! | backtick identifiers `` `col` `` | parsed natively by `MySqlDialect` |
+//! | `LIMIT offset, count` | parsed natively → `PostProcess::{offset,limit}` |
+//! | `LIMIT count OFFSET offset` | → `PostProcess::{limit,offset}` |
+//! | `STRAIGHT_JOIN` | → rewritten to `JOIN` (planner hint, no Datalog effect) |
+//! | `OVER (...)` window functions | → `EnterpriseFeature::OlapWindow` |
+
+use sqlparser::dialect::MySqlDialect as SqlparserMySql;
+
+use super::{
+    sql_base::SchemaBasedSqlCompiler, CompiledEnterpriseQuery, EnterpriseDialect, EnterpriseFeature,
+};
+use crate::schema::SchemaMap;
+
+pub struct MySqlDialect;
+
+impl EnterpriseDialect for MySqlDialect {
+    fn dialect_name(&self) -> &'static str {
+        "mysql"
+    }
+
+    fn compile(
+        &self,
+        query: &str,
+        schema: &SchemaMap,
+        output: &str,
+    ) -> anyhow::Result<CompiledEnterpriseQuery> {
+        let mut features = Vec::new();
+        let upper = query.to_uppercase();
+
+        if upper.contains("OVER (") || upper.contains("OVER(") {
+            features.push(EnterpriseFeature::OlapWindow);
+        }
+
+        let prepped = preprocess_mysql(query);
+
+        let (program, pp) =
+            SchemaBasedSqlCompiler::compile(&prepped, &SqlparserMySql {}, schema, output)?;
+
+        Ok(CompiledEnterpriseQuery {
+            program,
+            output_relation: output.to_string(),
+            dialect: self.dialect_name(),
+            features,
+            post_process: pp,
+        })
+    }
+}
+
+// ── Preprocessor ─────────────────────────────────────────────────────────────
+
+fn preprocess_mysql(sql: &str) -> String {
+    // STRAIGHT_JOIN is a MySQL planner hint forcing join order; Kotoba's Datalog
+    // engine reorders freely, so it is semantically a plain INNER JOIN.
+    sql.replace("STRAIGHT_JOIN", "JOIN")
+        .replace("straight_join", "JOIN")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{AttrDef, SchemaMap, TableSchema};
+    use crate::{
+        datom::{Datom, Value},
+        delta::Delta,
+    };
+    use kotoba_core::cid::KotobaCid;
+
+    fn cid(s: &str) -> KotobaCid {
+        KotobaCid::from_bytes(s.as_bytes())
+    }
+    fn fact(pred: &str, s: &str, o: &str) -> Delta {
+        Delta::assert_datom(Datom::assert(
+            cid(s),
+            pred.to_string(),
+            Value::Cid(cid(o)),
+            cid("g"),
+        ))
+    }
+    fn has(d: &[Delta], pred: &str, s: &str, o: &str) -> bool {
+        d.iter().any(|x| {
+            x.attribute() == pred
+                && x.entity() == &cid(s)
+                && matches!(x.value(), Value::Cid(c) if *c == cid(o))
+        })
+    }
+
+    #[test]
+    fn standard_mysql_select() {
+        let mut schema = SchemaMap::new();
+        schema.add(
+            "users",
+            TableSchema::new("id")
+                .with_attr(AttrDef::scalar("name", "users"))
+                .with_attr(AttrDef::scalar("status", "users")),
+        );
+
+        let result = MySqlDialect
+            .compile(
+                "SELECT u.id, u.name FROM users u WHERE u.status = 'active'",
+                &schema,
+                "active_users",
+            )
+            .unwrap();
+        assert_eq!(result.dialect, "mysql");
+
+        let input = vec![
+            fact("users/name", "u1", "alice"),
+            fact("users/status", "u1", "active"),
+            fact("users/name", "u2", "bob"),
+            fact("users/status", "u2", "banned"),
+        ];
+        let derived = result.program.evaluate_delta(&input);
+        assert!(has(&derived, "active_users", "u1", "alice"));
+        assert!(!has(&derived, "active_users", "u2", "bob"));
+    }
+
+    #[test]
+    fn backtick_identifiers_parse() {
+        let mut schema = SchemaMap::new();
+        schema.add(
+            "orders",
+            TableSchema::new("id").with_attr(AttrDef::scalar("state", "orders")),
+        );
+
+        let result = MySqlDialect
+            .compile(
+                "SELECT `o`.`id`, `o`.`state` FROM `orders` `o` WHERE `o`.`state` = 'paid'",
+                &schema,
+                "out",
+            )
+            .unwrap();
+        let input = vec![fact("orders/state", "o1", "paid")];
+        let derived = result.program.evaluate_delta(&input);
+        assert!(has(&derived, "out", "o1", "paid"));
+    }
+
+    #[test]
+    fn limit_comma_offset_form() {
+        // MySQL legacy `LIMIT offset, count` → offset=5, limit=10
+        let mut schema = SchemaMap::new();
+        schema.add(
+            "logs",
+            TableSchema::new("id").with_attr(AttrDef::scalar("msg", "logs")),
+        );
+
+        let result = MySqlDialect
+            .compile("SELECT l.id, l.msg FROM logs l LIMIT 5, 10", &schema, "out")
+            .unwrap();
+        assert_eq!(result.post_process.offset, Some(5));
+        assert_eq!(result.post_process.limit, Some(10));
+    }
+
+    #[test]
+    fn limit_offset_keyword_form() {
+        let mut schema = SchemaMap::new();
+        schema.add(
+            "logs",
+            TableSchema::new("id").with_attr(AttrDef::scalar("msg", "logs")),
+        );
+
+        let result = MySqlDialect
+            .compile(
+                "SELECT l.id, l.msg FROM logs l LIMIT 10 OFFSET 5",
+                &schema,
+                "out",
+            )
+            .unwrap();
+        assert_eq!(result.post_process.limit, Some(10));
+        assert_eq!(result.post_process.offset, Some(5));
+    }
+
+    #[test]
+    fn straight_join_rewritten() {
+        let mut schema = SchemaMap::new();
+        schema.add(
+            "a",
+            TableSchema::new("id").with_attr(AttrDef::scalar("ref", "a")),
+        );
+        schema.add(
+            "b",
+            TableSchema::new("id").with_attr(AttrDef::scalar("val", "b")),
+        );
+        // Should compile cleanly with the hint stripped.
+        let result = MySqlDialect.compile(
+            "SELECT a.id, b.val FROM a STRAIGHT_JOIN b ON a.ref = b.id",
+            &schema,
+            "out",
+        );
+        assert!(
+            result.is_ok(),
+            "STRAIGHT_JOIN should compile: {:?}",
+            result.err()
+        );
+    }
+}

--- a/crates/kotoba-kqe/src/enterprise/postgresql.rs
+++ b/crates/kotoba-kqe/src/enterprise/postgresql.rs
@@ -1,0 +1,217 @@
+//! PostgreSQL SQL dialect compiler.
+//!
+//! Uses `sqlparser::dialect::PostgreSqlDialect`, which natively handles
+//! `LIMIT count OFFSET offset`, `FETCH FIRST N ROWS ONLY`, dollar-quoted
+//! strings, and `::` cast expressions — so the preprocessor stays minimal.
+//!
+//! `LIMIT` / `OFFSET` / `FETCH` / `ORDER BY` are extracted into `PostProcess`
+//! by `SchemaBasedSqlCompiler` (shared with every other dialect).
+//!
+//! NOTE: this compiles **PostgreSQL dialect TEXT → Datalog**. It is unrelated
+//! to PostgreSQL *wire-protocol* compatibility, which Kotoba deliberately does
+//! not implement (see ADR-2605240001 §2 OUT-scope).
+//!
+//! # Supported PostgreSQL-specific features
+//!
+//! | Feature | Handling |
+//! |---------|----------|
+//! | `LIMIT n OFFSET m` | → `PostProcess::{limit,offset}` |
+//! | `FETCH FIRST N ROWS ONLY` | → `PostProcess::limit` |
+//! | `ILIKE` | → rewritten to `LIKE` (Kotoba CID space is case-sensitive) |
+//! | `LIMIT ALL` | → stripped (no row cap) |
+//! | `OVER (...)` window functions | → `EnterpriseFeature::OlapWindow` |
+
+use sqlparser::dialect::PostgreSqlDialect as SqlparserPostgres;
+
+use super::{
+    sql_base::SchemaBasedSqlCompiler, CompiledEnterpriseQuery, EnterpriseDialect, EnterpriseFeature,
+};
+use crate::schema::SchemaMap;
+
+pub struct PostgreSqlDialect;
+
+impl EnterpriseDialect for PostgreSqlDialect {
+    fn dialect_name(&self) -> &'static str {
+        "postgresql"
+    }
+
+    fn compile(
+        &self,
+        query: &str,
+        schema: &SchemaMap,
+        output: &str,
+    ) -> anyhow::Result<CompiledEnterpriseQuery> {
+        let mut features = Vec::new();
+        let upper = query.to_uppercase();
+
+        if upper.contains("OVER (") || upper.contains("OVER(") {
+            features.push(EnterpriseFeature::OlapWindow);
+        }
+
+        let prepped = preprocess_postgres(query);
+
+        let (program, pp) =
+            SchemaBasedSqlCompiler::compile(&prepped, &SqlparserPostgres {}, schema, output)?;
+
+        Ok(CompiledEnterpriseQuery {
+            program,
+            output_relation: output.to_string(),
+            dialect: self.dialect_name(),
+            features,
+            post_process: pp,
+        })
+    }
+}
+
+// ── Preprocessor ─────────────────────────────────────────────────────────────
+
+fn preprocess_postgres(sql: &str) -> String {
+    let mut s = sql.to_string();
+
+    // ILIKE → LIKE (case-insensitive match has no analogue in the case-sensitive
+    // CID space; approximate with LIKE — same precedent as the Snowflake dialect).
+    s = s.replace("ILIKE", "LIKE").replace("ilike", "LIKE");
+
+    // `LIMIT ALL` means "no limit" in PostgreSQL; drop it so the parser does not
+    // choke and no spurious PostProcess::limit is produced.
+    s = s.replace("LIMIT ALL", "").replace("limit all", "");
+
+    s
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::schema::{AttrDef, SchemaMap, TableSchema};
+    use crate::{
+        datom::{Datom, Value},
+        delta::Delta,
+    };
+    use kotoba_core::cid::KotobaCid;
+
+    fn cid(s: &str) -> KotobaCid {
+        KotobaCid::from_bytes(s.as_bytes())
+    }
+    fn fact(pred: &str, s: &str, o: &str) -> Delta {
+        Delta::assert_datom(Datom::assert(
+            cid(s),
+            pred.to_string(),
+            Value::Cid(cid(o)),
+            cid("g"),
+        ))
+    }
+    fn has(d: &[Delta], pred: &str, s: &str, o: &str) -> bool {
+        d.iter().any(|x| {
+            x.attribute() == pred
+                && x.entity() == &cid(s)
+                && matches!(x.value(), Value::Cid(c) if *c == cid(o))
+        })
+    }
+
+    #[test]
+    fn standard_postgres_select() {
+        let mut schema = SchemaMap::new();
+        schema.add(
+            "people",
+            TableSchema::new("id")
+                .with_attr(AttrDef::scalar("name", "people"))
+                .with_attr(AttrDef::scalar("role", "people")),
+        );
+
+        let result = PostgreSqlDialect
+            .compile(
+                "SELECT p.id, p.name FROM people p WHERE p.role = 'admin'",
+                &schema,
+                "admins",
+            )
+            .unwrap();
+        assert_eq!(result.dialect, "postgresql");
+
+        let input = vec![
+            fact("people/name", "p1", "alice"),
+            fact("people/role", "p1", "admin"),
+            fact("people/name", "p2", "bob"),
+            fact("people/role", "p2", "user"),
+        ];
+        let derived = result.program.evaluate_delta(&input);
+        assert!(has(&derived, "admins", "p1", "alice"));
+        assert!(!has(&derived, "admins", "p2", "bob"));
+    }
+
+    #[test]
+    fn limit_offset_form() {
+        let mut schema = SchemaMap::new();
+        schema.add(
+            "events",
+            TableSchema::new("id").with_attr(AttrDef::scalar("kind", "events")),
+        );
+
+        let result = PostgreSqlDialect
+            .compile(
+                "SELECT e.id, e.kind FROM events e LIMIT 25 OFFSET 50",
+                &schema,
+                "out",
+            )
+            .unwrap();
+        assert_eq!(result.post_process.limit, Some(25));
+        assert_eq!(result.post_process.offset, Some(50));
+    }
+
+    #[test]
+    fn fetch_first_limit() {
+        let mut schema = SchemaMap::new();
+        schema.add(
+            "events",
+            TableSchema::new("id").with_attr(AttrDef::scalar("kind", "events")),
+        );
+
+        let result = PostgreSqlDialect
+            .compile(
+                "SELECT e.id, e.kind FROM events e FETCH FIRST 7 ROWS ONLY",
+                &schema,
+                "out",
+            )
+            .unwrap();
+        assert_eq!(result.post_process.limit, Some(7));
+    }
+
+    #[test]
+    fn ilike_rewritten_to_like() {
+        let mut schema = SchemaMap::new();
+        schema.add(
+            "docs",
+            TableSchema::new("id").with_attr(AttrDef::scalar("title", "docs")),
+        );
+        // Should compile cleanly with ILIKE rewritten to LIKE.
+        let result = PostgreSqlDialect.compile(
+            "SELECT d.id, d.title FROM docs d WHERE d.title ILIKE 'report%'",
+            &schema,
+            "out",
+        );
+        assert!(
+            result.is_ok(),
+            "ILIKE should compile: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn limit_all_stripped() {
+        let mut schema = SchemaMap::new();
+        schema.add(
+            "events",
+            TableSchema::new("id").with_attr(AttrDef::scalar("kind", "events")),
+        );
+
+        let result = PostgreSqlDialect
+            .compile(
+                "SELECT e.id, e.kind FROM events e LIMIT ALL",
+                &schema,
+                "out",
+            )
+            .unwrap();
+        assert_eq!(result.post_process.limit, None);
+    }
+}

--- a/crates/kotoba-kqe/src/enterprise/postgresql.rs
+++ b/crates/kotoba-kqe/src/enterprise/postgresql.rs
@@ -178,23 +178,28 @@ mod tests {
     }
 
     #[test]
-    fn ilike_rewritten_to_like() {
+    fn ilike_is_rejected_fail_loud() {
+        // ILIKE is preprocessed to LIKE, but LIKE is not a supported WHERE filter
+        // in the CID-hashed object space — it must be rejected, not silently
+        // dropped (which would return an unfiltered superset).
+        assert_eq!(preprocess_postgres("WHERE x ILIKE 'a%'"), "WHERE x LIKE 'a%'");
+
         let mut schema = SchemaMap::new();
         schema.add(
             "docs",
             TableSchema::new("id").with_attr(AttrDef::scalar("title", "docs")),
         );
-        // Should compile cleanly with ILIKE rewritten to LIKE.
-        let result = PostgreSqlDialect.compile(
+        match PostgreSqlDialect.compile(
             "SELECT d.id, d.title FROM docs d WHERE d.title ILIKE 'report%'",
             &schema,
             "out",
-        );
-        assert!(
-            result.is_ok(),
-            "ILIKE should compile: {:?}",
-            result.err()
-        );
+        ) {
+            Ok(_) => panic!("LIKE/ILIKE WHERE must be rejected fail-loud"),
+            Err(e) => assert!(
+                e.to_string().contains("unsupported WHERE"),
+                "unexpected error: {e}"
+            ),
+        }
     }
 
     #[test]

--- a/crates/kotoba-kqe/src/enterprise/sql_base.rs
+++ b/crates/kotoba-kqe/src/enterprise/sql_base.rs
@@ -423,7 +423,18 @@ fn apply_where(
             apply_where(left, tables, schema, state)?;
             apply_where(right, tables, schema, state)
         }
-        _ => Ok(()),
+        // Parenthesised sub-expression — unwrap and recurse.
+        Expr::Nested(inner) => apply_where(inner, tables, schema, state),
+        // Fail loud on anything else. The EAV projection compiles objects into a
+        // CID space that has no ordering or substring structure, so `<>`, `>`, `<`,
+        // `>=`, `<=`, `LIKE`, `OR`, `IN`, `BETWEEN` cannot be evaluated correctly —
+        // previously they were silently dropped and returned the unfiltered
+        // superset. Reject them so callers get an error instead of wrong rows.
+        other => bail!(
+            "unsupported WHERE expression: only equality `col = 'literal'` joined by AND \
+             is supported (operators like <>, >, <, LIKE, OR, IN, BETWEEN have no meaning \
+             in the CID-hashed object space and would silently return unfiltered rows); got {other:?}"
+        ),
     }
 }
 

--- a/crates/kotoba-kqe/src/enterprise/sql_base.rs
+++ b/crates/kotoba-kqe/src/enterprise/sql_base.rs
@@ -86,6 +86,11 @@ impl SchemaBasedSqlCompiler {
         if let Some(fetch) = &query.fetch {
             extract_fetch(fetch, &mut pp);
         }
+        if let Some(offset) = &query.offset {
+            if let Some(n) = expr_to_usize(&offset.value) {
+                pp.offset = Some(n);
+            }
+        }
         for ob in &query.order_by {
             if let Some(col) = order_by_col(ob) {
                 pp.order_by.push(col);

--- a/crates/kotoba-kqe/src/lib.rs
+++ b/crates/kotoba-kqe/src/lib.rs
@@ -21,8 +21,8 @@ pub use datom::{
 pub use delta::Delta;
 pub use enterprise::{
     BigQueryDialect, CompiledEnterpriseQuery, Db2Dialect, EnterpriseDialect, EnterpriseFeature,
-    HanaDialect, HiveQlDialect, MdxDialect, OracleDialect, PostProcess, PrestoDialect,
-    SnowflakeDialect, TSqlDialect, TeradataDialect,
+    HanaDialect, HiveQlDialect, MdxDialect, MySqlDialect, OracleDialect, PostProcess,
+    PostgreSqlDialect, PrestoDialect, SnowflakeDialect, TSqlDialect, TeradataDialect,
 };
 pub use mv::MaterializedView;
 pub use quad::{LegacyQuad, LegacyQuadObject};

--- a/crates/kotoba-kqe/src/lib.rs
+++ b/crates/kotoba-kqe/src/lib.rs
@@ -13,7 +13,7 @@ pub mod sql;
 pub use arrangement::Arrangement;
 pub use citation::{CitationLedger, DatomKey};
 pub use cypher::{CompiledCypherMv, CypherCompiler};
-pub use datalog::{DatalogProgram, DatalogRule};
+pub use datalog::{object_value_cid, DatalogProgram, DatalogRule};
 pub use datom::{
     Datom, DatomArrangement, DatomIndex, DatomIndexComponent, TensorDtype as DatomTensorDtype,
     Value,

--- a/crates/kotoba-kse/src/pre_key_registry.rs
+++ b/crates/kotoba-kse/src/pre_key_registry.rs
@@ -182,6 +182,20 @@ impl PreKeyRegistry {
         owner_did: &str,
         accessor_did: &str,
     ) -> Result<KotobaCid, PreKeyError> {
+        self.revoke_emit_warrant_bytes(owner_did, accessor_did)
+            .await
+            .map(|(cid, _)| cid)
+    }
+
+    /// Like `revoke_emit_warrant` but also returns the serialized
+    /// `RekeyRevocationRecord` bytes for GossipSub propagation (the
+    /// `rekey/revoke` topic). Peers apply it via `apply_revocation_warrant_bytes`
+    /// with NO BlockStore fetch — completes the §23.7 wire integration.
+    pub async fn revoke_emit_warrant_bytes(
+        &self,
+        owner_did: &str,
+        accessor_did: &str,
+    ) -> Result<(KotobaCid, Vec<u8>), PreKeyError> {
         self.revoke_inner(owner_did, accessor_did).await;
 
         let ts = SystemTime::now()
@@ -200,7 +214,7 @@ impl PreKeyRegistry {
         self.store
             .put(&evidence_cid, &evidence_bytes)
             .map_err(|e| PreKeyError::Store(e.to_string()))?;
-        Ok(evidence_cid)
+        Ok((evidence_cid, evidence_bytes))
     }
 
     /// Process an incoming peer Warrant with `rule_id = RULE_REKEY_REVOKED`.
@@ -211,17 +225,23 @@ impl PreKeyRegistry {
         let Some(bytes) = self.store.get(evidence_cid).ok().flatten() else {
             return;
         };
+        self.apply_revocation_warrant_bytes(&bytes).await;
+    }
 
-        let Ok(record) = serde_json::from_slice::<RekeyRevocationRecord>(&bytes) else {
+    /// Apply a revocation warrant directly from its serialized record bytes —
+    /// the GossipSub receive path (§23.7 wire). The gossiped payload IS the
+    /// record, so no BlockStore fetch is needed (unlike `apply_revocation_warrant`).
+    /// No-ops on malformed bytes or already-revoked pairs.
+    pub async fn apply_revocation_warrant_bytes(&self, bytes: &[u8]) {
+        let Ok(record) = serde_json::from_slice::<RekeyRevocationRecord>(bytes) else {
             return;
         };
-
         self.revoke_inner(&record.owner_did, &record.accessor_did)
             .await;
         tracing::info!(
             owner_did = %record.owner_did,
             accessor_did = %record.accessor_did,
-            "PreKeyRegistry: applied peer revocation warrant",
+            "PreKeyRegistry: applied peer revocation warrant (gossip bytes)",
         );
     }
 
@@ -610,6 +630,46 @@ mod tests {
     }
 
     // ---- New tests --------------------------------------------------------
+
+    /// GossipSub wire path: node A revokes + serializes; node B applies the
+    /// bytes directly WITHOUT a shared BlockStore (the gossip payload IS the
+    /// record). This is the §23.7 propagation that `apply_revocation_warrant`
+    /// (block-fetch) could not do across independent nodes.
+    #[tokio::test]
+    async fn revocation_warrant_bytes_propagate_without_shared_store() {
+        let enc_key = rand_key();
+
+        // Node A: holds the grant, revokes, and emits warrant bytes.
+        let node_a = PreKeyRegistry::new(store());
+        node_a
+            .grant("did:alice", "did:bob", &rand_key(), &enc_key)
+            .await
+            .unwrap();
+        let (_cid, bytes) = node_a
+            .revoke_emit_warrant_bytes("did:alice", "did:bob")
+            .await
+            .unwrap();
+
+        // Node B: a SEPARATE store (no block replication) — receives only the
+        // gossiped bytes and applies them.
+        let node_b = PreKeyRegistry::new(store());
+        node_b
+            .grant("did:alice", "did:bob", &rand_key(), &enc_key)
+            .await
+            .unwrap();
+        node_b.apply_revocation_warrant_bytes(&bytes).await;
+
+        assert!(
+            node_b
+                .revoked
+                .read()
+                .await
+                .contains(&("did:alice".to_string(), "did:bob".to_string())),
+            "node B must revoke from gossiped warrant bytes alone"
+        );
+        // Malformed bytes must be a safe no-op.
+        node_b.apply_revocation_warrant_bytes(b"not-a-record").await;
+    }
 
     #[test]
     fn rule_rekey_revoked_constant_is_seven() {

--- a/crates/kotoba-kse/src/sovereign_key.rs
+++ b/crates/kotoba-kse/src/sovereign_key.rs
@@ -289,6 +289,10 @@ impl AgentCrypto for SovereignCrypto {
     ) -> Result<Zeroizing<Vec<u8>>, CryptoError> {
         self.inner.decrypt(scope, ciphertext).await
     }
+
+    fn derive_wrapping_key(&self, owner_did: &[u8]) -> Zeroizing<[u8; 32]> {
+        self.inner.derive_wrapping_key(owner_did)
+    }
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/crates/kotoba-runtime/src/host.rs
+++ b/crates/kotoba-runtime/src/host.rs
@@ -307,6 +307,7 @@ impl KotobaLinker {
         bind_llm(&mut self.0)?;
         bind_chain(&mut self.0)?;
         bind_evm(&mut self.0)?;
+        bind_http(&mut self.0)?;
         Ok(())
     }
 }
@@ -1043,6 +1044,69 @@ fn bind_evm(linker: &mut Linker<HostState>) -> Result<()> {
                 let token = evm_parse_addr(&token)?;
                 let ret = evm_eth_call(&agent_e5, &rpc_url, &token, &erc20::name())?;
                 erc20::decode_string(&ret).map_err(|e| e.to_string())
+            })();
+            Ok((result,))
+        },
+    )?;
+
+    Ok(())
+}
+
+// ── kotoba:kais/http ───────────────────────────────────────────────────────
+// Generic outbound HTTP for guests. The runtime already does host-side HTTP for
+// `evm` (ureq JSON-RPC); this exposes it generically so componentize-py guests —
+// which cannot reach wasi:http — can call external services (ADR-2605312355).
+
+fn bind_http(linker: &mut Linker<HostState>) -> Result<()> {
+    use std::io::Read;
+    use std::time::Duration;
+
+    let mut inst = linker.instance("kotoba:kais/http@0.1.0")?;
+    inst.func_wrap(
+        "fetch",
+        move |mut ctx: wasmtime::StoreContextMut<HostState>,
+              (method, url, headers, body, timeout_ms): (
+            String,
+            String,
+            Vec<(String, String)>,
+            Option<Vec<u8>>,
+            u32,
+        )|
+              -> Result<(Result<(u16, Vec<u8>), String>,)> {
+            ctx.data_mut().charge_gas(1000)?;
+            let result = (|| -> Result<(u16, Vec<u8>), String> {
+                let agent = ureq::AgentBuilder::new()
+                    .timeout(Duration::from_millis(u64::from(timeout_ms.max(1))))
+                    .build();
+                let mut req = agent.request(&method, &url);
+                for (k, v) in &headers {
+                    req = req.set(k, v);
+                }
+                let sent = match &body {
+                    Some(b) => req.send_bytes(b),
+                    None => req.call(),
+                };
+                // ureq treats non-2xx as an error; surface its status + body instead.
+                let response = match sent {
+                    Ok(r) => r,
+                    Err(ureq::Error::Status(code, r)) => {
+                        let mut buf = Vec::new();
+                        r.into_reader()
+                            .take(16 * 1024 * 1024)
+                            .read_to_end(&mut buf)
+                            .map_err(|e| e.to_string())?;
+                        return Ok((code, buf));
+                    }
+                    Err(e) => return Err(e.to_string()),
+                };
+                let status = response.status();
+                let mut buf = Vec::new();
+                response
+                    .into_reader()
+                    .take(16 * 1024 * 1024)
+                    .read_to_end(&mut buf)
+                    .map_err(|e| e.to_string())?;
+                Ok((status, buf))
             })();
             Ok((result,))
         },

--- a/crates/kotoba-runtime/wit/deps/cli/command.wit
+++ b/crates/kotoba-runtime/wit/deps/cli/command.wit
@@ -1,0 +1,7 @@
+package wasi:cli@0.2.0;
+
+world command {
+  include imports;
+
+  export run;
+}

--- a/crates/kotoba-runtime/wit/deps/cli/environment.wit
+++ b/crates/kotoba-runtime/wit/deps/cli/environment.wit
@@ -1,0 +1,18 @@
+interface environment {
+  /// Get the POSIX-style environment variables.
+  ///
+  /// Each environment variable is provided as a pair of string variable names
+  /// and string value.
+  ///
+  /// Morally, these are a value import, but until value imports are available
+  /// in the component model, this import function should return the same
+  /// values each time it is called.
+  get-environment: func() -> list<tuple<string, string>>;
+
+  /// Get the POSIX-style arguments to the program.
+  get-arguments: func() -> list<string>;
+
+  /// Return a path that programs should use as their initial current working
+  /// directory, interpreting `.` as shorthand for this.
+  initial-cwd: func() -> option<string>;
+}

--- a/crates/kotoba-runtime/wit/deps/cli/exit.wit
+++ b/crates/kotoba-runtime/wit/deps/cli/exit.wit
@@ -1,0 +1,4 @@
+interface exit {
+  /// Exit the current instance and any linked instances.
+  exit: func(status: result);
+}

--- a/crates/kotoba-runtime/wit/deps/cli/imports.wit
+++ b/crates/kotoba-runtime/wit/deps/cli/imports.wit
@@ -1,0 +1,20 @@
+package wasi:cli@0.2.0;
+
+world imports {
+  include wasi:clocks/imports@0.2.0;
+  include wasi:filesystem/imports@0.2.0;
+  include wasi:sockets/imports@0.2.0;
+  include wasi:random/imports@0.2.0;
+  include wasi:io/imports@0.2.0;
+
+  import environment;
+  import exit;
+  import stdin;
+  import stdout;
+  import stderr;
+  import terminal-input;
+  import terminal-output;
+  import terminal-stdin;
+  import terminal-stdout;
+  import terminal-stderr;
+}

--- a/crates/kotoba-runtime/wit/deps/cli/run.wit
+++ b/crates/kotoba-runtime/wit/deps/cli/run.wit
@@ -1,0 +1,4 @@
+interface run {
+  /// Run the program.
+  run: func() -> result;
+}

--- a/crates/kotoba-runtime/wit/deps/cli/stdio.wit
+++ b/crates/kotoba-runtime/wit/deps/cli/stdio.wit
@@ -1,0 +1,17 @@
+interface stdin {
+  use wasi:io/streams@0.2.0.{input-stream};
+
+  get-stdin: func() -> input-stream;
+}
+
+interface stdout {
+  use wasi:io/streams@0.2.0.{output-stream};
+
+  get-stdout: func() -> output-stream;
+}
+
+interface stderr {
+  use wasi:io/streams@0.2.0.{output-stream};
+
+  get-stderr: func() -> output-stream;
+}

--- a/crates/kotoba-runtime/wit/deps/cli/terminal.wit
+++ b/crates/kotoba-runtime/wit/deps/cli/terminal.wit
@@ -1,0 +1,49 @@
+/// Terminal input.
+///
+/// In the future, this may include functions for disabling echoing,
+/// disabling input buffering so that keyboard events are sent through
+/// immediately, querying supported features, and so on.
+interface terminal-input {
+    /// The input side of a terminal.
+    resource terminal-input;
+}
+
+/// Terminal output.
+///
+/// In the future, this may include functions for querying the terminal
+/// size, being notified of terminal size changes, querying supported
+/// features, and so on.
+interface terminal-output {
+    /// The output side of a terminal.
+    resource terminal-output;
+}
+
+/// An interface providing an optional `terminal-input` for stdin as a
+/// link-time authority.
+interface terminal-stdin {
+    use terminal-input.{terminal-input};
+
+    /// If stdin is connected to a terminal, return a `terminal-input` handle
+    /// allowing further interaction with it.
+    get-terminal-stdin: func() -> option<terminal-input>;
+}
+
+/// An interface providing an optional `terminal-output` for stdout as a
+/// link-time authority.
+interface terminal-stdout {
+    use terminal-output.{terminal-output};
+
+    /// If stdout is connected to a terminal, return a `terminal-output` handle
+    /// allowing further interaction with it.
+    get-terminal-stdout: func() -> option<terminal-output>;
+}
+
+/// An interface providing an optional `terminal-output` for stderr as a
+/// link-time authority.
+interface terminal-stderr {
+    use terminal-output.{terminal-output};
+
+    /// If stderr is connected to a terminal, return a `terminal-output` handle
+    /// allowing further interaction with it.
+    get-terminal-stderr: func() -> option<terminal-output>;
+}

--- a/crates/kotoba-runtime/wit/deps/clocks/monotonic-clock.wit
+++ b/crates/kotoba-runtime/wit/deps/clocks/monotonic-clock.wit
@@ -1,0 +1,45 @@
+package wasi:clocks@0.2.0;
+/// WASI Monotonic Clock is a clock API intended to let users measure elapsed
+/// time.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+///
+/// A monotonic clock is a clock which has an unspecified initial value, and
+/// successive reads of the clock will produce non-decreasing values.
+///
+/// It is intended for measuring elapsed time.
+interface monotonic-clock {
+    use wasi:io/poll@0.2.0.{pollable};
+
+    /// An instant in time, in nanoseconds. An instant is relative to an
+    /// unspecified initial value, and can only be compared to instances from
+    /// the same monotonic-clock.
+    type instant = u64;
+
+    /// A duration of time, in nanoseconds.
+    type duration = u64;
+
+    /// Read the current value of the clock.
+    ///
+    /// The clock is monotonic, therefore calling this function repeatedly will
+    /// produce a sequence of non-decreasing values.
+    now: func() -> instant;
+
+    /// Query the resolution of the clock. Returns the duration of time
+    /// corresponding to a clock tick.
+    resolution: func() -> duration;
+
+    /// Create a `pollable` which will resolve once the specified instant
+    /// occured.
+    subscribe-instant: func(
+        when: instant,
+    ) -> pollable;
+
+    /// Create a `pollable` which will resolve once the given duration has
+    /// elapsed, starting at the time at which this function was called.
+    /// occured.
+    subscribe-duration: func(
+        when: duration,
+    ) -> pollable;
+}

--- a/crates/kotoba-runtime/wit/deps/clocks/wall-clock.wit
+++ b/crates/kotoba-runtime/wit/deps/clocks/wall-clock.wit
@@ -1,0 +1,42 @@
+package wasi:clocks@0.2.0;
+/// WASI Wall Clock is a clock API intended to let users query the current
+/// time. The name "wall" makes an analogy to a "clock on the wall", which
+/// is not necessarily monotonic as it may be reset.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+///
+/// A wall clock is a clock which measures the date and time according to
+/// some external reference.
+///
+/// External references may be reset, so this clock is not necessarily
+/// monotonic, making it unsuitable for measuring elapsed time.
+///
+/// It is intended for reporting the current date and time for humans.
+interface wall-clock {
+    /// A time and date in seconds plus nanoseconds.
+    record datetime {
+        seconds: u64,
+        nanoseconds: u32,
+    }
+
+    /// Read the current value of the clock.
+    ///
+    /// This clock is not monotonic, therefore calling this function repeatedly
+    /// will not necessarily produce a sequence of non-decreasing values.
+    ///
+    /// The returned timestamps represent the number of seconds since
+    /// 1970-01-01T00:00:00Z, also known as [POSIX's Seconds Since the Epoch],
+    /// also known as [Unix Time].
+    ///
+    /// The nanoseconds field of the output is always less than 1000000000.
+    ///
+    /// [POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
+    /// [Unix Time]: https://en.wikipedia.org/wiki/Unix_time
+    now: func() -> datetime;
+
+    /// Query the resolution of the clock.
+    ///
+    /// The nanoseconds field of the output is always less than 1000000000.
+    resolution: func() -> datetime;
+}

--- a/crates/kotoba-runtime/wit/deps/clocks/world.wit
+++ b/crates/kotoba-runtime/wit/deps/clocks/world.wit
@@ -1,0 +1,6 @@
+package wasi:clocks@0.2.0;
+
+world imports {
+    import monotonic-clock;
+    import wall-clock;
+}

--- a/crates/kotoba-runtime/wit/deps/filesystem/preopens.wit
+++ b/crates/kotoba-runtime/wit/deps/filesystem/preopens.wit
@@ -1,0 +1,8 @@
+package wasi:filesystem@0.2.0;
+
+interface preopens {
+    use types.{descriptor};
+
+    /// Return the set of preopened directories, and their path.
+    get-directories: func() -> list<tuple<descriptor, string>>;
+}

--- a/crates/kotoba-runtime/wit/deps/filesystem/types.wit
+++ b/crates/kotoba-runtime/wit/deps/filesystem/types.wit
@@ -1,0 +1,634 @@
+package wasi:filesystem@0.2.0;
+/// WASI filesystem is a filesystem API primarily intended to let users run WASI
+/// programs that access their files on their existing filesystems, without
+/// significant overhead.
+///
+/// It is intended to be roughly portable between Unix-family platforms and
+/// Windows, though it does not hide many of the major differences.
+///
+/// Paths are passed as interface-type `string`s, meaning they must consist of
+/// a sequence of Unicode Scalar Values (USVs). Some filesystems may contain
+/// paths which are not accessible by this API.
+///
+/// The directory separator in WASI is always the forward-slash (`/`).
+///
+/// All paths in WASI are relative paths, and are interpreted relative to a
+/// `descriptor` referring to a base directory. If a `path` argument to any WASI
+/// function starts with `/`, or if any step of resolving a `path`, including
+/// `..` and symbolic link steps, reaches a directory outside of the base
+/// directory, or reaches a symlink to an absolute or rooted path in the
+/// underlying filesystem, the function fails with `error-code::not-permitted`.
+///
+/// For more information about WASI path resolution and sandboxing, see
+/// [WASI filesystem path resolution].
+///
+/// [WASI filesystem path resolution]: https://github.com/WebAssembly/wasi-filesystem/blob/main/path-resolution.md
+interface types {
+    use wasi:io/streams@0.2.0.{input-stream, output-stream, error};
+    use wasi:clocks/wall-clock@0.2.0.{datetime};
+
+    /// File size or length of a region within a file.
+    type filesize = u64;
+
+    /// The type of a filesystem object referenced by a descriptor.
+    ///
+    /// Note: This was called `filetype` in earlier versions of WASI.
+    enum descriptor-type {
+        /// The type of the descriptor or file is unknown or is different from
+        /// any of the other types specified.
+        unknown,
+        /// The descriptor refers to a block device inode.
+        block-device,
+        /// The descriptor refers to a character device inode.
+        character-device,
+        /// The descriptor refers to a directory inode.
+        directory,
+        /// The descriptor refers to a named pipe.
+        fifo,
+        /// The file refers to a symbolic link inode.
+        symbolic-link,
+        /// The descriptor refers to a regular file inode.
+        regular-file,
+        /// The descriptor refers to a socket.
+        socket,
+    }
+
+    /// Descriptor flags.
+    ///
+    /// Note: This was called `fdflags` in earlier versions of WASI.
+    flags descriptor-flags {
+        /// Read mode: Data can be read.
+        read,
+        /// Write mode: Data can be written to.
+        write,
+        /// Request that writes be performed according to synchronized I/O file
+        /// integrity completion. The data stored in the file and the file's
+        /// metadata are synchronized. This is similar to `O_SYNC` in POSIX.
+        ///
+        /// The precise semantics of this operation have not yet been defined for
+        /// WASI. At this time, it should be interpreted as a request, and not a
+        /// requirement.
+        file-integrity-sync,
+        /// Request that writes be performed according to synchronized I/O data
+        /// integrity completion. Only the data stored in the file is
+        /// synchronized. This is similar to `O_DSYNC` in POSIX.
+        ///
+        /// The precise semantics of this operation have not yet been defined for
+        /// WASI. At this time, it should be interpreted as a request, and not a
+        /// requirement.
+        data-integrity-sync,
+        /// Requests that reads be performed at the same level of integrety
+        /// requested for writes. This is similar to `O_RSYNC` in POSIX.
+        ///
+        /// The precise semantics of this operation have not yet been defined for
+        /// WASI. At this time, it should be interpreted as a request, and not a
+        /// requirement.
+        requested-write-sync,
+        /// Mutating directories mode: Directory contents may be mutated.
+        ///
+        /// When this flag is unset on a descriptor, operations using the
+        /// descriptor which would create, rename, delete, modify the data or
+        /// metadata of filesystem objects, or obtain another handle which
+        /// would permit any of those, shall fail with `error-code::read-only` if
+        /// they would otherwise succeed.
+        ///
+        /// This may only be set on directories.
+        mutate-directory,
+    }
+
+    /// File attributes.
+    ///
+    /// Note: This was called `filestat` in earlier versions of WASI.
+    record descriptor-stat {
+        /// File type.
+        %type: descriptor-type,
+        /// Number of hard links to the file.
+        link-count: link-count,
+        /// For regular files, the file size in bytes. For symbolic links, the
+        /// length in bytes of the pathname contained in the symbolic link.
+        size: filesize,
+        /// Last data access timestamp.
+        ///
+        /// If the `option` is none, the platform doesn't maintain an access
+        /// timestamp for this file.
+        data-access-timestamp: option<datetime>,
+        /// Last data modification timestamp.
+        ///
+        /// If the `option` is none, the platform doesn't maintain a
+        /// modification timestamp for this file.
+        data-modification-timestamp: option<datetime>,
+        /// Last file status-change timestamp.
+        ///
+        /// If the `option` is none, the platform doesn't maintain a
+        /// status-change timestamp for this file.
+        status-change-timestamp: option<datetime>,
+    }
+
+    /// Flags determining the method of how paths are resolved.
+    flags path-flags {
+        /// As long as the resolved path corresponds to a symbolic link, it is
+        /// expanded.
+        symlink-follow,
+    }
+
+    /// Open flags used by `open-at`.
+    flags open-flags {
+        /// Create file if it does not exist, similar to `O_CREAT` in POSIX.
+        create,
+        /// Fail if not a directory, similar to `O_DIRECTORY` in POSIX.
+        directory,
+        /// Fail if file already exists, similar to `O_EXCL` in POSIX.
+        exclusive,
+        /// Truncate file to size 0, similar to `O_TRUNC` in POSIX.
+        truncate,
+    }
+
+    /// Number of hard links to an inode.
+    type link-count = u64;
+
+    /// When setting a timestamp, this gives the value to set it to.
+    variant new-timestamp {
+        /// Leave the timestamp set to its previous value.
+        no-change,
+        /// Set the timestamp to the current time of the system clock associated
+        /// with the filesystem.
+        now,
+        /// Set the timestamp to the given value.
+        timestamp(datetime),
+    }
+
+    /// A directory entry.
+    record directory-entry {
+        /// The type of the file referred to by this directory entry.
+        %type: descriptor-type,
+
+        /// The name of the object.
+        name: string,
+    }
+
+    /// Error codes returned by functions, similar to `errno` in POSIX.
+    /// Not all of these error codes are returned by the functions provided by this
+    /// API; some are used in higher-level library layers, and others are provided
+    /// merely for alignment with POSIX.
+    enum error-code {
+        /// Permission denied, similar to `EACCES` in POSIX.
+        access,
+        /// Resource unavailable, or operation would block, similar to `EAGAIN` and `EWOULDBLOCK` in POSIX.
+        would-block,
+        /// Connection already in progress, similar to `EALREADY` in POSIX.
+        already,
+        /// Bad descriptor, similar to `EBADF` in POSIX.
+        bad-descriptor,
+        /// Device or resource busy, similar to `EBUSY` in POSIX.
+        busy,
+        /// Resource deadlock would occur, similar to `EDEADLK` in POSIX.
+        deadlock,
+        /// Storage quota exceeded, similar to `EDQUOT` in POSIX.
+        quota,
+        /// File exists, similar to `EEXIST` in POSIX.
+        exist,
+        /// File too large, similar to `EFBIG` in POSIX.
+        file-too-large,
+        /// Illegal byte sequence, similar to `EILSEQ` in POSIX.
+        illegal-byte-sequence,
+        /// Operation in progress, similar to `EINPROGRESS` in POSIX.
+        in-progress,
+        /// Interrupted function, similar to `EINTR` in POSIX.
+        interrupted,
+        /// Invalid argument, similar to `EINVAL` in POSIX.
+        invalid,
+        /// I/O error, similar to `EIO` in POSIX.
+        io,
+        /// Is a directory, similar to `EISDIR` in POSIX.
+        is-directory,
+        /// Too many levels of symbolic links, similar to `ELOOP` in POSIX.
+        loop,
+        /// Too many links, similar to `EMLINK` in POSIX.
+        too-many-links,
+        /// Message too large, similar to `EMSGSIZE` in POSIX.
+        message-size,
+        /// Filename too long, similar to `ENAMETOOLONG` in POSIX.
+        name-too-long,
+        /// No such device, similar to `ENODEV` in POSIX.
+        no-device,
+        /// No such file or directory, similar to `ENOENT` in POSIX.
+        no-entry,
+        /// No locks available, similar to `ENOLCK` in POSIX.
+        no-lock,
+        /// Not enough space, similar to `ENOMEM` in POSIX.
+        insufficient-memory,
+        /// No space left on device, similar to `ENOSPC` in POSIX.
+        insufficient-space,
+        /// Not a directory or a symbolic link to a directory, similar to `ENOTDIR` in POSIX.
+        not-directory,
+        /// Directory not empty, similar to `ENOTEMPTY` in POSIX.
+        not-empty,
+        /// State not recoverable, similar to `ENOTRECOVERABLE` in POSIX.
+        not-recoverable,
+        /// Not supported, similar to `ENOTSUP` and `ENOSYS` in POSIX.
+        unsupported,
+        /// Inappropriate I/O control operation, similar to `ENOTTY` in POSIX.
+        no-tty,
+        /// No such device or address, similar to `ENXIO` in POSIX.
+        no-such-device,
+        /// Value too large to be stored in data type, similar to `EOVERFLOW` in POSIX.
+        overflow,
+        /// Operation not permitted, similar to `EPERM` in POSIX.
+        not-permitted,
+        /// Broken pipe, similar to `EPIPE` in POSIX.
+        pipe,
+        /// Read-only file system, similar to `EROFS` in POSIX.
+        read-only,
+        /// Invalid seek, similar to `ESPIPE` in POSIX.
+        invalid-seek,
+        /// Text file busy, similar to `ETXTBSY` in POSIX.
+        text-file-busy,
+        /// Cross-device link, similar to `EXDEV` in POSIX.
+        cross-device,
+    }
+
+    /// File or memory access pattern advisory information.
+    enum advice {
+        /// The application has no advice to give on its behavior with respect
+        /// to the specified data.
+        normal,
+        /// The application expects to access the specified data sequentially
+        /// from lower offsets to higher offsets.
+        sequential,
+        /// The application expects to access the specified data in a random
+        /// order.
+        random,
+        /// The application expects to access the specified data in the near
+        /// future.
+        will-need,
+        /// The application expects that it will not access the specified data
+        /// in the near future.
+        dont-need,
+        /// The application expects to access the specified data once and then
+        /// not reuse it thereafter.
+        no-reuse,
+    }
+
+    /// A 128-bit hash value, split into parts because wasm doesn't have a
+    /// 128-bit integer type.
+    record metadata-hash-value {
+       /// 64 bits of a 128-bit hash value.
+       lower: u64,
+       /// Another 64 bits of a 128-bit hash value.
+       upper: u64,
+    }
+
+    /// A descriptor is a reference to a filesystem object, which may be a file,
+    /// directory, named pipe, special file, or other object on which filesystem
+    /// calls may be made.
+    resource descriptor {
+        /// Return a stream for reading from a file, if available.
+        ///
+        /// May fail with an error-code describing why the file cannot be read.
+        ///
+        /// Multiple read, write, and append streams may be active on the same open
+        /// file and they do not interfere with each other.
+        ///
+        /// Note: This allows using `read-stream`, which is similar to `read` in POSIX.
+        read-via-stream: func(
+            /// The offset within the file at which to start reading.
+            offset: filesize,
+        ) -> result<input-stream, error-code>;
+
+        /// Return a stream for writing to a file, if available.
+        ///
+        /// May fail with an error-code describing why the file cannot be written.
+        ///
+        /// Note: This allows using `write-stream`, which is similar to `write` in
+        /// POSIX.
+        write-via-stream: func(
+            /// The offset within the file at which to start writing.
+            offset: filesize,
+        ) -> result<output-stream, error-code>;
+
+        /// Return a stream for appending to a file, if available.
+        ///
+        /// May fail with an error-code describing why the file cannot be appended.
+        ///
+        /// Note: This allows using `write-stream`, which is similar to `write` with
+        /// `O_APPEND` in in POSIX.
+        append-via-stream: func() -> result<output-stream, error-code>;
+
+        /// Provide file advisory information on a descriptor.
+        ///
+        /// This is similar to `posix_fadvise` in POSIX.
+        advise: func(
+            /// The offset within the file to which the advisory applies.
+            offset: filesize,
+            /// The length of the region to which the advisory applies.
+            length: filesize,
+            /// The advice.
+            advice: advice
+        ) -> result<_, error-code>;
+
+        /// Synchronize the data of a file to disk.
+        ///
+        /// This function succeeds with no effect if the file descriptor is not
+        /// opened for writing.
+        ///
+        /// Note: This is similar to `fdatasync` in POSIX.
+        sync-data: func() -> result<_, error-code>;
+
+        /// Get flags associated with a descriptor.
+        ///
+        /// Note: This returns similar flags to `fcntl(fd, F_GETFL)` in POSIX.
+        ///
+        /// Note: This returns the value that was the `fs_flags` value returned
+        /// from `fdstat_get` in earlier versions of WASI.
+        get-flags: func() -> result<descriptor-flags, error-code>;
+
+        /// Get the dynamic type of a descriptor.
+        ///
+        /// Note: This returns the same value as the `type` field of the `fd-stat`
+        /// returned by `stat`, `stat-at` and similar.
+        ///
+        /// Note: This returns similar flags to the `st_mode & S_IFMT` value provided
+        /// by `fstat` in POSIX.
+        ///
+        /// Note: This returns the value that was the `fs_filetype` value returned
+        /// from `fdstat_get` in earlier versions of WASI.
+        get-type: func() -> result<descriptor-type, error-code>;
+
+        /// Adjust the size of an open file. If this increases the file's size, the
+        /// extra bytes are filled with zeros.
+        ///
+        /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
+        set-size: func(size: filesize) -> result<_, error-code>;
+
+        /// Adjust the timestamps of an open file or directory.
+        ///
+        /// Note: This is similar to `futimens` in POSIX.
+        ///
+        /// Note: This was called `fd_filestat_set_times` in earlier versions of WASI.
+        set-times: func(
+            /// The desired values of the data access timestamp.
+            data-access-timestamp: new-timestamp,
+            /// The desired values of the data modification timestamp.
+            data-modification-timestamp: new-timestamp,
+        ) -> result<_, error-code>;
+
+        /// Read from a descriptor, without using and updating the descriptor's offset.
+        ///
+        /// This function returns a list of bytes containing the data that was
+        /// read, along with a bool which, when true, indicates that the end of the
+        /// file was reached. The returned list will contain up to `length` bytes; it
+        /// may return fewer than requested, if the end of the file is reached or
+        /// if the I/O operation is interrupted.
+        ///
+        /// In the future, this may change to return a `stream<u8, error-code>`.
+        ///
+        /// Note: This is similar to `pread` in POSIX.
+        read: func(
+            /// The maximum number of bytes to read.
+            length: filesize,
+            /// The offset within the file at which to read.
+            offset: filesize,
+        ) -> result<tuple<list<u8>, bool>, error-code>;
+
+        /// Write to a descriptor, without using and updating the descriptor's offset.
+        ///
+        /// It is valid to write past the end of a file; the file is extended to the
+        /// extent of the write, with bytes between the previous end and the start of
+        /// the write set to zero.
+        ///
+        /// In the future, this may change to take a `stream<u8, error-code>`.
+        ///
+        /// Note: This is similar to `pwrite` in POSIX.
+        write: func(
+            /// Data to write
+            buffer: list<u8>,
+            /// The offset within the file at which to write.
+            offset: filesize,
+        ) -> result<filesize, error-code>;
+
+        /// Read directory entries from a directory.
+        ///
+        /// On filesystems where directories contain entries referring to themselves
+        /// and their parents, often named `.` and `..` respectively, these entries
+        /// are omitted.
+        ///
+        /// This always returns a new stream which starts at the beginning of the
+        /// directory. Multiple streams may be active on the same directory, and they
+        /// do not interfere with each other.
+        read-directory: func() -> result<directory-entry-stream, error-code>;
+
+        /// Synchronize the data and metadata of a file to disk.
+        ///
+        /// This function succeeds with no effect if the file descriptor is not
+        /// opened for writing.
+        ///
+        /// Note: This is similar to `fsync` in POSIX.
+        sync: func() -> result<_, error-code>;
+
+        /// Create a directory.
+        ///
+        /// Note: This is similar to `mkdirat` in POSIX.
+        create-directory-at: func(
+            /// The relative path at which to create the directory.
+            path: string,
+        ) -> result<_, error-code>;
+
+        /// Return the attributes of an open file or directory.
+        ///
+        /// Note: This is similar to `fstat` in POSIX, except that it does not return
+        /// device and inode information. For testing whether two descriptors refer to
+        /// the same underlying filesystem object, use `is-same-object`. To obtain
+        /// additional data that can be used do determine whether a file has been
+        /// modified, use `metadata-hash`.
+        ///
+        /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
+        stat: func() -> result<descriptor-stat, error-code>;
+
+        /// Return the attributes of a file or directory.
+        ///
+        /// Note: This is similar to `fstatat` in POSIX, except that it does not
+        /// return device and inode information. See the `stat` description for a
+        /// discussion of alternatives.
+        ///
+        /// Note: This was called `path_filestat_get` in earlier versions of WASI.
+        stat-at: func(
+            /// Flags determining the method of how the path is resolved.
+            path-flags: path-flags,
+            /// The relative path of the file or directory to inspect.
+            path: string,
+        ) -> result<descriptor-stat, error-code>;
+
+        /// Adjust the timestamps of a file or directory.
+        ///
+        /// Note: This is similar to `utimensat` in POSIX.
+        ///
+        /// Note: This was called `path_filestat_set_times` in earlier versions of
+        /// WASI.
+        set-times-at: func(
+            /// Flags determining the method of how the path is resolved.
+            path-flags: path-flags,
+            /// The relative path of the file or directory to operate on.
+            path: string,
+            /// The desired values of the data access timestamp.
+            data-access-timestamp: new-timestamp,
+            /// The desired values of the data modification timestamp.
+            data-modification-timestamp: new-timestamp,
+        ) -> result<_, error-code>;
+
+        /// Create a hard link.
+        ///
+        /// Note: This is similar to `linkat` in POSIX.
+        link-at: func(
+            /// Flags determining the method of how the path is resolved.
+            old-path-flags: path-flags,
+            /// The relative source path from which to link.
+            old-path: string,
+            /// The base directory for `new-path`.
+            new-descriptor: borrow<descriptor>,
+            /// The relative destination path at which to create the hard link.
+            new-path: string,
+        ) -> result<_, error-code>;
+
+        /// Open a file or directory.
+        ///
+        /// The returned descriptor is not guaranteed to be the lowest-numbered
+        /// descriptor not currently open/ it is randomized to prevent applications
+        /// from depending on making assumptions about indexes, since this is
+        /// error-prone in multi-threaded contexts. The returned descriptor is
+        /// guaranteed to be less than 2**31.
+        ///
+        /// If `flags` contains `descriptor-flags::mutate-directory`, and the base
+        /// descriptor doesn't have `descriptor-flags::mutate-directory` set,
+        /// `open-at` fails with `error-code::read-only`.
+        ///
+        /// If `flags` contains `write` or `mutate-directory`, or `open-flags`
+        /// contains `truncate` or `create`, and the base descriptor doesn't have
+        /// `descriptor-flags::mutate-directory` set, `open-at` fails with
+        /// `error-code::read-only`.
+        ///
+        /// Note: This is similar to `openat` in POSIX.
+        open-at: func(
+            /// Flags determining the method of how the path is resolved.
+            path-flags: path-flags,
+            /// The relative path of the object to open.
+            path: string,
+            /// The method by which to open the file.
+            open-flags: open-flags,
+            /// Flags to use for the resulting descriptor.
+            %flags: descriptor-flags,
+        ) -> result<descriptor, error-code>;
+
+        /// Read the contents of a symbolic link.
+        ///
+        /// If the contents contain an absolute or rooted path in the underlying
+        /// filesystem, this function fails with `error-code::not-permitted`.
+        ///
+        /// Note: This is similar to `readlinkat` in POSIX.
+        readlink-at: func(
+            /// The relative path of the symbolic link from which to read.
+            path: string,
+        ) -> result<string, error-code>;
+
+        /// Remove a directory.
+        ///
+        /// Return `error-code::not-empty` if the directory is not empty.
+        ///
+        /// Note: This is similar to `unlinkat(fd, path, AT_REMOVEDIR)` in POSIX.
+        remove-directory-at: func(
+            /// The relative path to a directory to remove.
+            path: string,
+        ) -> result<_, error-code>;
+
+        /// Rename a filesystem object.
+        ///
+        /// Note: This is similar to `renameat` in POSIX.
+        rename-at: func(
+            /// The relative source path of the file or directory to rename.
+            old-path: string,
+            /// The base directory for `new-path`.
+            new-descriptor: borrow<descriptor>,
+            /// The relative destination path to which to rename the file or directory.
+            new-path: string,
+        ) -> result<_, error-code>;
+
+        /// Create a symbolic link (also known as a "symlink").
+        ///
+        /// If `old-path` starts with `/`, the function fails with
+        /// `error-code::not-permitted`.
+        ///
+        /// Note: This is similar to `symlinkat` in POSIX.
+        symlink-at: func(
+            /// The contents of the symbolic link.
+            old-path: string,
+            /// The relative destination path at which to create the symbolic link.
+            new-path: string,
+        ) -> result<_, error-code>;
+
+        /// Unlink a filesystem object that is not a directory.
+        ///
+        /// Return `error-code::is-directory` if the path refers to a directory.
+        /// Note: This is similar to `unlinkat(fd, path, 0)` in POSIX.
+        unlink-file-at: func(
+            /// The relative path to a file to unlink.
+            path: string,
+        ) -> result<_, error-code>;
+
+        /// Test whether two descriptors refer to the same filesystem object.
+        ///
+        /// In POSIX, this corresponds to testing whether the two descriptors have the
+        /// same device (`st_dev`) and inode (`st_ino` or `d_ino`) numbers.
+        /// wasi-filesystem does not expose device and inode numbers, so this function
+        /// may be used instead.
+        is-same-object: func(other: borrow<descriptor>) -> bool;
+
+        /// Return a hash of the metadata associated with a filesystem object referred
+        /// to by a descriptor.
+        ///
+        /// This returns a hash of the last-modification timestamp and file size, and
+        /// may also include the inode number, device number, birth timestamp, and
+        /// other metadata fields that may change when the file is modified or
+        /// replaced. It may also include a secret value chosen by the
+        /// implementation and not otherwise exposed.
+        ///
+        /// Implementations are encourated to provide the following properties:
+        ///
+        ///  - If the file is not modified or replaced, the computed hash value should
+        ///    usually not change.
+        ///  - If the object is modified or replaced, the computed hash value should
+        ///    usually change.
+        ///  - The inputs to the hash should not be easily computable from the
+        ///    computed hash.
+        ///
+        /// However, none of these is required.
+        metadata-hash: func() -> result<metadata-hash-value, error-code>;
+
+        /// Return a hash of the metadata associated with a filesystem object referred
+        /// to by a directory descriptor and a relative path.
+        ///
+        /// This performs the same hash computation as `metadata-hash`.
+        metadata-hash-at: func(
+            /// Flags determining the method of how the path is resolved.
+            path-flags: path-flags,
+            /// The relative path of the file or directory to inspect.
+            path: string,
+        ) -> result<metadata-hash-value, error-code>;
+    }
+
+    /// A stream of directory entries.
+    resource directory-entry-stream {
+        /// Read a single directory entry from a `directory-entry-stream`.
+        read-directory-entry: func() -> result<option<directory-entry>, error-code>;
+    }
+
+    /// Attempts to extract a filesystem-related `error-code` from the stream
+    /// `error` provided.
+    ///
+    /// Stream operations which return `stream-error::last-operation-failed`
+    /// have a payload with more information about the operation that failed.
+    /// This payload can be passed through to this function to see if there's
+    /// filesystem-related information about the error to return.
+    ///
+    /// Note that this function is fallible because not all stream-related
+    /// errors are filesystem-related errors.
+    filesystem-error-code: func(err: borrow<error>) -> option<error-code>;
+}

--- a/crates/kotoba-runtime/wit/deps/filesystem/world.wit
+++ b/crates/kotoba-runtime/wit/deps/filesystem/world.wit
@@ -1,0 +1,6 @@
+package wasi:filesystem@0.2.0;
+
+world imports {
+    import types;
+    import preopens;
+}

--- a/crates/kotoba-runtime/wit/deps/http/handler.wit
+++ b/crates/kotoba-runtime/wit/deps/http/handler.wit
@@ -1,0 +1,43 @@
+/// This interface defines a handler of incoming HTTP Requests. It should
+/// be exported by components which can respond to HTTP Requests.
+interface incoming-handler {
+  use types.{incoming-request, response-outparam};
+
+  /// This function is invoked with an incoming HTTP Request, and a resource
+  /// `response-outparam` which provides the capability to reply with an HTTP
+  /// Response. The response is sent by calling the `response-outparam.set`
+  /// method, which allows execution to continue after the response has been
+  /// sent. This enables both streaming to the response body, and performing other
+  /// work.
+  ///
+  /// The implementor of this function must write a response to the
+  /// `response-outparam` before returning, or else the caller will respond
+  /// with an error on its behalf.
+  handle: func(
+    request: incoming-request,
+    response-out: response-outparam
+  );
+}
+
+/// This interface defines a handler of outgoing HTTP Requests. It should be
+/// imported by components which wish to make HTTP Requests.
+interface outgoing-handler {
+  use types.{
+    outgoing-request, request-options, future-incoming-response, error-code
+  };
+
+  /// This function is invoked with an outgoing HTTP Request, and it returns
+  /// a resource `future-incoming-response` which represents an HTTP Response
+  /// which may arrive in the future.
+  ///
+  /// The `options` argument accepts optional parameters for the HTTP
+  /// protocol's transport layer.
+  ///
+  /// This function may return an error if the `outgoing-request` is invalid
+  /// or not allowed to be made. Otherwise, protocol errors are reported
+  /// through the `future-incoming-response`.
+  handle: func(
+    request: outgoing-request,
+    options: option<request-options>
+  ) -> result<future-incoming-response, error-code>;
+}

--- a/crates/kotoba-runtime/wit/deps/http/proxy.wit
+++ b/crates/kotoba-runtime/wit/deps/http/proxy.wit
@@ -1,0 +1,32 @@
+package wasi:http@0.2.0;
+
+/// The `wasi:http/proxy` world captures a widely-implementable intersection of
+/// hosts that includes HTTP forward and reverse proxies. Components targeting
+/// this world may concurrently stream in and out any number of incoming and
+/// outgoing HTTP requests.
+world proxy {
+  /// HTTP proxies have access to time and randomness.
+  include wasi:clocks/imports@0.2.0;
+  import wasi:random/random@0.2.0;
+
+  /// Proxies have standard output and error streams which are expected to
+  /// terminate in a developer-facing console provided by the host.
+  import wasi:cli/stdout@0.2.0;
+  import wasi:cli/stderr@0.2.0;
+
+  /// TODO: this is a temporary workaround until component tooling is able to
+  /// gracefully handle the absence of stdin. Hosts must return an eof stream
+  /// for this import, which is what wasi-libc + tooling will do automatically
+  /// when this import is properly removed.
+  import wasi:cli/stdin@0.2.0;
+
+  /// This is the default handler to use when user code simply wants to make an
+  /// HTTP request (e.g., via `fetch()`).
+  import outgoing-handler;
+
+  /// The host delivers incoming HTTP requests to a component by calling the
+  /// `handle` function of this exported interface. A host may arbitrarily reuse
+  /// or not reuse component instance when delivering incoming HTTP requests and
+  /// thus a component must be able to handle 0..N calls to `handle`.
+  export incoming-handler;
+}

--- a/crates/kotoba-runtime/wit/deps/http/types.wit
+++ b/crates/kotoba-runtime/wit/deps/http/types.wit
@@ -1,0 +1,570 @@
+/// This interface defines all of the types and methods for implementing
+/// HTTP Requests and Responses, both incoming and outgoing, as well as
+/// their headers, trailers, and bodies.
+interface types {
+  use wasi:clocks/monotonic-clock@0.2.0.{duration};
+  use wasi:io/streams@0.2.0.{input-stream, output-stream};
+  use wasi:io/error@0.2.0.{error as io-error};
+  use wasi:io/poll@0.2.0.{pollable};
+
+  /// This type corresponds to HTTP standard Methods.
+  variant method {
+    get,
+    head,
+    post,
+    put,
+    delete,
+    connect,
+    options,
+    trace,
+    patch,
+    other(string)
+  }
+
+  /// This type corresponds to HTTP standard Related Schemes.
+  variant scheme {
+    HTTP,
+    HTTPS,
+    other(string)
+  }
+
+  /// These cases are inspired by the IANA HTTP Proxy Error Types:
+  ///   https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
+  variant error-code {
+    DNS-timeout,
+    DNS-error(DNS-error-payload),
+    destination-not-found,
+    destination-unavailable,
+    destination-IP-prohibited,
+    destination-IP-unroutable,
+    connection-refused,
+    connection-terminated,
+    connection-timeout,
+    connection-read-timeout,
+    connection-write-timeout,
+    connection-limit-reached,
+    TLS-protocol-error,
+    TLS-certificate-error,
+    TLS-alert-received(TLS-alert-received-payload),
+    HTTP-request-denied,
+    HTTP-request-length-required,
+    HTTP-request-body-size(option<u64>),
+    HTTP-request-method-invalid,
+    HTTP-request-URI-invalid,
+    HTTP-request-URI-too-long,
+    HTTP-request-header-section-size(option<u32>),
+    HTTP-request-header-size(option<field-size-payload>),
+    HTTP-request-trailer-section-size(option<u32>),
+    HTTP-request-trailer-size(field-size-payload),
+    HTTP-response-incomplete,
+    HTTP-response-header-section-size(option<u32>),
+    HTTP-response-header-size(field-size-payload),
+    HTTP-response-body-size(option<u64>),
+    HTTP-response-trailer-section-size(option<u32>),
+    HTTP-response-trailer-size(field-size-payload),
+    HTTP-response-transfer-coding(option<string>),
+    HTTP-response-content-coding(option<string>),
+    HTTP-response-timeout,
+    HTTP-upgrade-failed,
+    HTTP-protocol-error,
+    loop-detected,
+    configuration-error,
+    /// This is a catch-all error for anything that doesn't fit cleanly into a
+    /// more specific case. It also includes an optional string for an
+    /// unstructured description of the error. Users should not depend on the
+    /// string for diagnosing errors, as it's not required to be consistent
+    /// between implementations.
+    internal-error(option<string>)
+  }
+
+  /// Defines the case payload type for `DNS-error` above:
+  record DNS-error-payload {
+    rcode: option<string>,
+    info-code: option<u16>
+  }
+
+  /// Defines the case payload type for `TLS-alert-received` above:
+  record TLS-alert-received-payload {
+    alert-id: option<u8>,
+    alert-message: option<string>
+  }
+
+  /// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
+  record field-size-payload {
+    field-name: option<string>,
+    field-size: option<u32>
+  }
+
+  /// Attempts to extract a http-related `error` from the wasi:io `error`
+  /// provided.
+  ///
+  /// Stream operations which return
+  /// `wasi:io/stream/stream-error::last-operation-failed` have a payload of
+  /// type `wasi:io/error/error` with more information about the operation
+  /// that failed. This payload can be passed through to this function to see
+  /// if there's http-related information about the error to return.
+  ///
+  /// Note that this function is fallible because not all io-errors are
+  /// http-related errors.
+  http-error-code: func(err: borrow<io-error>) -> option<error-code>;
+
+  /// This type enumerates the different kinds of errors that may occur when
+  /// setting or appending to a `fields` resource.
+  variant header-error {
+    /// This error indicates that a `field-key` or `field-value` was
+    /// syntactically invalid when used with an operation that sets headers in a
+    /// `fields`.
+    invalid-syntax,
+
+    /// This error indicates that a forbidden `field-key` was used when trying
+    /// to set a header in a `fields`.
+    forbidden,
+
+    /// This error indicates that the operation on the `fields` was not
+    /// permitted because the fields are immutable.
+    immutable,
+  }
+
+  /// Field keys are always strings.
+  type field-key = string;
+
+  /// Field values should always be ASCII strings. However, in
+  /// reality, HTTP implementations often have to interpret malformed values,
+  /// so they are provided as a list of bytes.
+  type field-value = list<u8>;
+
+  /// This following block defines the `fields` resource which corresponds to
+  /// HTTP standard Fields. Fields are a common representation used for both
+  /// Headers and Trailers.
+  ///
+  /// A `fields` may be mutable or immutable. A `fields` created using the
+  /// constructor, `from-list`, or `clone` will be mutable, but a `fields`
+  /// resource given by other means (including, but not limited to,
+  /// `incoming-request.headers`, `outgoing-request.headers`) might be be
+  /// immutable. In an immutable fields, the `set`, `append`, and `delete`
+  /// operations will fail with `header-error.immutable`.
+  resource fields {
+
+    /// Construct an empty HTTP Fields.
+    ///
+    /// The resulting `fields` is mutable.
+    constructor();
+
+    /// Construct an HTTP Fields.
+    ///
+    /// The resulting `fields` is mutable.
+    ///
+    /// The list represents each key-value pair in the Fields. Keys
+    /// which have multiple values are represented by multiple entries in this
+    /// list with the same key.
+    ///
+    /// The tuple is a pair of the field key, represented as a string, and
+    /// Value, represented as a list of bytes. In a valid Fields, all keys
+    /// and values are valid UTF-8 strings. However, values are not always
+    /// well-formed, so they are represented as a raw list of bytes.
+    ///
+    /// An error result will be returned if any header or value was
+    /// syntactically invalid, or if a header was forbidden.
+    from-list: static func(
+      entries: list<tuple<field-key,field-value>>
+    ) -> result<fields, header-error>;
+
+    /// Get all of the values corresponding to a key. If the key is not present
+    /// in this `fields`, an empty list is returned. However, if the key is
+    /// present but empty, this is represented by a list with one or more
+    /// empty field-values present.
+    get: func(name: field-key) -> list<field-value>;
+
+    /// Returns `true` when the key is present in this `fields`. If the key is
+    /// syntactically invalid, `false` is returned.
+    has: func(name: field-key) -> bool;
+
+    /// Set all of the values for a key. Clears any existing values for that
+    /// key, if they have been set.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
+    set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
+
+    /// Delete all values for a key. Does nothing if no values for the key
+    /// exist.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
+    delete: func(name: field-key) -> result<_, header-error>;
+
+    /// Append a value for a key. Does not change or delete any existing
+    /// values for that key.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
+    append: func(name: field-key, value: field-value) -> result<_, header-error>;
+
+    /// Retrieve the full set of keys and values in the Fields. Like the
+    /// constructor, the list represents each key-value pair.
+    ///
+    /// The outer list represents each key-value pair in the Fields. Keys
+    /// which have multiple values are represented by multiple entries in this
+    /// list with the same key.
+    entries: func() -> list<tuple<field-key,field-value>>;
+
+    /// Make a deep copy of the Fields. Equivelant in behavior to calling the
+    /// `fields` constructor on the return value of `entries`. The resulting
+    /// `fields` is mutable.
+    clone: func() -> fields;
+  }
+
+  /// Headers is an alias for Fields.
+  type headers = fields;
+
+  /// Trailers is an alias for Fields.
+  type trailers = fields;
+
+  /// Represents an incoming HTTP Request.
+  resource incoming-request {
+
+    /// Returns the method of the incoming request.
+    method: func() -> method;
+
+    /// Returns the path with query parameters from the request, as a string.
+    path-with-query: func() -> option<string>;
+
+    /// Returns the protocol scheme from the request.
+    scheme: func() -> option<scheme>;
+
+    /// Returns the authority from the request, if it was present.
+    authority: func() -> option<string>;
+
+    /// Get the `headers` associated with the request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
+    ///
+    /// The `headers` returned are a child resource: it must be dropped before
+    /// the parent `incoming-request` is dropped. Dropping this
+    /// `incoming-request` before all children are dropped will trap.
+    headers: func() -> headers;
+
+    /// Gives the `incoming-body` associated with this request. Will only
+    /// return success at most once, and subsequent calls will return error.
+    consume: func() -> result<incoming-body>;
+  }
+
+  /// Represents an outgoing HTTP Request.
+  resource outgoing-request {
+
+    /// Construct a new `outgoing-request` with a default `method` of `GET`, and
+    /// `none` values for `path-with-query`, `scheme`, and `authority`.
+    ///
+    /// * `headers` is the HTTP Headers for the Request.
+    ///
+    /// It is possible to construct, or manipulate with the accessor functions
+    /// below, an `outgoing-request` with an invalid combination of `scheme`
+    /// and `authority`, or `headers` which are not permitted to be sent.
+    /// It is the obligation of the `outgoing-handler.handle` implementation
+    /// to reject invalid constructions of `outgoing-request`.
+    constructor(
+      headers: headers
+    );
+
+    /// Returns the resource corresponding to the outgoing Body for this
+    /// Request.
+    ///
+    /// Returns success on the first call: the `outgoing-body` resource for
+    /// this `outgoing-request` can be retrieved at most once. Subsequent
+    /// calls will return error.
+    body: func() -> result<outgoing-body>;
+
+    /// Get the Method for the Request.
+    method: func() -> method;
+    /// Set the Method for the Request. Fails if the string present in a
+    /// `method.other` argument is not a syntactically valid method.
+    set-method: func(method: method) -> result;
+
+    /// Get the combination of the HTTP Path and Query for the Request.
+    /// When `none`, this represents an empty Path and empty Query.
+    path-with-query: func() -> option<string>;
+    /// Set the combination of the HTTP Path and Query for the Request.
+    /// When `none`, this represents an empty Path and empty Query. Fails is the
+    /// string given is not a syntactically valid path and query uri component.
+    set-path-with-query: func(path-with-query: option<string>) -> result;
+
+    /// Get the HTTP Related Scheme for the Request. When `none`, the
+    /// implementation may choose an appropriate default scheme.
+    scheme: func() -> option<scheme>;
+    /// Set the HTTP Related Scheme for the Request. When `none`, the
+    /// implementation may choose an appropriate default scheme. Fails if the
+    /// string given is not a syntactically valid uri scheme.
+    set-scheme: func(scheme: option<scheme>) -> result;
+
+    /// Get the HTTP Authority for the Request. A value of `none` may be used
+    /// with Related Schemes which do not require an Authority. The HTTP and
+    /// HTTPS schemes always require an authority.
+    authority: func() -> option<string>;
+    /// Set the HTTP Authority for the Request. A value of `none` may be used
+    /// with Related Schemes which do not require an Authority. The HTTP and
+    /// HTTPS schemes always require an authority. Fails if the string given is
+    /// not a syntactically valid uri authority.
+    set-authority: func(authority: option<string>) -> result;
+
+    /// Get the headers associated with the Request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `outgoing-request` is dropped, or its ownership is transfered to
+    /// another component by e.g. `outgoing-handler.handle`.
+    headers: func() -> headers;
+  }
+
+  /// Parameters for making an HTTP Request. Each of these parameters is
+  /// currently an optional timeout applicable to the transport layer of the
+  /// HTTP protocol.
+  ///
+  /// These timeouts are separate from any the user may use to bound a
+  /// blocking call to `wasi:io/poll.poll`.
+  resource request-options {
+    /// Construct a default `request-options` value.
+    constructor();
+
+    /// The timeout for the initial connect to the HTTP Server.
+    connect-timeout: func() -> option<duration>;
+
+    /// Set the timeout for the initial connect to the HTTP Server. An error
+    /// return value indicates that this timeout is not supported.
+    set-connect-timeout: func(duration: option<duration>) -> result;
+
+    /// The timeout for receiving the first byte of the Response body.
+    first-byte-timeout: func() -> option<duration>;
+
+    /// Set the timeout for receiving the first byte of the Response body. An
+    /// error return value indicates that this timeout is not supported.
+    set-first-byte-timeout: func(duration: option<duration>) -> result;
+
+    /// The timeout for receiving subsequent chunks of bytes in the Response
+    /// body stream.
+    between-bytes-timeout: func() -> option<duration>;
+
+    /// Set the timeout for receiving subsequent chunks of bytes in the Response
+    /// body stream. An error return value indicates that this timeout is not
+    /// supported.
+    set-between-bytes-timeout: func(duration: option<duration>) -> result;
+  }
+
+  /// Represents the ability to send an HTTP Response.
+  ///
+  /// This resource is used by the `wasi:http/incoming-handler` interface to
+  /// allow a Response to be sent corresponding to the Request provided as the
+  /// other argument to `incoming-handler.handle`.
+  resource response-outparam {
+
+    /// Set the value of the `response-outparam` to either send a response,
+    /// or indicate an error.
+    ///
+    /// This method consumes the `response-outparam` to ensure that it is
+    /// called at most once. If it is never called, the implementation
+    /// will respond with an error.
+    ///
+    /// The user may provide an `error` to `response` to allow the
+    /// implementation determine how to respond with an HTTP error response.
+    set: static func(
+      param: response-outparam,
+      response: result<outgoing-response, error-code>,
+    );
+  }
+
+  /// This type corresponds to the HTTP standard Status Code.
+  type status-code = u16;
+
+  /// Represents an incoming HTTP Response.
+  resource incoming-response {
+
+    /// Returns the status code from the incoming response.
+    status: func() -> status-code;
+
+    /// Returns the headers from the incoming response.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `incoming-response` is dropped.
+    headers: func() -> headers;
+
+    /// Returns the incoming body. May be called at most once. Returns error
+    /// if called additional times.
+    consume: func() -> result<incoming-body>;
+  }
+
+  /// Represents an incoming HTTP Request or Response's Body.
+  ///
+  /// A body has both its contents - a stream of bytes - and a (possibly
+  /// empty) set of trailers, indicating that the full contents of the
+  /// body have been received. This resource represents the contents as
+  /// an `input-stream` and the delivery of trailers as a `future-trailers`,
+  /// and ensures that the user of this interface may only be consuming either
+  /// the body contents or waiting on trailers at any given time.
+  resource incoming-body {
+
+    /// Returns the contents of the body, as a stream of bytes.
+    ///
+    /// Returns success on first call: the stream representing the contents
+    /// can be retrieved at most once. Subsequent calls will return error.
+    ///
+    /// The returned `input-stream` resource is a child: it must be dropped
+    /// before the parent `incoming-body` is dropped, or consumed by
+    /// `incoming-body.finish`.
+    ///
+    /// This invariant ensures that the implementation can determine whether
+    /// the user is consuming the contents of the body, waiting on the
+    /// `future-trailers` to be ready, or neither. This allows for network
+    /// backpressure is to be applied when the user is consuming the body,
+    /// and for that backpressure to not inhibit delivery of the trailers if
+    /// the user does not read the entire body.
+    %stream: func() -> result<input-stream>;
+
+    /// Takes ownership of `incoming-body`, and returns a `future-trailers`.
+    /// This function will trap if the `input-stream` child is still alive.
+    finish: static func(this: incoming-body) -> future-trailers;
+  }
+
+  /// Represents a future which may eventaully return trailers, or an error.
+  ///
+  /// In the case that the incoming HTTP Request or Response did not have any
+  /// trailers, this future will resolve to the empty set of trailers once the
+  /// complete Request or Response body has been received.
+  resource future-trailers {
+
+    /// Returns a pollable which becomes ready when either the trailers have
+    /// been received, or an error has occured. When this pollable is ready,
+    /// the `get` method will return `some`.
+    subscribe: func() -> pollable;
+
+    /// Returns the contents of the trailers, or an error which occured,
+    /// once the future is ready.
+    ///
+    /// The outer `option` represents future readiness. Users can wait on this
+    /// `option` to become `some` using the `subscribe` method.
+    ///
+    /// The outer `result` is used to retrieve the trailers or error at most
+    /// once. It will be success on the first call in which the outer option
+    /// is `some`, and error on subsequent calls.
+    ///
+    /// The inner `result` represents that either the HTTP Request or Response
+    /// body, as well as any trailers, were received successfully, or that an
+    /// error occured receiving them. The optional `trailers` indicates whether
+    /// or not trailers were present in the body.
+    ///
+    /// When some `trailers` are returned by this method, the `trailers`
+    /// resource is immutable, and a child. Use of the `set`, `append`, or
+    /// `delete` methods will return an error, and the resource must be
+    /// dropped before the parent `future-trailers` is dropped.
+    get: func() -> option<result<result<option<trailers>, error-code>>>;
+  }
+
+  /// Represents an outgoing HTTP Response.
+  resource outgoing-response {
+
+    /// Construct an `outgoing-response`, with a default `status-code` of `200`.
+    /// If a different `status-code` is needed, it must be set via the
+    /// `set-status-code` method.
+    ///
+    /// * `headers` is the HTTP Headers for the Response.
+    constructor(headers: headers);
+
+    /// Get the HTTP Status Code for the Response.
+    status-code: func() -> status-code;
+
+    /// Set the HTTP Status Code for the Response. Fails if the status-code
+    /// given is not a valid http status code.
+    set-status-code: func(status-code: status-code) -> result;
+
+    /// Get the headers associated with the Request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `outgoing-request` is dropped, or its ownership is transfered to
+    /// another component by e.g. `outgoing-handler.handle`.
+    headers: func() -> headers;
+
+    /// Returns the resource corresponding to the outgoing Body for this Response.
+    ///
+    /// Returns success on the first call: the `outgoing-body` resource for
+    /// this `outgoing-response` can be retrieved at most once. Subsequent
+    /// calls will return error.
+    body: func() -> result<outgoing-body>;
+  }
+
+  /// Represents an outgoing HTTP Request or Response's Body.
+  ///
+  /// A body has both its contents - a stream of bytes - and a (possibly
+  /// empty) set of trailers, inducating the full contents of the body
+  /// have been sent. This resource represents the contents as an
+  /// `output-stream` child resource, and the completion of the body (with
+  /// optional trailers) with a static function that consumes the
+  /// `outgoing-body` resource, and ensures that the user of this interface
+  /// may not write to the body contents after the body has been finished.
+  ///
+  /// If the user code drops this resource, as opposed to calling the static
+  /// method `finish`, the implementation should treat the body as incomplete,
+  /// and that an error has occured. The implementation should propogate this
+  /// error to the HTTP protocol by whatever means it has available,
+  /// including: corrupting the body on the wire, aborting the associated
+  /// Request, or sending a late status code for the Response.
+  resource outgoing-body {
+
+    /// Returns a stream for writing the body contents.
+    ///
+    /// The returned `output-stream` is a child resource: it must be dropped
+    /// before the parent `outgoing-body` resource is dropped (or finished),
+    /// otherwise the `outgoing-body` drop or `finish` will trap.
+    ///
+    /// Returns success on the first call: the `output-stream` resource for
+    /// this `outgoing-body` may be retrieved at most once. Subsequent calls
+    /// will return error.
+    write: func() -> result<output-stream>;
+
+    /// Finalize an outgoing body, optionally providing trailers. This must be
+    /// called to signal that the response is complete. If the `outgoing-body`
+    /// is dropped without calling `outgoing-body.finalize`, the implementation
+    /// should treat the body as corrupted.
+    ///
+    /// Fails if the body's `outgoing-request` or `outgoing-response` was
+    /// constructed with a Content-Length header, and the contents written
+    /// to the body (via `write`) does not match the value given in the
+    /// Content-Length.
+    finish: static func(
+      this: outgoing-body,
+      trailers: option<trailers>
+    ) -> result<_, error-code>;
+  }
+
+  /// Represents a future which may eventaully return an incoming HTTP
+  /// Response, or an error.
+  ///
+  /// This resource is returned by the `wasi:http/outgoing-handler` interface to
+  /// provide the HTTP Response corresponding to the sent Request.
+  resource future-incoming-response {
+    /// Returns a pollable which becomes ready when either the Response has
+    /// been received, or an error has occured. When this pollable is ready,
+    /// the `get` method will return `some`.
+    subscribe: func() -> pollable;
+
+    /// Returns the incoming HTTP Response, or an error, once one is ready.
+    ///
+    /// The outer `option` represents future readiness. Users can wait on this
+    /// `option` to become `some` using the `subscribe` method.
+    ///
+    /// The outer `result` is used to retrieve the response or error at most
+    /// once. It will be success on the first call in which the outer option
+    /// is `some`, and error on subsequent calls.
+    ///
+    /// The inner `result` represents that either the incoming HTTP Response
+    /// status and headers have recieved successfully, or that an error
+    /// occured. Errors may also occur while consuming the response body,
+    /// but those will be reported by the `incoming-body` and its
+    /// `output-stream` child.
+    get: func() -> option<result<result<incoming-response, error-code>>>;
+
+  }
+}

--- a/crates/kotoba-runtime/wit/deps/io/error.wit
+++ b/crates/kotoba-runtime/wit/deps/io/error.wit
@@ -1,0 +1,34 @@
+package wasi:io@0.2.0;
+
+
+interface error {
+    /// A resource which represents some error information.
+    ///
+    /// The only method provided by this resource is `to-debug-string`,
+    /// which provides some human-readable information about the error.
+    ///
+    /// In the `wasi:io` package, this resource is returned through the
+    /// `wasi:io/streams/stream-error` type.
+    ///
+    /// To provide more specific error information, other interfaces may
+    /// provide functions to further "downcast" this error into more specific
+    /// error information. For example, `error`s returned in streams derived
+    /// from filesystem types to be described using the filesystem's own
+    /// error-code type, using the function
+    /// `wasi:filesystem/types/filesystem-error-code`, which takes a parameter
+    /// `borrow<error>` and returns
+    /// `option<wasi:filesystem/types/error-code>`.
+    ///
+    /// The set of functions which can "downcast" an `error` into a more
+    /// concrete type is open.
+    resource error {
+        /// Returns a string that is suitable to assist humans in debugging
+        /// this error.
+        ///
+        /// WARNING: The returned string should not be consumed mechanically!
+        /// It may change across platforms, hosts, or other implementation
+        /// details. Parsing this string is a major platform-compatibility
+        /// hazard.
+        to-debug-string: func() -> string;
+    }
+}

--- a/crates/kotoba-runtime/wit/deps/io/poll.wit
+++ b/crates/kotoba-runtime/wit/deps/io/poll.wit
@@ -1,0 +1,41 @@
+package wasi:io@0.2.0;
+
+/// A poll API intended to let users wait for I/O events on multiple handles
+/// at once.
+interface poll {
+    /// `pollable` represents a single I/O event which may be ready, or not.
+    resource pollable {
+
+      /// Return the readiness of a pollable. This function never blocks.
+      ///
+      /// Returns `true` when the pollable is ready, and `false` otherwise.
+      ready: func() -> bool;
+
+      /// `block` returns immediately if the pollable is ready, and otherwise
+      /// blocks until ready.
+      ///
+      /// This function is equivalent to calling `poll.poll` on a list
+      /// containing only this pollable.
+      block: func();
+    }
+
+    /// Poll for completion on a set of pollables.
+    ///
+    /// This function takes a list of pollables, which identify I/O sources of
+    /// interest, and waits until one or more of the events is ready for I/O.
+    ///
+    /// The result `list<u32>` contains one or more indices of handles in the
+    /// argument list that is ready for I/O.
+    ///
+    /// If the list contains more elements than can be indexed with a `u32`
+    /// value, this function traps.
+    ///
+    /// A timeout can be implemented by adding a pollable from the
+    /// wasi-clocks API to the list.
+    ///
+    /// This function does not return a `result`; polling in itself does not
+    /// do any I/O so it doesn't fail. If any of the I/O sources identified by
+    /// the pollables has an error, it is indicated by marking the source as
+    /// being reaedy for I/O.
+    poll: func(in: list<borrow<pollable>>) -> list<u32>;
+}

--- a/crates/kotoba-runtime/wit/deps/io/streams.wit
+++ b/crates/kotoba-runtime/wit/deps/io/streams.wit
@@ -1,0 +1,262 @@
+package wasi:io@0.2.0;
+
+/// WASI I/O is an I/O abstraction API which is currently focused on providing
+/// stream types.
+///
+/// In the future, the component model is expected to add built-in stream types;
+/// when it does, they are expected to subsume this API.
+interface streams {
+    use error.{error};
+    use poll.{pollable};
+
+    /// An error for input-stream and output-stream operations.
+    variant stream-error {
+        /// The last operation (a write or flush) failed before completion.
+        ///
+        /// More information is available in the `error` payload.
+        last-operation-failed(error),
+        /// The stream is closed: no more input will be accepted by the
+        /// stream. A closed output-stream will return this error on all
+        /// future operations.
+        closed
+    }
+
+    /// An input bytestream.
+    ///
+    /// `input-stream`s are *non-blocking* to the extent practical on underlying
+    /// platforms. I/O operations always return promptly; if fewer bytes are
+    /// promptly available than requested, they return the number of bytes promptly
+    /// available, which could even be zero. To wait for data to be available,
+    /// use the `subscribe` function to obtain a `pollable` which can be polled
+    /// for using `wasi:io/poll`.
+    resource input-stream {
+        /// Perform a non-blocking read from the stream.
+        ///
+        /// When the source of a `read` is binary data, the bytes from the source
+        /// are returned verbatim. When the source of a `read` is known to the
+        /// implementation to be text, bytes containing the UTF-8 encoding of the
+        /// text are returned.
+        ///
+        /// This function returns a list of bytes containing the read data,
+        /// when successful. The returned list will contain up to `len` bytes;
+        /// it may return fewer than requested, but not more. The list is
+        /// empty when no bytes are available for reading at this time. The
+        /// pollable given by `subscribe` will be ready when more bytes are
+        /// available.
+        ///
+        /// This function fails with a `stream-error` when the operation
+        /// encounters an error, giving `last-operation-failed`, or when the
+        /// stream is closed, giving `closed`.
+        ///
+        /// When the caller gives a `len` of 0, it represents a request to
+        /// read 0 bytes. If the stream is still open, this call should
+        /// succeed and return an empty list, or otherwise fail with `closed`.
+        ///
+        /// The `len` parameter is a `u64`, which could represent a list of u8 which
+        /// is not possible to allocate in wasm32, or not desirable to allocate as
+        /// as a return value by the callee. The callee may return a list of bytes
+        /// less than `len` in size while more bytes are available for reading.
+        read: func(
+            /// The maximum number of bytes to read
+            len: u64
+        ) -> result<list<u8>, stream-error>;
+
+        /// Read bytes from a stream, after blocking until at least one byte can
+        /// be read. Except for blocking, behavior is identical to `read`.
+        blocking-read: func(
+            /// The maximum number of bytes to read
+            len: u64
+        ) -> result<list<u8>, stream-error>;
+
+        /// Skip bytes from a stream. Returns number of bytes skipped.
+        ///
+        /// Behaves identical to `read`, except instead of returning a list
+        /// of bytes, returns the number of bytes consumed from the stream.
+        skip: func(
+            /// The maximum number of bytes to skip.
+            len: u64,
+        ) -> result<u64, stream-error>;
+
+        /// Skip bytes from a stream, after blocking until at least one byte
+        /// can be skipped. Except for blocking behavior, identical to `skip`.
+        blocking-skip: func(
+            /// The maximum number of bytes to skip.
+            len: u64,
+        ) -> result<u64, stream-error>;
+
+        /// Create a `pollable` which will resolve once either the specified stream
+        /// has bytes available to read or the other end of the stream has been
+        /// closed.
+        /// The created `pollable` is a child resource of the `input-stream`.
+        /// Implementations may trap if the `input-stream` is dropped before
+        /// all derived `pollable`s created with this function are dropped.
+        subscribe: func() -> pollable;
+    }
+
+
+    /// An output bytestream.
+    ///
+    /// `output-stream`s are *non-blocking* to the extent practical on
+    /// underlying platforms. Except where specified otherwise, I/O operations also
+    /// always return promptly, after the number of bytes that can be written
+    /// promptly, which could even be zero. To wait for the stream to be ready to
+    /// accept data, the `subscribe` function to obtain a `pollable` which can be
+    /// polled for using `wasi:io/poll`.
+    resource output-stream {
+        /// Check readiness for writing. This function never blocks.
+        ///
+        /// Returns the number of bytes permitted for the next call to `write`,
+        /// or an error. Calling `write` with more bytes than this function has
+        /// permitted will trap.
+        ///
+        /// When this function returns 0 bytes, the `subscribe` pollable will
+        /// become ready when this function will report at least 1 byte, or an
+        /// error.
+        check-write: func() -> result<u64, stream-error>;
+
+        /// Perform a write. This function never blocks.
+        ///
+        /// When the destination of a `write` is binary data, the bytes from
+        /// `contents` are written verbatim. When the destination of a `write` is
+        /// known to the implementation to be text, the bytes of `contents` are
+        /// transcoded from UTF-8 into the encoding of the destination and then
+        /// written.
+        ///
+        /// Precondition: check-write gave permit of Ok(n) and contents has a
+        /// length of less than or equal to n. Otherwise, this function will trap.
+        ///
+        /// returns Err(closed) without writing if the stream has closed since
+        /// the last call to check-write provided a permit.
+        write: func(
+            contents: list<u8>
+        ) -> result<_, stream-error>;
+
+        /// Perform a write of up to 4096 bytes, and then flush the stream. Block
+        /// until all of these operations are complete, or an error occurs.
+        ///
+        /// This is a convenience wrapper around the use of `check-write`,
+        /// `subscribe`, `write`, and `flush`, and is implemented with the
+        /// following pseudo-code:
+        ///
+        /// ```text
+        /// let pollable = this.subscribe();
+        /// while !contents.is_empty() {
+        ///     // Wait for the stream to become writable
+        ///     pollable.block();
+        ///     let Ok(n) = this.check-write(); // eliding error handling
+        ///     let len = min(n, contents.len());
+        ///     let (chunk, rest) = contents.split_at(len);
+        ///     this.write(chunk  );            // eliding error handling
+        ///     contents = rest;
+        /// }
+        /// this.flush();
+        /// // Wait for completion of `flush`
+        /// pollable.block();
+        /// // Check for any errors that arose during `flush`
+        /// let _ = this.check-write();         // eliding error handling
+        /// ```
+        blocking-write-and-flush: func(
+            contents: list<u8>
+        ) -> result<_, stream-error>;
+
+        /// Request to flush buffered output. This function never blocks.
+        ///
+        /// This tells the output-stream that the caller intends any buffered
+        /// output to be flushed. the output which is expected to be flushed
+        /// is all that has been passed to `write` prior to this call.
+        ///
+        /// Upon calling this function, the `output-stream` will not accept any
+        /// writes (`check-write` will return `ok(0)`) until the flush has
+        /// completed. The `subscribe` pollable will become ready when the
+        /// flush has completed and the stream can accept more writes.
+        flush: func() -> result<_, stream-error>;
+
+        /// Request to flush buffered output, and block until flush completes
+        /// and stream is ready for writing again.
+        blocking-flush: func() -> result<_, stream-error>;
+
+        /// Create a `pollable` which will resolve once the output-stream
+        /// is ready for more writing, or an error has occured. When this
+        /// pollable is ready, `check-write` will return `ok(n)` with n>0, or an
+        /// error.
+        ///
+        /// If the stream is closed, this pollable is always ready immediately.
+        ///
+        /// The created `pollable` is a child resource of the `output-stream`.
+        /// Implementations may trap if the `output-stream` is dropped before
+        /// all derived `pollable`s created with this function are dropped.
+        subscribe: func() -> pollable;
+
+        /// Write zeroes to a stream.
+        ///
+        /// This should be used precisely like `write` with the exact same
+        /// preconditions (must use check-write first), but instead of
+        /// passing a list of bytes, you simply pass the number of zero-bytes
+        /// that should be written.
+        write-zeroes: func(
+            /// The number of zero-bytes to write
+            len: u64
+        ) -> result<_, stream-error>;
+
+        /// Perform a write of up to 4096 zeroes, and then flush the stream.
+        /// Block until all of these operations are complete, or an error
+        /// occurs.
+        ///
+        /// This is a convenience wrapper around the use of `check-write`,
+        /// `subscribe`, `write-zeroes`, and `flush`, and is implemented with
+        /// the following pseudo-code:
+        ///
+        /// ```text
+        /// let pollable = this.subscribe();
+        /// while num_zeroes != 0 {
+        ///     // Wait for the stream to become writable
+        ///     pollable.block();
+        ///     let Ok(n) = this.check-write(); // eliding error handling
+        ///     let len = min(n, num_zeroes);
+        ///     this.write-zeroes(len);         // eliding error handling
+        ///     num_zeroes -= len;
+        /// }
+        /// this.flush();
+        /// // Wait for completion of `flush`
+        /// pollable.block();
+        /// // Check for any errors that arose during `flush`
+        /// let _ = this.check-write();         // eliding error handling
+        /// ```
+        blocking-write-zeroes-and-flush: func(
+            /// The number of zero-bytes to write
+            len: u64
+        ) -> result<_, stream-error>;
+
+        /// Read from one stream and write to another.
+        ///
+        /// The behavior of splice is equivelant to:
+        /// 1. calling `check-write` on the `output-stream`
+        /// 2. calling `read` on the `input-stream` with the smaller of the
+        /// `check-write` permitted length and the `len` provided to `splice`
+        /// 3. calling `write` on the `output-stream` with that read data.
+        ///
+        /// Any error reported by the call to `check-write`, `read`, or
+        /// `write` ends the splice and reports that error.
+        ///
+        /// This function returns the number of bytes transferred; it may be less
+        /// than `len`.
+        splice: func(
+            /// The stream to read from
+            src: borrow<input-stream>,
+            /// The number of bytes to splice
+            len: u64,
+        ) -> result<u64, stream-error>;
+
+        /// Read from one stream and write to another, with blocking.
+        ///
+        /// This is similar to `splice`, except that it blocks until the
+        /// `output-stream` is ready for writing, and the `input-stream`
+        /// is ready for reading, before performing the `splice`.
+        blocking-splice: func(
+            /// The stream to read from
+            src: borrow<input-stream>,
+            /// The number of bytes to splice
+            len: u64,
+        ) -> result<u64, stream-error>;
+    }
+}

--- a/crates/kotoba-runtime/wit/deps/io/world.wit
+++ b/crates/kotoba-runtime/wit/deps/io/world.wit
@@ -1,0 +1,6 @@
+package wasi:io@0.2.0;
+
+world imports {
+    import streams;
+    import poll;
+}

--- a/crates/kotoba-runtime/wit/deps/random/insecure-seed.wit
+++ b/crates/kotoba-runtime/wit/deps/random/insecure-seed.wit
@@ -1,0 +1,25 @@
+package wasi:random@0.2.0;
+/// The insecure-seed interface for seeding hash-map DoS resistance.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+interface insecure-seed {
+    /// Return a 128-bit value that may contain a pseudo-random value.
+    ///
+    /// The returned value is not required to be computed from a CSPRNG, and may
+    /// even be entirely deterministic. Host implementations are encouraged to
+    /// provide pseudo-random values to any program exposed to
+    /// attacker-controlled content, to enable DoS protection built into many
+    /// languages' hash-map implementations.
+    ///
+    /// This function is intended to only be called once, by a source language
+    /// to initialize Denial Of Service (DoS) protection in its hash-map
+    /// implementation.
+    ///
+    /// # Expected future evolution
+    ///
+    /// This will likely be changed to a value import, to prevent it from being
+    /// called multiple times and potentially used for purposes other than DoS
+    /// protection.
+    insecure-seed: func() -> tuple<u64, u64>;
+}

--- a/crates/kotoba-runtime/wit/deps/random/insecure.wit
+++ b/crates/kotoba-runtime/wit/deps/random/insecure.wit
@@ -1,0 +1,22 @@
+package wasi:random@0.2.0;
+/// The insecure interface for insecure pseudo-random numbers.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+interface insecure {
+    /// Return `len` insecure pseudo-random bytes.
+    ///
+    /// This function is not cryptographically secure. Do not use it for
+    /// anything related to security.
+    ///
+    /// There are no requirements on the values of the returned bytes, however
+    /// implementations are encouraged to return evenly distributed values with
+    /// a long period.
+    get-insecure-random-bytes: func(len: u64) -> list<u8>;
+
+    /// Return an insecure pseudo-random `u64` value.
+    ///
+    /// This function returns the same type of pseudo-random data as
+    /// `get-insecure-random-bytes`, represented as a `u64`.
+    get-insecure-random-u64: func() -> u64;
+}

--- a/crates/kotoba-runtime/wit/deps/random/random.wit
+++ b/crates/kotoba-runtime/wit/deps/random/random.wit
@@ -1,0 +1,26 @@
+package wasi:random@0.2.0;
+/// WASI Random is a random data API.
+///
+/// It is intended to be portable at least between Unix-family platforms and
+/// Windows.
+interface random {
+    /// Return `len` cryptographically-secure random or pseudo-random bytes.
+    ///
+    /// This function must produce data at least as cryptographically secure and
+    /// fast as an adequately seeded cryptographically-secure pseudo-random
+    /// number generator (CSPRNG). It must not block, from the perspective of
+    /// the calling program, under any circumstances, including on the first
+    /// request and on requests for numbers of bytes. The returned data must
+    /// always be unpredictable.
+    ///
+    /// This function must always return fresh data. Deterministic environments
+    /// must omit this function, rather than implementing it with deterministic
+    /// data.
+    get-random-bytes: func(len: u64) -> list<u8>;
+
+    /// Return a cryptographically-secure random or pseudo-random `u64` value.
+    ///
+    /// This function returns the same type of data as `get-random-bytes`,
+    /// represented as a `u64`.
+    get-random-u64: func() -> u64;
+}

--- a/crates/kotoba-runtime/wit/deps/random/world.wit
+++ b/crates/kotoba-runtime/wit/deps/random/world.wit
@@ -1,0 +1,7 @@
+package wasi:random@0.2.0;
+
+world imports {
+    import random;
+    import insecure;
+    import insecure-seed;
+}

--- a/crates/kotoba-runtime/wit/deps/sockets/instance-network.wit
+++ b/crates/kotoba-runtime/wit/deps/sockets/instance-network.wit
@@ -1,0 +1,9 @@
+
+/// This interface provides a value-export of the default network handle..
+interface instance-network {
+    use network.{network};
+
+    /// Get a handle to the default network.
+    instance-network: func() -> network;
+
+}

--- a/crates/kotoba-runtime/wit/deps/sockets/ip-name-lookup.wit
+++ b/crates/kotoba-runtime/wit/deps/sockets/ip-name-lookup.wit
@@ -1,0 +1,51 @@
+
+interface ip-name-lookup {
+    use wasi:io/poll@0.2.0.{pollable};
+    use network.{network, error-code, ip-address};
+
+
+    /// Resolve an internet host name to a list of IP addresses.
+    ///
+    /// Unicode domain names are automatically converted to ASCII using IDNA encoding.
+    /// If the input is an IP address string, the address is parsed and returned
+    /// as-is without making any external requests.
+    ///
+    /// See the wasi-socket proposal README.md for a comparison with getaddrinfo.
+    ///
+    /// This function never blocks. It either immediately fails or immediately
+    /// returns successfully with a `resolve-address-stream` that can be used
+    /// to (asynchronously) fetch the results.
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`: `name` is a syntactically invalid domain name or IP address.
+    ///
+    /// # References:
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html>
+    /// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
+    resolve-addresses: func(network: borrow<network>, name: string) -> result<resolve-address-stream, error-code>;
+
+    resource resolve-address-stream {
+        /// Returns the next address from the resolver.
+        ///
+        /// This function should be called multiple times. On each call, it will
+        /// return the next address in connection order preference. If all
+        /// addresses have been exhausted, this function returns `none`.
+        ///
+        /// This function never returns IPv4-mapped IPv6 addresses.
+        ///
+        /// # Typical errors
+        /// - `name-unresolvable`:          Name does not exist or has no suitable associated IP addresses. (EAI_NONAME, EAI_NODATA, EAI_ADDRFAMILY)
+        /// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
+        /// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
+        /// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
+        resolve-next-address: func() -> result<option<ip-address>, error-code>;
+
+        /// Create a `pollable` which will resolve once the stream is ready for I/O.
+        ///
+        /// Note: this function is here for WASI Preview2 only.
+        /// It's planned to be removed when `future` is natively supported in Preview3.
+        subscribe: func() -> pollable;
+    }
+}

--- a/crates/kotoba-runtime/wit/deps/sockets/network.wit
+++ b/crates/kotoba-runtime/wit/deps/sockets/network.wit
@@ -1,0 +1,145 @@
+
+interface network {
+    /// An opaque resource that represents access to (a subset of) the network.
+    /// This enables context-based security for networking.
+    /// There is no need for this to map 1:1 to a physical network interface.
+    resource network;
+
+    /// Error codes.
+    ///
+    /// In theory, every API can return any error code.
+    /// In practice, API's typically only return the errors documented per API
+    /// combined with a couple of errors that are always possible:
+    /// - `unknown`
+    /// - `access-denied`
+    /// - `not-supported`
+    /// - `out-of-memory`
+    /// - `concurrency-conflict`
+    ///
+    /// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
+    enum error-code {
+        /// Unknown error
+        unknown,
+
+        /// Access denied.
+        ///
+        /// POSIX equivalent: EACCES, EPERM
+        access-denied,
+
+        /// The operation is not supported.
+        ///
+        /// POSIX equivalent: EOPNOTSUPP
+        not-supported,
+
+        /// One of the arguments is invalid.
+        ///
+        /// POSIX equivalent: EINVAL
+        invalid-argument,
+
+        /// Not enough memory to complete the operation.
+        ///
+        /// POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
+        out-of-memory,
+
+        /// The operation timed out before it could finish completely.
+        timeout,
+
+        /// This operation is incompatible with another asynchronous operation that is already in progress.
+        ///
+        /// POSIX equivalent: EALREADY
+        concurrency-conflict,
+
+        /// Trying to finish an asynchronous operation that:
+        /// - has not been started yet, or:
+        /// - was already finished by a previous `finish-*` call.
+        ///
+        /// Note: this is scheduled to be removed when `future`s are natively supported.
+        not-in-progress,
+
+        /// The operation has been aborted because it could not be completed immediately.
+        ///
+        /// Note: this is scheduled to be removed when `future`s are natively supported.
+        would-block,
+
+
+        /// The operation is not valid in the socket's current state.
+        invalid-state,
+
+        /// A new socket resource could not be created because of a system limit.
+        new-socket-limit,
+
+        /// A bind operation failed because the provided address is not an address that the `network` can bind to.
+        address-not-bindable,
+
+        /// A bind operation failed because the provided address is already in use or because there are no ephemeral ports available.
+        address-in-use,
+
+        /// The remote address is not reachable
+        remote-unreachable,
+
+
+        /// The TCP connection was forcefully rejected
+        connection-refused,
+
+        /// The TCP connection was reset.
+        connection-reset,
+
+        /// A TCP connection was aborted.
+        connection-aborted,
+
+
+        /// The size of a datagram sent to a UDP socket exceeded the maximum
+        /// supported size.
+        datagram-too-large,
+
+
+        /// Name does not exist or has no suitable associated IP addresses.
+        name-unresolvable,
+
+        /// A temporary failure in name resolution occurred.
+        temporary-resolver-failure,
+
+        /// A permanent failure in name resolution occurred.
+        permanent-resolver-failure,
+    }
+
+    enum ip-address-family {
+        /// Similar to `AF_INET` in POSIX.
+        ipv4,
+
+        /// Similar to `AF_INET6` in POSIX.
+        ipv6,
+    }
+
+    type ipv4-address = tuple<u8, u8, u8, u8>;
+    type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>;
+
+    variant ip-address {
+        ipv4(ipv4-address),
+        ipv6(ipv6-address),
+    }
+
+    record ipv4-socket-address {
+        /// sin_port
+        port: u16,
+        /// sin_addr
+        address: ipv4-address,
+    }
+
+    record ipv6-socket-address {
+        /// sin6_port
+        port: u16,
+        /// sin6_flowinfo
+        flow-info: u32,
+        /// sin6_addr
+        address: ipv6-address,
+        /// sin6_scope_id
+        scope-id: u32,
+    }
+
+    variant ip-socket-address {
+        ipv4(ipv4-socket-address),
+        ipv6(ipv6-socket-address),
+    }
+
+}

--- a/crates/kotoba-runtime/wit/deps/sockets/tcp-create-socket.wit
+++ b/crates/kotoba-runtime/wit/deps/sockets/tcp-create-socket.wit
@@ -1,0 +1,27 @@
+
+interface tcp-create-socket {
+    use network.{network, error-code, ip-address-family};
+    use tcp.{tcp-socket};
+
+    /// Create a new TCP socket.
+    ///
+    /// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
+    /// On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured otherwise.
+    ///
+    /// This function does not require a network capability handle. This is considered to be safe because
+    /// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect`
+    /// is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
+    ///
+    /// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+    ///
+    /// # Typical errors
+    /// - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
+    /// - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
+    /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+    create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
+}

--- a/crates/kotoba-runtime/wit/deps/sockets/tcp.wit
+++ b/crates/kotoba-runtime/wit/deps/sockets/tcp.wit
@@ -1,0 +1,353 @@
+
+interface tcp {
+    use wasi:io/streams@0.2.0.{input-stream, output-stream};
+    use wasi:io/poll@0.2.0.{pollable};
+    use wasi:clocks/monotonic-clock@0.2.0.{duration};
+    use network.{network, error-code, ip-socket-address, ip-address-family};
+
+    enum shutdown-type {
+        /// Similar to `SHUT_RD` in POSIX.
+        receive,
+
+        /// Similar to `SHUT_WR` in POSIX.
+        send,
+
+        /// Similar to `SHUT_RDWR` in POSIX.
+        both,
+    }
+    
+    /// A TCP socket resource.
+    ///
+    /// The socket can be in one of the following states:
+    /// - `unbound`
+    /// - `bind-in-progress`
+    /// - `bound` (See note below)
+    /// - `listen-in-progress`
+    /// - `listening`
+    /// - `connect-in-progress`
+    /// - `connected`
+    /// - `closed`
+    /// See <https://github.com/WebAssembly/wasi-sockets/TcpSocketOperationalSemantics.md>
+    /// for a more information.
+    ///
+    /// Note: Except where explicitly mentioned, whenever this documentation uses
+    /// the term "bound" without backticks it actually means: in the `bound` state *or higher*.
+    /// (i.e. `bound`, `listen-in-progress`, `listening`, `connect-in-progress` or `connected`)
+    ///
+    /// In addition to the general error codes documented on the
+    /// `network::error-code` type, TCP socket methods may always return
+    /// `error(invalid-state)` when in the `closed` state.
+    resource tcp-socket {
+        /// Bind the socket to a specific network on the provided IP address and port.
+        ///
+        /// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
+        /// network interface(s) to bind to.
+        /// If the TCP/UDP port is zero, the socket will be bound to a random free port.
+        ///
+        /// Bind can be attempted multiple times on the same socket, even with
+        /// different arguments on each iteration. But never concurrently and
+        /// only as long as the previous bind failed. Once a bind succeeds, the
+        /// binding can't be changed anymore.
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
+        /// - `invalid-argument`:          `local-address` is not a unicast address. (EINVAL)
+        /// - `invalid-argument`:          `local-address` is an IPv4-mapped IPv6 address. (EINVAL)
+        /// - `invalid-state`:             The socket is already bound. (EINVAL)
+        /// - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+        /// - `address-in-use`:            Address is already in use. (EADDRINUSE)
+        /// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+        /// - `not-in-progress`:           A `bind` operation is not in progress.
+        /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        /// 
+        /// # Implementors note
+        /// When binding to a non-zero port, this bind operation shouldn't be affected by the TIME_WAIT
+        /// state of a recently closed socket on the same local address. In practice this means that the SO_REUSEADDR 
+        /// socket option should be set implicitly on all platforms, except on Windows where this is the default behavior
+        /// and SO_REUSEADDR performs something different entirely.
+        ///
+        /// Unlike in POSIX, in WASI the bind operation is async. This enables
+        /// interactive WASI hosts to inject permission prompts. Runtimes that
+        /// don't want to make use of this ability can simply call the native
+        /// `bind` as part of either `start-bind` or `finish-bind`.
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
+        /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+        start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+        finish-bind: func() -> result<_, error-code>;
+
+        /// Connect to a remote endpoint.
+        ///
+        /// On success:
+        /// - the socket is transitioned into the `connection` state.
+        /// - a pair of streams is returned that can be used to read & write to the connection
+        ///
+        /// After a failed connection attempt, the socket will be in the `closed`
+        /// state and the only valid action left is to `drop` the socket. A single
+        /// socket can not be used to connect more than once.
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+        /// - `invalid-argument`:          `remote-address` is not a unicast address. (EINVAL, ENETUNREACH on Linux, EAFNOSUPPORT on MacOS)
+        /// - `invalid-argument`:          `remote-address` is an IPv4-mapped IPv6 address. (EINVAL, EADDRNOTAVAIL on Illumos)
+        /// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
+        /// - `invalid-argument`:          The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
+        /// - `invalid-argument`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
+        /// - `invalid-state`:             The socket is already in the `connected` state. (EISCONN)
+        /// - `invalid-state`:             The socket is already in the `listening` state. (EOPNOTSUPP, EINVAL on Windows)
+        /// - `timeout`:                   Connection timed out. (ETIMEDOUT)
+        /// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
+        /// - `connection-reset`:          The connection was reset. (ECONNRESET)
+        /// - `connection-aborted`:        The connection was aborted. (ECONNABORTED)
+        /// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+        /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+        /// - `not-in-progress`:           A connect operation is not in progress.
+        /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # Implementors note
+        /// The POSIX equivalent of `start-connect` is the regular `connect` syscall.
+        /// Because all WASI sockets are non-blocking this is expected to return
+        /// EINPROGRESS, which should be translated to `ok()` in WASI.
+        ///
+        /// The POSIX equivalent of `finish-connect` is a `poll` for event `POLLOUT`
+        /// with a timeout of 0 on the socket descriptor. Followed by a check for
+        /// the `SO_ERROR` socket option, in case the poll signaled readiness.
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
+        /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+        /// - <https://man.freebsd.org/cgi/man.cgi?connect>
+        start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+        finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
+
+        /// Start listening for new connections.
+        ///
+        /// Transitions the socket into the `listening` state.
+        ///
+        /// Unlike POSIX, the socket must already be explicitly bound.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`:             The socket is not bound to any local address. (EDESTADDRREQ)
+        /// - `invalid-state`:             The socket is already in the `connected` state. (EISCONN, EINVAL on BSD)
+        /// - `invalid-state`:             The socket is already in the `listening` state.
+        /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
+        /// - `not-in-progress`:           A listen operation is not in progress.
+        /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # Implementors note
+        /// Unlike in POSIX, in WASI the listen operation is async. This enables
+        /// interactive WASI hosts to inject permission prompts. Runtimes that
+        /// don't want to make use of this ability can simply call the native
+        /// `listen` as part of either `start-listen` or `finish-listen`.
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
+        /// - <https://man7.org/linux/man-pages/man2/listen.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
+        start-listen: func() -> result<_, error-code>;
+        finish-listen: func() -> result<_, error-code>;
+
+        /// Accept a new client socket.
+        ///
+        /// The returned socket is bound and in the `connected` state. The following properties are inherited from the listener socket:
+        /// - `address-family`
+        /// - `keep-alive-enabled`
+        /// - `keep-alive-idle-time`
+        /// - `keep-alive-interval`
+        /// - `keep-alive-count`
+        /// - `hop-limit`
+        /// - `receive-buffer-size`
+        /// - `send-buffer-size`
+        ///
+        /// On success, this function returns the newly accepted client socket along with
+        /// a pair of streams that can be used to read & write to the connection.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`:      Socket is not in the `listening` state. (EINVAL)
+        /// - `would-block`:        No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
+        /// - `connection-aborted`: An incoming connection was pending, but was terminated by the client before this listener could accept it. (ECONNABORTED)
+        /// - `new-socket-limit`:   The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
+        /// - <https://man7.org/linux/man-pages/man2/accept.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
+        accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>;
+
+        /// Get the bound local address.
+        ///
+        /// POSIX mentions:
+        /// > If the socket has not been bound to a local name, the value
+        /// > stored in the object pointed to by `address` is unspecified.
+        ///
+        /// WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not bound to any local address.
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
+        /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+        /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+        local-address: func() -> result<ip-socket-address, error-code>;
+
+        /// Get the remote address.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
+        /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+        remote-address: func() -> result<ip-socket-address, error-code>;
+
+        /// Whether the socket is in the `listening` state.
+        ///
+        /// Equivalent to the SO_ACCEPTCONN socket option.
+        is-listening: func() -> bool;
+
+        /// Whether this is a IPv4 or IPv6 socket.
+        ///
+        /// Equivalent to the SO_DOMAIN socket option.
+        address-family: func() -> ip-address-family;
+
+        /// Hints the desired listen queue size. Implementations are free to ignore this.
+        ///
+        /// If the provided value is 0, an `invalid-argument` error is returned.
+        /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
+        ///
+        /// # Typical errors
+        /// - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
+        /// - `invalid-argument`:     (set) The provided value was 0.
+        /// - `invalid-state`:        (set) The socket is in the `connect-in-progress` or `connected` state.
+        set-listen-backlog-size: func(value: u64) -> result<_, error-code>;
+
+        /// Enables or disables keepalive.
+        ///
+        /// The keepalive behavior can be adjusted using:
+        /// - `keep-alive-idle-time`
+        /// - `keep-alive-interval`
+        /// - `keep-alive-count`
+        /// These properties can be configured while `keep-alive-enabled` is false, but only come into effect when `keep-alive-enabled` is true.
+        ///
+        /// Equivalent to the SO_KEEPALIVE socket option.
+        keep-alive-enabled: func() -> result<bool, error-code>;
+        set-keep-alive-enabled: func(value: bool) -> result<_, error-code>;
+
+        /// Amount of time the connection has to be idle before TCP starts sending keepalive packets.
+        ///
+        /// If the provided value is 0, an `invalid-argument` error is returned.
+        /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
+        /// I.e. after setting a value, reading the same setting back may return a different value.
+        ///
+        /// Equivalent to the TCP_KEEPIDLE socket option. (TCP_KEEPALIVE on MacOS)
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:     (set) The provided value was 0.
+        keep-alive-idle-time: func() -> result<duration, error-code>;
+        set-keep-alive-idle-time: func(value: duration) -> result<_, error-code>;
+
+        /// The time between keepalive packets.
+        ///
+        /// If the provided value is 0, an `invalid-argument` error is returned.
+        /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
+        /// I.e. after setting a value, reading the same setting back may return a different value.
+        ///
+        /// Equivalent to the TCP_KEEPINTVL socket option.
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:     (set) The provided value was 0.
+        keep-alive-interval: func() -> result<duration, error-code>;
+        set-keep-alive-interval: func(value: duration) -> result<_, error-code>;
+
+        /// The maximum amount of keepalive packets TCP should send before aborting the connection.
+        ///
+        /// If the provided value is 0, an `invalid-argument` error is returned.
+        /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
+        /// I.e. after setting a value, reading the same setting back may return a different value.
+        ///
+        /// Equivalent to the TCP_KEEPCNT socket option.
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:     (set) The provided value was 0.
+        keep-alive-count: func() -> result<u32, error-code>;
+        set-keep-alive-count: func(value: u32) -> result<_, error-code>;
+
+        /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
+        ///
+        /// If the provided value is 0, an `invalid-argument` error is returned.
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
+        hop-limit: func() -> result<u8, error-code>;
+        set-hop-limit: func(value: u8) -> result<_, error-code>;
+
+        /// The kernel buffer space reserved for sends/receives on this socket.
+        ///
+        /// If the provided value is 0, an `invalid-argument` error is returned.
+        /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
+        /// I.e. after setting a value, reading the same setting back may return a different value.
+        ///
+        /// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:     (set) The provided value was 0.
+        receive-buffer-size: func() -> result<u64, error-code>;
+        set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+        send-buffer-size: func() -> result<u64, error-code>;
+        set-send-buffer-size: func(value: u64) -> result<_, error-code>;
+
+        /// Create a `pollable` which can be used to poll for, or block on,
+        /// completion of any of the asynchronous operations of this socket.
+        ///
+        /// When `finish-bind`, `finish-listen`, `finish-connect` or `accept`
+        /// return `error(would-block)`, this pollable can be used to wait for
+        /// their success or failure, after which the method can be retried.
+        ///
+        /// The pollable is not limited to the async operation that happens to be
+        /// in progress at the time of calling `subscribe` (if any). Theoretically,
+        /// `subscribe` only has to be called once per socket and can then be
+        /// (re)used for the remainder of the socket's lifetime.
+        ///
+        /// See <https://github.com/WebAssembly/wasi-sockets/TcpSocketOperationalSemantics.md#Pollable-readiness>
+        /// for a more information.
+        ///
+        /// Note: this function is here for WASI Preview2 only.
+        /// It's planned to be removed when `future` is natively supported in Preview3.
+        subscribe: func() -> pollable;
+
+        /// Initiate a graceful shutdown.
+        ///
+        /// - `receive`: The socket is not expecting to receive any data from
+        ///   the peer. The `input-stream` associated with this socket will be
+        ///   closed. Any data still in the receive queue at time of calling
+        ///   this method will be discarded.
+        /// - `send`: The socket has no more data to send to the peer. The `output-stream`
+        ///   associated with this socket will be closed and a FIN packet will be sent.
+        /// - `both`: Same effect as `receive` & `send` combined.
+        ///
+        /// This function is idempotent. Shutting a down a direction more than once
+        /// has no effect and returns `ok`.
+        ///
+        /// The shutdown function does not close (drop) the socket.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not in the `connected` state. (ENOTCONN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
+        /// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
+        shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>;
+    }
+}

--- a/crates/kotoba-runtime/wit/deps/sockets/udp-create-socket.wit
+++ b/crates/kotoba-runtime/wit/deps/sockets/udp-create-socket.wit
@@ -1,0 +1,27 @@
+
+interface udp-create-socket {
+    use network.{network, error-code, ip-address-family};
+    use udp.{udp-socket};
+
+    /// Create a new UDP socket.
+    ///
+    /// Similar to `socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)` in POSIX.
+    /// On IPv6 sockets, IPV6_V6ONLY is enabled by default and can't be configured otherwise.
+    ///
+    /// This function does not require a network capability handle. This is considered to be safe because
+    /// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind` is called,
+    /// the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
+    ///
+    /// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+    ///
+    /// # Typical errors
+    /// - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
+    /// - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+    ///
+    /// # References:
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
+    /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+    create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>;
+}

--- a/crates/kotoba-runtime/wit/deps/sockets/udp.wit
+++ b/crates/kotoba-runtime/wit/deps/sockets/udp.wit
@@ -1,0 +1,266 @@
+
+interface udp {
+    use wasi:io/poll@0.2.0.{pollable};
+    use network.{network, error-code, ip-socket-address, ip-address-family};
+
+    /// A received datagram.
+    record incoming-datagram {
+        /// The payload.
+        /// 
+        /// Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
+        data: list<u8>,
+
+        /// The source address.
+        ///
+        /// This field is guaranteed to match the remote address the stream was initialized with, if any.
+        ///
+        /// Equivalent to the `src_addr` out parameter of `recvfrom`.
+        remote-address: ip-socket-address,
+    }
+
+    /// A datagram to be sent out.
+    record outgoing-datagram {
+        /// The payload.
+        data: list<u8>,
+
+        /// The destination address.
+        ///
+        /// The requirements on this field depend on how the stream was initialized:
+        /// - with a remote address: this field must be None or match the stream's remote address exactly.
+        /// - without a remote address: this field is required.
+        ///
+        /// If this value is None, the send operation is equivalent to `send` in POSIX. Otherwise it is equivalent to `sendto`.
+        remote-address: option<ip-socket-address>,
+    }
+
+
+
+    /// A UDP socket handle.
+    resource udp-socket {
+        /// Bind the socket to a specific network on the provided IP address and port.
+        ///
+        /// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
+        /// network interface(s) to bind to.
+        /// If the port is zero, the socket will be bound to a random free port.
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
+        /// - `invalid-state`:             The socket is already bound. (EINVAL)
+        /// - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+        /// - `address-in-use`:            Address is already in use. (EADDRINUSE)
+        /// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+        /// - `not-in-progress`:           A `bind` operation is not in progress.
+        /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # Implementors note
+        /// Unlike in POSIX, in WASI the bind operation is async. This enables
+        /// interactive WASI hosts to inject permission prompts. Runtimes that
+        /// don't want to make use of this ability can simply call the native
+        /// `bind` as part of either `start-bind` or `finish-bind`.
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
+        /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+        start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+        finish-bind: func() -> result<_, error-code>;
+
+        /// Set up inbound & outbound communication channels, optionally to a specific peer.
+        ///
+        /// This function only changes the local socket configuration and does not generate any network traffic.
+        /// On success, the `remote-address` of the socket is updated. The `local-address` may be updated as well,
+        /// based on the best network path to `remote-address`.
+        ///
+        /// When a `remote-address` is provided, the returned streams are limited to communicating with that specific peer:
+        /// - `send` can only be used to send to this destination.
+        /// - `receive` will only return datagrams sent from the provided `remote-address`.
+        ///
+        /// This method may be called multiple times on the same socket to change its association, but
+        /// only the most recently returned pair of streams will be operational. Implementations may trap if
+        /// the streams returned by a previous invocation haven't been dropped yet before calling `stream` again.
+        /// 
+        /// The POSIX equivalent in pseudo-code is:
+        /// ```text
+        /// if (was previously connected) {
+        /// 	connect(s, AF_UNSPEC)
+        /// }
+        /// if (remote_address is Some) {
+        /// 	connect(s, remote_address)
+        /// }
+        /// ```
+        ///
+        /// Unlike in POSIX, the socket must already be explicitly bound.
+        /// 
+        /// # Typical errors
+        /// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+        /// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
+        /// - `invalid-argument`:          The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
+        /// - `invalid-state`:             The socket is not bound.
+        /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+        /// - `remote-unreachable`:        The remote address is not reachable. (ECONNRESET, ENETRESET, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+        /// - `connection-refused`:        The connection was refused. (ECONNREFUSED)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
+        /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+        /// - <https://man.freebsd.org/cgi/man.cgi?connect>
+        %stream: func(remote-address: option<ip-socket-address>) -> result<tuple<incoming-datagram-stream, outgoing-datagram-stream>, error-code>;
+
+        /// Get the current bound address.
+        ///
+        /// POSIX mentions:
+        /// > If the socket has not been bound to a local name, the value
+        /// > stored in the object pointed to by `address` is unspecified.
+        ///
+        /// WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
+        /// 
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not bound to any local address.
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
+        /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+        /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+        local-address: func() -> result<ip-socket-address, error-code>;
+
+        /// Get the address the socket is currently streaming to.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not streaming to a specific remote address. (ENOTCONN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
+        /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+        remote-address: func() -> result<ip-socket-address, error-code>;
+
+        /// Whether this is a IPv4 or IPv6 socket.
+        ///
+        /// Equivalent to the SO_DOMAIN socket option.
+        address-family: func() -> ip-address-family;
+
+        /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
+        ///
+        /// If the provided value is 0, an `invalid-argument` error is returned.
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
+        unicast-hop-limit: func() -> result<u8, error-code>;
+        set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
+
+        /// The kernel buffer space reserved for sends/receives on this socket.
+        ///
+        /// If the provided value is 0, an `invalid-argument` error is returned.
+        /// Any other value will never cause an error, but it might be silently clamped and/or rounded.
+        /// I.e. after setting a value, reading the same setting back may return a different value.
+        ///
+        /// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:     (set) The provided value was 0.
+        receive-buffer-size: func() -> result<u64, error-code>;
+        set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+        send-buffer-size: func() -> result<u64, error-code>;
+        set-send-buffer-size: func(value: u64) -> result<_, error-code>;
+
+        /// Create a `pollable` which will resolve once the socket is ready for I/O.
+        ///
+        /// Note: this function is here for WASI Preview2 only.
+        /// It's planned to be removed when `future` is natively supported in Preview3.
+        subscribe: func() -> pollable;
+    }
+
+    resource incoming-datagram-stream {
+        /// Receive messages on the socket.
+        ///
+        /// This function attempts to receive up to `max-results` datagrams on the socket without blocking.
+        /// The returned list may contain fewer elements than requested, but never more.
+        ///
+        /// This function returns successfully with an empty list when either:
+        /// - `max-results` is 0, or:
+        /// - `max-results` is greater than 0, but no results are immediately available.
+        /// This function never returns `error(would-block)`.
+        ///
+        /// # Typical errors
+        /// - `remote-unreachable`: The remote address is not reachable. (ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+        /// - `connection-refused`: The connection was refused. (ECONNREFUSED)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html>
+        /// - <https://man7.org/linux/man-pages/man2/recv.2.html>
+        /// - <https://man7.org/linux/man-pages/man2/recvmmsg.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
+        /// - <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms741687(v=vs.85)>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
+        receive: func(max-results: u64) -> result<list<incoming-datagram>, error-code>;
+
+        /// Create a `pollable` which will resolve once the stream is ready to receive again.
+        ///
+        /// Note: this function is here for WASI Preview2 only.
+        /// It's planned to be removed when `future` is natively supported in Preview3.
+        subscribe: func() -> pollable;
+    }
+
+    resource outgoing-datagram-stream {
+        /// Check readiness for sending. This function never blocks.
+        ///
+        /// Returns the number of datagrams permitted for the next call to `send`,
+        /// or an error. Calling `send` with more datagrams than this function has
+        /// permitted will trap.
+        ///
+        /// When this function returns ok(0), the `subscribe` pollable will
+        /// become ready when this function will report at least ok(1), or an
+        /// error.
+        /// 
+        /// Never returns `would-block`.
+        check-send: func() -> result<u64, error-code>;
+
+        /// Send messages on the socket.
+        ///
+        /// This function attempts to send all provided `datagrams` on the socket without blocking and
+        /// returns how many messages were actually sent (or queued for sending). This function never
+        /// returns `error(would-block)`. If none of the datagrams were able to be sent, `ok(0)` is returned.
+        ///
+        /// This function semantically behaves the same as iterating the `datagrams` list and sequentially
+        /// sending each individual datagram until either the end of the list has been reached or the first error occurred.
+        /// If at least one datagram has been sent successfully, this function never returns an error.
+        ///
+        /// If the input list is empty, the function returns `ok(0)`.
+        ///
+        /// Each call to `send` must be permitted by a preceding `check-send`. Implementations must trap if
+        /// either `check-send` was not called or `datagrams` contains more items than `check-send` permitted.
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:        The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+        /// - `invalid-argument`:        The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
+        /// - `invalid-argument`:        The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
+        /// - `invalid-argument`:        The socket is in "connected" mode and `remote-address` is `some` value that does not match the address passed to `stream`. (EISCONN)
+        /// - `invalid-argument`:        The socket is not "connected" and no value for `remote-address` was provided. (EDESTADDRREQ)
+        /// - `remote-unreachable`:      The remote address is not reachable. (ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+        /// - `connection-refused`:      The connection was refused. (ECONNREFUSED)
+        /// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html>
+        /// - <https://man7.org/linux/man-pages/man2/send.2.html>
+        /// - <https://man7.org/linux/man-pages/man2/sendmmsg.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
+        send: func(datagrams: list<outgoing-datagram>) -> result<u64, error-code>;
+        
+        /// Create a `pollable` which will resolve once the stream is ready to send again.
+        ///
+        /// Note: this function is here for WASI Preview2 only.
+        /// It's planned to be removed when `future` is natively supported in Preview3.
+        subscribe: func() -> pollable;
+    }
+}

--- a/crates/kotoba-runtime/wit/deps/sockets/world.wit
+++ b/crates/kotoba-runtime/wit/deps/sockets/world.wit
@@ -1,0 +1,11 @@
+package wasi:sockets@0.2.0;
+
+world imports {
+    import instance-network;
+    import network;
+    import udp;
+    import udp-create-socket;
+    import tcp;
+    import tcp-create-socket;
+    import ip-name-lookup;
+}

--- a/crates/kotoba-runtime/wit/world.wit
+++ b/crates/kotoba-runtime/wit/world.wit
@@ -226,11 +226,18 @@ world kotoba-node {
     import chain;
     import evm;
     import http;
-    // wasi:http stays in the world so componentize-py's bundled poll_loop.py (which
-    // unconditionally `import`s outgoing_handler) resolves. build-pywasm passes
-    // `--stub-wasi`, so the wasi:http binding is a packed TRAPPING stub: the import
-    // succeeds, and it only traps if actually called — but guests use kotoba:kais/http
-    // (a real host import) for outbound HTTP, so the trap is never hit (ADR-2605312355).
+    // KNOWN BLOCKER (verified 2026-05-31, ADR-2605312355): host-side `kotoba:kais/http`
+    // is implemented (bind_http) + deployed and its binding generates, BUT no guest can
+    // USE it — any componentize-py guest that imports the `http` interface binding dies
+    // at instantiation with `ImportError: cannot import name 'outgoing_handler' from
+    // wit_world.imports`. Reproduced with wasi:http BOTH present and absent from this
+    // world, and with/without `--stub-wasi` — so the trigger is componentize-py's
+    // internal packing, not this declaration. kqe/llm/evm/chain guests are unaffected
+    // (e.g. the live compose guest), which isolates it to the interface literally named
+    // `http` colliding with componentize-py's built-in wasi:http/poll_loop machinery.
+    // NEXT STEP: rename `kotoba:kais/http` → `kotoba:kais/egress` (host.rs + this file)
+    // and rebuild the kotoba host, then re-test the guest. wasi:http kept below only to
+    // match the currently-deployed host image (it is otherwise vestigial — unused).
     import wasi:http/outgoing-handler@0.2.0;
 
     /// Entry point called by KotobaRuntime for each Invoke ChainEntry.

--- a/crates/kotoba-runtime/wit/world.wit
+++ b/crates/kotoba-runtime/wit/world.wit
@@ -196,6 +196,24 @@ interface chain {
     head-cid: func() -> option<string>;
 }
 
+/// Outbound HTTP via the host's egress client. Exposed as a custom kotoba:kais
+/// interface (not wasi:http) because componentize-py does NOT pack the wasi:http
+/// guest stub — but it DOES pack kotoba:kais/* stubs, so guest Python can call
+/// this (ADR-2605312355). Lets yukkuri guests reach VOICEVOX / ComfyUI / dougaka /
+/// PDS / litellm.
+interface http {
+    /// Blocking HTTP request. method: "GET"|"POST"|... ; headers: request headers;
+    /// body: optional request body; timeout-ms: per-request deadline. Returns
+    /// (status-code, response-body). CALL_FOREIGN-class gas.
+    fetch: func(
+        method:     string,
+        url:        string,
+        headers:    list<tuple<string, string>>,
+        body:       option<list<u8>>,
+        timeout-ms: u32,
+    ) -> result<tuple<u16, list<u8>>, string>;
+}
+
 /// KOTOBA world — imported by every WASM guest node program
 ///
 /// Guest exports `run` to be called by the KotobaRuntime executor.
@@ -207,6 +225,12 @@ world kotoba-node {
     import llm;
     import chain;
     import evm;
+    import http;
+    // wasi:http stays in the world so componentize-py's bundled poll_loop.py (which
+    // unconditionally `import`s outgoing_handler) resolves. build-pywasm passes
+    // `--stub-wasi`, so the wasi:http binding is a packed TRAPPING stub: the import
+    // succeeds, and it only traps if actually called — but guests use kotoba:kais/http
+    // (a real host import) for outbound HTTP, so the trap is never hit (ADR-2605312355).
     import wasi:http/outgoing-handler@0.2.0;
 
     /// Entry point called by KotobaRuntime for each Invoke ChainEntry.

--- a/crates/kotoba-server/Cargo.toml
+++ b/crates/kotoba-server/Cargo.toml
@@ -26,6 +26,7 @@ kotoba-ipfs              = { path = "../kotoba-ipfs" }
 kotoba-vc                = { path = "../kotoba-vc" }
 kotoba-didcomm           = { path = "../kotoba-didcomm" }
 kotoba-crypto.workspace  = true
+zeroize.workspace        = true
 kotoba-signal.workspace  = true
 kotoba-store             = { path = "../kotoba-store" }
 kotoba-kse.workspace     = true

--- a/crates/kotoba-server/src/kg.rs
+++ b/crates/kotoba-server/src/kg.rs
@@ -28,6 +28,7 @@ use axum::{
     Json,
 };
 use kotoba_core::cid::KotobaCid;
+use kotoba_crypto::AgentCrypto;
 use kotoba_datomic::distributed::{
     CommitDatomsRequest, DistributedCommitError, DistributedCommitWriter,
 };
@@ -100,6 +101,75 @@ fn kg_tx_cid(label: &str, parts: &[&str]) -> KotobaCid {
         .map(|duration| duration.as_nanos())
         .unwrap_or_default();
     KotobaCid::from_bytes(format!("kg:{label}:{nanos}:{}", parts.join(":")).as_bytes())
+}
+
+// ── Operator-trusted Pattern B content encryption (ADR-2605240001 §29.6) ──────
+//
+// Sensitive claim values are sealed at rest with the node's opaque vault key
+// (`signal:v1:` envelope, stored as opaque Text — no AVET / SPARQL FILTER on the
+// ciphertext: the documented §29.3 trade-off) and decrypted for CACAO-authorized
+// readers. Operator-trusted (the node holds the key), NOT zero-knowledge.
+//
+// Opt-in via `KOTOBA_ENCRYPT_CLAIM_PREDS` = comma-separated FULL predicate names
+// (e.g. "kg/claim/settlementAmount,kg/claim/ssn"). Unset/empty → no encryption,
+// byte-identical to prior behaviour (zero regression for existing deploys).
+
+/// `signal:v1:` envelope prefix (matches `kotoba_crypto::envelope::SIGNAL_VAL_PREFIX`).
+const SIGNAL_ENVELOPE_PREFIX: &str = "signal:v1:";
+
+/// Parse the sensitive-claim-predicate allowlist from the environment.
+fn sensitive_claim_preds() -> std::collections::HashSet<String> {
+    std::env::var("KOTOBA_ENCRYPT_CLAIM_PREDS")
+        .ok()
+        .map(|s| {
+            s.split(',')
+                .map(|p| p.trim().to_string())
+                .filter(|p| !p.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Encrypt-on-write for a sensitive claim value. Scope = the full predicate
+/// (domain separation). Falls back to plaintext when the predicate is not in
+/// the allowlist, crypto is absent, or sealing fails — never silently drops data.
+async fn maybe_seal_claim_value(
+    crypto: Option<&Arc<dyn AgentCrypto>>,
+    sensitive: &std::collections::HashSet<String>,
+    full_pred: &str,
+    value: &str,
+) -> String {
+    if !sensitive.contains(full_pred) {
+        return value.to_string();
+    }
+    match crypto {
+        Some(c) => c
+            .seal_field(full_pred.as_bytes(), value)
+            .await
+            .unwrap_or_else(|_| value.to_string()),
+        None => value.to_string(),
+    }
+}
+
+/// Decrypt-on-read counterpart. Returns plaintext for a `signal:v1:` Text claim
+/// object (scope = full predicate); otherwise delegates to `obj_to_json`.
+/// Callers MUST have passed `check_read_access` first (operator-trusted: the
+/// node decrypts for any CACAO-authorized reader).
+async fn decrypt_claim_obj(
+    crypto: Option<&Arc<dyn AgentCrypto>>,
+    full_pred: &str,
+    obj: &QuadObject,
+) -> serde_json::Value {
+    if let QuadObject::Text(s) = obj {
+        if s.starts_with(SIGNAL_ENVELOPE_PREFIX) {
+            if let Some(c) = crypto {
+                if let Ok(pt) = c.open_field(full_pred.as_bytes(), s).await {
+                    return serde_json::Value::String(pt);
+                }
+            }
+        }
+    }
+    obj_to_json(obj)
 }
 
 fn kg_datom(subject: &KotobaCid, predicate: impl Into<String>, value: KqeValue) -> KqeDatom {
@@ -485,9 +555,12 @@ pub async fn kg_entity(
             }
             _ if pred.starts_with("kg/claim/") && q.include_claims => {
                 let claim_pred = &pred["kg/claim/".len()..];
+                // Decrypt operator-trusted Pattern B sealed claims for this
+                // CACAO-authorized reader (no-op for plaintext claims).
+                let value = decrypt_claim_obj(state.crypto.as_ref(), pred, &quad.object).await;
                 claims.push(serde_json::json!({
                     "predicate": claim_pred,
-                    "value":     obj_to_json(&quad.object),
+                    "value":     value,
                 }));
             }
             _ if pred.starts_with("kg/relation/")
@@ -1055,8 +1128,13 @@ pub async fn kg_ingest(
         assert_text!("kg/source_id", v);
     }
 
+    let sensitive = sensitive_claim_preds();
     for claim in &req.claims {
-        assert_text!(format!("kg/claim/{}", claim.pred), claim.value);
+        let pred = format!("kg/claim/{}", claim.pred);
+        let value =
+            maybe_seal_claim_value(state.crypto.as_ref(), &sensitive, &pred, &claim.value).await;
+        datoms.push(kg_datom(&subject, pred, KqeValue::Text(value)));
+        count += 1;
     }
 
     for rel in &req.relations {
@@ -1197,6 +1275,7 @@ pub async fn kg_ingest_batch(
     let mut total_quads = 0usize;
     let mut all_datoms = Vec::new();
     let first_subject = KotobaCid::from_bytes(req.entities[0].id.as_bytes());
+    let sensitive = sensitive_claim_preds();
 
     for e in &req.entities {
         let subject = KotobaCid::from_bytes(e.id.as_bytes());
@@ -1246,7 +1325,12 @@ pub async fn kg_ingest_batch(
         }
 
         for claim in &e.claims {
-            assert_text!(format!("kg/claim/{}", claim.pred), claim.value);
+            let pred = format!("kg/claim/{}", claim.pred);
+            let value =
+                maybe_seal_claim_value(state.crypto.as_ref(), &sensitive, &pred, &claim.value)
+                    .await;
+            all_datoms.push(kg_datom(&subject, pred, KqeValue::Text(value)));
+            count += 1;
         }
         for rel in &e.relations {
             let dst_cid = KotobaCid::from_bytes(rel.dst_id.as_bytes());
@@ -2407,6 +2491,71 @@ mod tests {
             domain: Some("kotoba.protocol.write".into()),
         });
         presentation
+    }
+
+    // ── Pattern B operator-trusted claim encryption (ADR §29.6 / §28.5 inc.2) ──
+
+    #[tokio::test]
+    async fn pattern_b_claim_seal_open_roundtrip() {
+        use kotoba_crypto::VaultKeyedCrypto;
+        use zeroize::Zeroizing;
+
+        let crypto: Arc<dyn AgentCrypto> =
+            Arc::new(VaultKeyedCrypto::new(Zeroizing::new([7u8; 32])));
+        let mut sensitive = std::collections::HashSet::new();
+        sensitive.insert("kg/claim/settlementAmount".to_string());
+
+        // Sensitive claim → sealed `signal:v1:` envelope at rest.
+        let sealed = maybe_seal_claim_value(
+            Some(&crypto),
+            &sensitive,
+            "kg/claim/settlementAmount",
+            "JPY 12,300,000",
+        )
+        .await;
+        assert!(
+            sealed.starts_with(SIGNAL_ENVELOPE_PREFIX),
+            "sensitive claim must be sealed at rest, got {sealed}"
+        );
+
+        // Authorized read decrypts back to plaintext.
+        let opened = decrypt_claim_obj(
+            Some(&crypto),
+            "kg/claim/settlementAmount",
+            &QuadObject::Text(sealed.clone()),
+        )
+        .await;
+        assert_eq!(opened, serde_json::json!("JPY 12,300,000"));
+
+        // Non-sensitive predicate → plaintext passthrough (queryable).
+        assert_eq!(
+            maybe_seal_claim_value(Some(&crypto), &sensitive, "kg/claim/labelEn", "Acme").await,
+            "Acme"
+        );
+
+        // Empty allowlist (default) → zero-regression passthrough.
+        assert_eq!(
+            maybe_seal_claim_value(
+                Some(&crypto),
+                &std::collections::HashSet::new(),
+                "kg/claim/settlementAmount",
+                "x",
+            )
+            .await,
+            "x"
+        );
+
+        // Wrong scope (predicate) must NOT decrypt — domain separation; the
+        // envelope is returned unchanged rather than leaking plaintext.
+        assert_eq!(
+            decrypt_claim_obj(
+                Some(&crypto),
+                "kg/claim/other",
+                &QuadObject::Text(sealed.clone()),
+            )
+            .await,
+            serde_json::Value::String(sealed)
+        );
     }
 
     // ── obj_to_json ───────────────────────────────────────────────────────────

--- a/crates/kotoba-server/src/kg.rs
+++ b/crates/kotoba-server/src/kg.rs
@@ -1712,10 +1712,15 @@ pub async fn kg_query(
             // Enterprise SQL dialect → DatalogProgram + PostProcess. Each live KG
             // predicate `P` is registered as a binary table `P(s, o)`, so
             // `SELECT t.s, t.o FROM "<predicate>" t` projects that predicate's
-            // (subject, object) pairs. Supported shape = projection + LIMIT/OFFSET.
-            // NOT supported: WHERE on scalar object literals (the EAV compiler
-            // models objects as CIDs while KG scalars are stored as text), and
-            // ORDER BY (output is opaque content-addressed pairs).
+            // (subject, object) pairs.
+            //
+            // WHERE: equality (`col = 'literal'`, ANDed) filters correctly — the
+            // engine normalises stored text and the literal through the same
+            // cid_of_str hash. Non-equality operators (`<>`, `>`, `<`, `LIKE`, `OR`)
+            // are SILENTLY DROPPED by the EAV compiler (apply_where only emits `=`
+            // atoms) and return the unfiltered superset — use `=` only.
+            // ORDER BY is not applied. Object values come back as content-hash CIDs
+            // (the original scalar text is not yet resolved in the response).
             let dialect = kotoba_kqe::enterprise::dialect_by_name(sql_lang)
                 .ok_or_else(|| (StatusCode::BAD_REQUEST, format!("unknown lang: {sql_lang}")))?;
             let schema = schema_from_predicates(&input_deltas);
@@ -2674,5 +2679,61 @@ mod tests {
             // Both role rows project; the kg/name predicate is excluded.
             assert_eq!(rows, 2, "{lang}: expected 2 role rows, got {rows}");
         }
+    }
+
+    /// Precise WHERE semantics over KG scalar (text) objects. The datalog engine
+    /// normalises both stored `Value::Text` and the WHERE literal through
+    /// `cid_of_str` into the same CID space, so **equality filters correctly**.
+    /// Non-equality operators (`<>`, `>`, `<`, `LIKE`) are silently dropped by the
+    /// compiler (`apply_where` only emits `=` atoms) → they return the unfiltered
+    /// superset. This test pins that contract so the docs stay honest.
+    #[test]
+    fn sql_where_equality_filters_but_inequality_returns_superset() {
+        use kotoba_core::cid::KotobaCid;
+        use kotoba_kqe::datom::{Datom, Value};
+
+        let g = KotobaCid::from_bytes(b"g");
+        let cid = |s: &str| KotobaCid::from_bytes(s.as_bytes());
+        let deltas = vec![
+            Delta::assert_datom(Datom::assert(
+                cid("alice"),
+                "kg/claim/role".into(),
+                Value::Text("admin".into()),
+                g.clone(),
+            )),
+            Delta::assert_datom(Datom::assert(
+                cid("bob"),
+                "kg/claim/role".into(),
+                Value::Text("user".into()),
+                g,
+            )),
+        ];
+        let schema = schema_from_predicates(&deltas);
+        let pg = kotoba_kqe::enterprise::dialect_by_name("postgresql").unwrap();
+        let count = |sql: &str| {
+            let c = pg.compile(sql, &schema, "out").unwrap();
+            c.program
+                .evaluate_delta(&deltas)
+                .iter()
+                .filter(|d| d.attribute() == "out" && d.is_assert())
+                .count()
+        };
+        // Equality filters correctly.
+        assert_eq!(
+            count(r#"SELECT t.s, t.o FROM "kg/claim/role" t WHERE t.o = 'admin'"#),
+            1,
+            "equality on scalar text must filter to the matching row"
+        );
+        // Non-equality is silently dropped → unfiltered superset (documented footgun).
+        assert_eq!(
+            count(r#"SELECT t.s, t.o FROM "kg/claim/role" t WHERE t.o <> 'user'"#),
+            2,
+            "non-equality WHERE is currently a no-op (returns all rows)"
+        );
+        assert_eq!(
+            count(r#"SELECT t.s, t.o FROM "kg/claim/role" t WHERE t.o LIKE 'adm%'"#),
+            2,
+            "LIKE on scalar is currently a no-op (returns all rows)"
+        );
     }
 }

--- a/crates/kotoba-server/src/kg.rs
+++ b/crates/kotoba-server/src/kg.rs
@@ -2429,6 +2429,132 @@ mod tests {
         }));
     }
 
+    /// 実動作検証 (real e2e, ADR §21.8): operator-trusted Pattern B through the
+    /// live `kg_ingest` → QuadStore → `kg_entity` handlers. Proves (1) a sensitive
+    /// claim is SEALED at rest in the real store, (2) a non-sensitive claim stays
+    /// plaintext, (3) an authorized read DECRYPTS the sealed claim back.
+    #[tokio::test]
+    async fn pattern_b_end_to_end_through_kg_handlers() {
+        std::env::set_var("KOTOBA_IPFS", "off");
+        std::env::set_var("KOTOBA_IPNS_REQUIRE_SIGNATURE", "false");
+        // Unique predicate so this process-global env never seals another test's claims.
+        std::env::set_var("KOTOBA_ENCRYPT_CLAIM_PREDS", "kg/claim/secretAmount");
+
+        let state = KotobaState::new(None).unwrap();
+        let state = Arc::new(state.init_crypto().await.unwrap());
+        let graph = kg_graph_cid();
+        // Public so the kg_entity read gate passes without a CACAO.
+        state
+            .graph_registry
+            .write()
+            .await
+            .insert(graph.clone(), ("kg-default".into(), GraphVisibility::Public));
+
+        // ── Ingest one sensitive + one non-sensitive claim via the real handler ──
+        let resp = kg_ingest(
+            State(Arc::clone(&state)),
+            HeaderMap::new(),
+            Json(KgIngestReq {
+                id: "verify-ent-1".into(),
+                qid: None,
+                kind: Some("test".into()),
+                label_ja: None,
+                label_en: Some("PublicLabel".into()),
+                confidence: None,
+                license: None,
+                extractor: None,
+                valid_from: None,
+                valid_to: None,
+                ingested_at: None,
+                source_id: None,
+                label_vec: vec![],
+                claims: vec![
+                    KgClaim {
+                        pred: "secretAmount".into(),
+                        value: "JPY 12,300,000".into(),
+                    },
+                    KgClaim {
+                        pred: "publicNote".into(),
+                        value: "not-secret".into(),
+                    },
+                ],
+                relations: vec![],
+                cacao_b64: None,
+                auth_presentation: Some(signed_capability_presentation(
+                    &state,
+                    &graph,
+                    kotoba_auth::CacaoPayload::OP_DATOM_TRANSACT,
+                    "kg.ingest",
+                )),
+            }),
+        )
+        .await
+        .into_response();
+        assert_eq!(resp.status(), StatusCode::OK, "ingest must succeed");
+
+        // ── At rest: sensitive claim sealed, plaintext absent, public claim plain ──
+        let db = crate::xrpc::current_db_for_graph(&state, &graph)
+            .await
+            .unwrap();
+        let values: Vec<String> = db
+            .datoms()
+            .iter()
+            .map(|d| kotoba_edn::to_string(&d.v))
+            .collect();
+        assert!(
+            values.iter().any(|v| v.contains("signal:v1:")),
+            "sensitive claim must be SEALED at rest; datom values = {values:?}"
+        );
+        assert!(
+            !values.iter().any(|v| v.contains("JPY 12,300,000")),
+            "plaintext of the sealed claim must NOT appear at rest"
+        );
+        assert!(
+            values.iter().any(|v| v.contains("not-secret")),
+            "non-sensitive claim must remain plaintext at rest"
+        );
+
+        // ── Authorized read decrypts the sealed claim back to plaintext ──
+        let resp = kg_entity(
+            State(Arc::clone(&state)),
+            HeaderMap::new(),
+            Query(KgEntityQuery {
+                id: Some("verify-ent-1".into()),
+                qid: None,
+                include_claims: true,
+                include_relations: false,
+                max_relations: 50,
+                cacao_b64: None,
+            }),
+        )
+        .await
+        .unwrap()
+        .into_response();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let claims = body["entity"]["claims"]
+            .as_array()
+            .expect("entity.claims array");
+        let secret = claims
+            .iter()
+            .find(|c| c["predicate"] == "secretAmount")
+            .expect("secretAmount claim present");
+        assert_eq!(
+            secret["value"], "JPY 12,300,000",
+            "authorized read must DECRYPT the sealed claim"
+        );
+        let public = claims
+            .iter()
+            .find(|c| c["predicate"] == "publicNote")
+            .expect("publicNote claim present");
+        assert_eq!(public["value"], "not-secret");
+
+        std::env::remove_var("KOTOBA_ENCRYPT_CLAIM_PREDS");
+    }
+
     fn signed_capability_presentation(
         state: &KotobaState,
         graph: &KotobaCid,

--- a/crates/kotoba-server/src/kg.rs
+++ b/crates/kotoba-server/src/kg.rs
@@ -254,6 +254,19 @@ fn schema_from_predicates(deltas: &[Delta]) -> kotoba_kqe::SchemaMap {
     schema
 }
 
+/// Readable string form of a datom object value, for resolving enterprise-SQL
+/// result objects back from their content-hash CID. Matches the variants that
+/// `kotoba_kqe::object_value_cid` indexes (Text/Integer/Bool/Cid).
+fn readable_value(v: &KqeValue) -> String {
+    match v {
+        KqeValue::Text(s) => s.clone(),
+        KqeValue::Integer(n) => n.to_string(),
+        KqeValue::Bool(b) => b.to_string(),
+        KqeValue::Cid(c) => c.to_multibase(),
+        other => format!("{other:?}"),
+    }
+}
+
 async fn distributed_query_store(
     state: &Arc<KotobaState>,
     graph_cid: &KotobaCid,
@@ -1717,10 +1730,10 @@ pub async fn kg_query(
             // WHERE: equality (`col = 'literal'`, ANDed) filters correctly — the
             // engine normalises stored text and the literal through the same
             // cid_of_str hash. Non-equality operators (`<>`, `>`, `<`, `LIKE`, `OR`)
-            // are SILENTLY DROPPED by the EAV compiler (apply_where only emits `=`
-            // atoms) and return the unfiltered superset — use `=` only.
-            // ORDER BY is not applied. Object values come back as content-hash CIDs
-            // (the original scalar text is not yet resolved in the response).
+            // are now REJECTED fail-loud by apply_where (they cannot be evaluated
+            // in CID space and previously returned an unfiltered superset).
+            // ORDER BY is not applied. Object values in the response are resolved
+            // back to their source scalar text via `value_index` (see below).
             let dialect = kotoba_kqe::enterprise::dialect_by_name(sql_lang)
                 .ok_or_else(|| (StatusCode::BAD_REQUEST, format!("unknown lang: {sql_lang}")))?;
             let schema = schema_from_predicates(&input_deltas);
@@ -1734,6 +1747,23 @@ pub async fn kg_query(
             )
         }
     };
+    // For enterprise SQL, build a reverse index (object CID → source scalar) so
+    // the response carries readable values instead of opaque content hashes. The
+    // datalog engine stores only the hashed object CID in derived facts; we
+    // recover the original from the input deltas. SPARQL/Cypher keep their
+    // existing CID-multibase output shape (empty index → fallback).
+    let value_index: std::collections::HashMap<String, String> = if is_enterprise_sql {
+        input_deltas
+            .iter()
+            .filter_map(|d| {
+                kotoba_kqe::object_value_cid(d.value())
+                    .map(|cid| (cid.to_multibase(), readable_value(d.value())))
+            })
+            .collect()
+    } else {
+        std::collections::HashMap::new()
+    };
+
     let derived = tokio::task::spawn_blocking(move || program.evaluate_delta(&input_deltas))
         .await
         .map_err(|e| {
@@ -1756,13 +1786,15 @@ pub async fn kg_query(
         .skip(sql_offset)
         .take(effective_limit)
         .map(|d| {
-            serde_json::json!({
-                "a": d.entity().to_multibase(),
-                "b": match d.value() {
-                    kotoba_kqe::Value::Cid(c) => c.to_multibase(),
-                    other              => format!("{other:?}"),
-                },
-            })
+            let b = match d.value() {
+                kotoba_kqe::Value::Cid(c) => {
+                    let mb = c.to_multibase();
+                    // SQL path: resolve content-hash CID back to its source scalar.
+                    value_index.get(&mb).cloned().unwrap_or(mb)
+                }
+                other => format!("{other:?}"),
+            };
+            serde_json::json!({ "a": d.entity().to_multibase(), "b": b })
         })
         .collect();
 
@@ -2684,11 +2716,11 @@ mod tests {
     /// Precise WHERE semantics over KG scalar (text) objects. The datalog engine
     /// normalises both stored `Value::Text` and the WHERE literal through
     /// `cid_of_str` into the same CID space, so **equality filters correctly**.
-    /// Non-equality operators (`<>`, `>`, `<`, `LIKE`) are silently dropped by the
-    /// compiler (`apply_where` only emits `=` atoms) → they return the unfiltered
-    /// superset. This test pins that contract so the docs stay honest.
+    /// Non-equality operators (`<>`, `>`, `LIKE`) cannot be evaluated in CID space
+    /// and are now REJECTED fail-loud by `apply_where` (previously silently dropped
+    /// → unfiltered superset). This test pins that contract.
     #[test]
-    fn sql_where_equality_filters_but_inequality_returns_superset() {
+    fn sql_where_equality_works_and_inequality_is_rejected() {
         use kotoba_core::cid::KotobaCid;
         use kotoba_kqe::datom::{Datom, Value};
 
@@ -2710,30 +2742,84 @@ mod tests {
         ];
         let schema = schema_from_predicates(&deltas);
         let pg = kotoba_kqe::enterprise::dialect_by_name("postgresql").unwrap();
-        let count = |sql: &str| {
-            let c = pg.compile(sql, &schema, "out").unwrap();
-            c.program
-                .evaluate_delta(&deltas)
-                .iter()
-                .filter(|d| d.attribute() == "out" && d.is_assert())
-                .count()
-        };
-        // Equality filters correctly.
+
+        // Equality compiles and filters to the matching row.
+        let eq = pg
+            .compile(
+                r#"SELECT t.s, t.o FROM "kg/claim/role" t WHERE t.o = 'admin'"#,
+                &schema,
+                "out",
+            )
+            .unwrap();
+        let n = eq
+            .program
+            .evaluate_delta(&deltas)
+            .iter()
+            .filter(|d| d.attribute() == "out" && d.is_assert())
+            .count();
+        assert_eq!(n, 1, "equality on scalar text must filter to the matching row");
+
+        // Non-equality operators are rejected at compile (fail-loud).
+        for sql in [
+            r#"SELECT t.s, t.o FROM "kg/claim/role" t WHERE t.o <> 'user'"#,
+            r#"SELECT t.s, t.o FROM "kg/claim/role" t WHERE t.o LIKE 'adm%'"#,
+            r#"SELECT t.s, t.o FROM "kg/claim/role" t WHERE t.o > 'm'"#,
+        ] {
+            match pg.compile(sql, &schema, "out") {
+                Ok(_) => panic!("non-equality WHERE must be rejected: {sql}"),
+                Err(e) => assert!(
+                    e.to_string().contains("unsupported WHERE"),
+                    "unexpected error for {sql}: {e}"
+                ),
+            }
+        }
+    }
+
+    /// (a) Object value resolution: the handler reverse-indexes object CIDs back
+    /// to source scalar text via `object_value_cid` + `readable_value` (the exact
+    /// two lines kg_query uses), so `SELECT t.s, t.o` returns "admin", not a hash.
+    #[test]
+    fn sql_object_values_resolve_to_readable_text() {
+        use kotoba_core::cid::KotobaCid;
+        use kotoba_kqe::datom::{Datom, Value};
+
+        let g = KotobaCid::from_bytes(b"g");
+        let cid = |s: &str| KotobaCid::from_bytes(s.as_bytes());
+        let deltas = vec![
+            Delta::assert_datom(Datom::assert(
+                cid("alice"),
+                "kg/claim/role".into(),
+                Value::Text("admin".into()),
+                g.clone(),
+            )),
+            Delta::assert_datom(Datom::assert(
+                cid("bob"),
+                "kg/claim/age".into(),
+                Value::Integer(42),
+                g,
+            )),
+        ];
+        let index: std::collections::HashMap<String, String> = deltas
+            .iter()
+            .filter_map(|d| {
+                kotoba_kqe::object_value_cid(d.value())
+                    .map(|c| (c.to_multibase(), readable_value(d.value())))
+            })
+            .collect();
+
+        // A derived fact carries the object as Value::Cid(object_value_cid(value)).
+        let admin_cid =
+            kotoba_kqe::object_value_cid(&Value::Text("admin".into())).unwrap();
         assert_eq!(
-            count(r#"SELECT t.s, t.o FROM "kg/claim/role" t WHERE t.o = 'admin'"#),
-            1,
-            "equality on scalar text must filter to the matching row"
+            index.get(&admin_cid.to_multibase()).map(String::as_str),
+            Some("admin"),
+            "text object CID must resolve back to readable text"
         );
-        // Non-equality is silently dropped → unfiltered superset (documented footgun).
+        let age_cid = kotoba_kqe::object_value_cid(&Value::Integer(42)).unwrap();
         assert_eq!(
-            count(r#"SELECT t.s, t.o FROM "kg/claim/role" t WHERE t.o <> 'user'"#),
-            2,
-            "non-equality WHERE is currently a no-op (returns all rows)"
-        );
-        assert_eq!(
-            count(r#"SELECT t.s, t.o FROM "kg/claim/role" t WHERE t.o LIKE 'adm%'"#),
-            2,
-            "LIKE on scalar is currently a no-op (returns all rows)"
+            index.get(&age_cid.to_multibase()).map(String::as_str),
+            Some("42"),
+            "integer object CID must resolve back to its decimal string"
         );
     }
 }

--- a/crates/kotoba-server/src/kg.rs
+++ b/crates/kotoba-server/src/kg.rs
@@ -231,6 +231,29 @@ async fn current_graph_deltas(
         .collect())
 }
 
+/// Build an EAV `SchemaMap` from the predicates present in `deltas`.
+///
+/// Each distinct predicate `P` becomes a binary table `P(s, o)` whose value
+/// column `o` maps straight to predicate `P` (entity column `s` = subject), so
+/// enterprise SQL can address KG predicates directly: `SELECT t.s, t.o FROM "P" t`.
+/// Without this, the compiler's binary fallback would read predicate `P/o`, which
+/// no KG datom uses — the endpoint would be reachable but always return 0 rows.
+fn schema_from_predicates(deltas: &[Delta]) -> kotoba_kqe::SchemaMap {
+    use kotoba_kqe::{AttrDef, SchemaMap, TableSchema};
+    let mut schema = SchemaMap::new();
+    let mut seen = std::collections::HashSet::new();
+    for d in deltas {
+        let p = d.attribute();
+        if seen.insert(p.to_string()) {
+            schema.add(
+                p,
+                TableSchema::new("s").with_attr(AttrDef::scalar("o", p).with_predicate(p)),
+            );
+        }
+    }
+    schema
+}
+
 async fn distributed_query_store(
     state: &Arc<KotobaState>,
     graph_cid: &KotobaCid,
@@ -1585,7 +1608,8 @@ fn cosine(a: &[f32], b: &[f32]) -> f32 {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KgQueryReq {
-    /// "sparql" or "cypher"
+    /// Query language: "sparql", "cypher", or an enterprise SQL dialect
+    /// (oracle/tsql/hana/db2/teradata/snowflake/bigquery/presto/mdx/hiveql/mysql/postgresql).
     pub lang: String,
     /// Query string
     pub query: String,
@@ -1596,11 +1620,14 @@ pub struct KgQueryReq {
 }
 
 /// POST /xrpc/ai.gftd.apps.kotobase.kg.query
-/// Execute a SPARQL SELECT or Cypher MATCH/RETURN against the Datom projection.
+/// Execute a SPARQL SELECT, Cypher MATCH/RETURN, or enterprise SQL SELECT
+/// against the Datom projection. All compilers lower to a `DatalogProgram`.
 ///
-/// Both compilers enforce binary-relation arity (exactly 2 RETURN variables).
+/// All compilers enforce binary-relation arity (exactly 2 projected columns).
 /// Results are returned as `[{ "a": "<cid>", "b": "<cid>" }]` pairs where
-/// the variable names come from the compiled output_relation.
+/// the variable names come from the compiled output_relation. For enterprise
+/// SQL dialects, `LIMIT`/`OFFSET` are honoured (`ORDER BY` is not — output is
+/// opaque content-addressed CID pairs).
 const MAX_KG_QUERY_PROG_LEN: usize = 65_536; // 64 KiB — SPARQL/Cypher compile DoS guard
 
 pub async fn kg_query(
@@ -1629,10 +1656,13 @@ pub async fn kg_query(
             format!("query must be 1–{MAX_KG_QUERY_PROG_LEN} bytes"),
         ));
     }
-    if !matches!(req.lang.as_str(), "sparql" | "cypher") {
+    let is_enterprise_sql = kotoba_kqe::enterprise::dialect_by_name(&req.lang).is_some();
+    if !matches!(req.lang.as_str(), "sparql" | "cypher") && !is_enterprise_sql {
         return Err((
             StatusCode::BAD_REQUEST,
-            "lang must be 'sparql' or 'cypher'".to_string(),
+            "lang must be 'sparql', 'cypher', or an enterprise SQL dialect \
+             (oracle/tsql/hana/db2/teradata/snowflake/bigquery/presto/mdx/hiveql/mysql/postgresql)"
+                .to_string(),
         ));
     }
     let result_limit = req
@@ -1654,27 +1684,51 @@ pub async fn kg_query(
     )
     .map_err(AccessDenied::into_response)?;
 
-    // Compile query to DatalogProgram
-    let (program, output_relation) = match req.lang.as_str() {
+    // Load the current graph projection first — enterprise SQL builds its EAV
+    // schema from the live predicate set.
+    let input_deltas = current_graph_deltas(&state, &graph_cid).await?;
+
+    // Compile query to DatalogProgram (+ PostProcess for SQL LIMIT/OFFSET).
+    let (program, output_relation, post_process) = match req.lang.as_str() {
         "sparql" => {
             let compiled = SparqlCompiler::compile(&req.query, "kg_query_result")
                 .map_err(|e| (StatusCode::BAD_REQUEST, format!("SPARQL compile: {e}")))?;
-            (compiled.program, compiled.output_relation)
+            (
+                compiled.program,
+                compiled.output_relation,
+                kotoba_kqe::PostProcess::default(),
+            )
         }
         "cypher" => {
             let compiled = CypherCompiler::compile(&req.query, "kg_query_result")
                 .map_err(|e| (StatusCode::BAD_REQUEST, format!("Cypher compile: {e}")))?;
-            (compiled.program, compiled.output_relation)
+            (
+                compiled.program,
+                compiled.output_relation,
+                kotoba_kqe::PostProcess::default(),
+            )
         }
-        other => {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                format!("unknown lang: {other}; use sparql or cypher"),
-            ))
+        sql_lang => {
+            // Enterprise SQL dialect → DatalogProgram + PostProcess. Each live KG
+            // predicate `P` is registered as a binary table `P(s, o)`, so
+            // `SELECT t.s, t.o FROM "<predicate>" t` projects that predicate's
+            // (subject, object) pairs. Supported shape = projection + LIMIT/OFFSET.
+            // NOT supported: WHERE on scalar object literals (the EAV compiler
+            // models objects as CIDs while KG scalars are stored as text), and
+            // ORDER BY (output is opaque content-addressed pairs).
+            let dialect = kotoba_kqe::enterprise::dialect_by_name(sql_lang)
+                .ok_or_else(|| (StatusCode::BAD_REQUEST, format!("unknown lang: {sql_lang}")))?;
+            let schema = schema_from_predicates(&input_deltas);
+            let compiled = dialect
+                .compile(&req.query, &schema, "kg_query_result")
+                .map_err(|e| (StatusCode::BAD_REQUEST, format!("{sql_lang} compile: {e}")))?;
+            (
+                compiled.program,
+                compiled.output_relation,
+                compiled.post_process,
+            )
         }
     };
-
-    let input_deltas = current_graph_deltas(&state, &graph_cid).await?;
     let derived = tokio::task::spawn_blocking(move || program.evaluate_delta(&input_deltas))
         .await
         .map_err(|e| {
@@ -1684,11 +1738,18 @@ pub async fn kg_query(
             )
         })?;
 
-    // Collect derived facts for the output_relation, bounded by result_limit.
+    // Collect derived facts for the output_relation. SQL OFFSET skips leading
+    // rows; the effective cap is the tighter of SQL LIMIT and the request limit.
+    let sql_offset = post_process.offset.unwrap_or(0);
+    let effective_limit = post_process
+        .limit
+        .map(|l| l.min(result_limit))
+        .unwrap_or(result_limit);
     let results: Vec<serde_json::Value> = derived
         .iter()
         .filter(|d| d.attribute() == output_relation && d.is_assert())
-        .take(result_limit)
+        .skip(sql_offset)
+        .take(effective_limit)
         .map(|d| {
             serde_json::json!({
                 "a": d.entity().to_multibase(),
@@ -2482,5 +2543,136 @@ mod tests {
         // Caller-supplied small value passes through unchanged.
         let caller_small = Some(42usize).unwrap_or(MAX_KG_LIMIT).min(10_000);
         assert_eq!(caller_small, 42);
+    }
+
+    // ── kg.query enterprise SQL dialect wiring ────────────────────────────────
+
+    #[tokio::test]
+    async fn kg_query_rejects_unknown_lang_naming_dialects() {
+        std::env::set_var("KOTOBA_IPFS", "off");
+        let state = Arc::new(KotobaState::new(None).unwrap());
+
+        // lang validation runs before the read-access gate, so no graph/auth setup.
+        let result = kg_query(
+            State(Arc::clone(&state)),
+            HeaderMap::new(),
+            Json(KgQueryReq {
+                lang: "sqlite".into(),
+                query: "SELECT t.s, t.o FROM role t".into(),
+                cacao_b64: None,
+                limit: None,
+            }),
+        )
+        .await;
+        match result {
+            Ok(_) => panic!("unknown lang must be rejected"),
+            Err((status, msg)) => {
+                assert_eq!(status, StatusCode::BAD_REQUEST);
+                assert!(
+                    msg.contains("mysql") && msg.contains("postgresql"),
+                    "error should name the enterprise dialects, got: {msg}"
+                );
+            }
+        }
+    }
+
+    /// End-to-end reachability of the enterprise SQL path: validation → public
+    /// read-access → dialect resolve → SQL compile → datalog eval → JSON.
+    /// Data-bearing correctness of each dialect is covered by kotoba-kqe tests;
+    /// here the empty kg graph yields count=0 but proves the pipeline runs.
+    async fn assert_dialect_reachable(lang: &str) {
+        std::env::set_var("KOTOBA_IPFS", "off");
+        let state = Arc::new(KotobaState::new(None).unwrap());
+        // Register the fixed kg graph as Public in this test's own state so the
+        // read-access gate passes without CACAO (no global env mutation).
+        state.graph_registry.write().await.insert(
+            kg_graph_cid(),
+            ("kg".into(), GraphVisibility::Public),
+        );
+
+        let resp = kg_query(
+            State(Arc::clone(&state)),
+            HeaderMap::new(),
+            Json(KgQueryReq {
+                lang: lang.into(),
+                // Binary EAV fallback: table `role` → predicate `role/o`, cols s/o.
+                query: "SELECT t.s, t.o FROM role t".into(),
+                cacao_b64: None,
+                limit: None,
+            }),
+        )
+        .await
+        .unwrap_or_else(|e| panic!("{lang} query should succeed: {e:?}"))
+        .into_response();
+        assert_eq!(resp.status(), StatusCode::OK, "{lang} → 200");
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["ok"], true);
+        assert_eq!(body["lang"], lang);
+        assert_eq!(body["count"], 0, "empty kg graph → 0 rows");
+    }
+
+    #[tokio::test]
+    async fn kg_query_accepts_postgresql_dialect_end_to_end() {
+        assert_dialect_reachable("postgresql").await;
+    }
+
+    #[tokio::test]
+    async fn kg_query_accepts_mysql_dialect_end_to_end() {
+        assert_dialect_reachable("mysql").await;
+    }
+
+    /// Decisive data round-trip: schema_from_predicates maps a real KG predicate
+    /// so `SELECT t.s, t.o FROM "<predicate>" t` actually projects its rows
+    /// (proving the path is not inert). Uses the kqe compiler directly with the
+    /// exact SchemaMap the handler builds.
+    #[test]
+    fn schema_from_predicates_projects_real_kg_predicate_rows() {
+        use kotoba_core::cid::KotobaCid;
+        use kotoba_kqe::datom::{Datom, Value};
+
+        let g = KotobaCid::from_bytes(b"g");
+        let cid = |s: &str| KotobaCid::from_bytes(s.as_bytes());
+        let deltas = vec![
+            Delta::assert_datom(Datom::assert(
+                cid("alice"),
+                "kg/claim/role".into(),
+                Value::Text("admin".into()),
+                g.clone(),
+            )),
+            Delta::assert_datom(Datom::assert(
+                cid("bob"),
+                "kg/claim/role".into(),
+                Value::Text("user".into()),
+                g.clone(),
+            )),
+            Delta::assert_datom(Datom::assert(
+                cid("alice"),
+                "kg/name".into(),
+                Value::Text("Alice".into()),
+                g,
+            )),
+        ];
+
+        let schema = schema_from_predicates(&deltas);
+        for lang in ["postgresql", "mysql"] {
+            let dialect = kotoba_kqe::enterprise::dialect_by_name(lang).unwrap();
+            let compiled = dialect
+                .compile(
+                    r#"SELECT t.s, t.o FROM "kg/claim/role" t"#,
+                    &schema,
+                    "kg_query_result",
+                )
+                .unwrap_or_else(|e| panic!("{lang} compile failed: {e}"));
+            let derived = compiled.program.evaluate_delta(&deltas);
+            let rows = derived
+                .iter()
+                .filter(|d| d.attribute() == "kg_query_result" && d.is_assert())
+                .count();
+            // Both role rows project; the kg/name predicate is excluded.
+            assert_eq!(rows, 2, "{lang}: expected 2 role rows, got {rows}");
+        }
     }
 }

--- a/crates/kotoba-server/src/kotobase_xrpc.rs
+++ b/crates/kotoba-server/src/kotobase_xrpc.rs
@@ -17,6 +17,8 @@ pub const NSID_PIN_CREATE: &str = "ai.gftd.apps.kotobase.pinCreate";
 pub const NSID_PIN_LIST: &str = "ai.gftd.apps.kotobase.pinList";
 pub const NSID_PIN_DELETE: &str = "ai.gftd.apps.kotobase.pinDelete";
 pub const NSID_USAGE_GET: &str = "ai.gftd.apps.kotobase.usageGet";
+/// Revoke a PRE re-key grant + propagate over GossipSub (ADR §23.7 / §28.5).
+pub const NSID_PRE_REVOKE: &str = "ai.gftd.apps.kotobase.preRevoke";
 
 use crate::server::KotobaState;
 use axum::{
@@ -519,7 +521,51 @@ pub struct UsageGetResp {
     pub remaining_bytes: i64,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct PreRevokeReq {
+    /// DID that owns the grant being revoked. The caller's JWT `sub` must match
+    /// this (or `operator_did`) — only the owner/operator may revoke.
+    pub tenant_did: String,
+    /// DID whose re-key access is being revoked.
+    pub accessor_did: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PreRevokeResp {
+    pub ok: bool,
+    pub tenant_did: String,
+    pub accessor_did: String,
+}
+
 // ── Handlers ──────────────────────────────────────────────────────────────
+
+/// POST /xrpc/ai.gftd.apps.kotobase.preRevoke
+///
+/// Revoke a PRE re-key grant (owner → accessor) and propagate the revocation
+/// to peers over GossipSub (ADR §23.7 / §28.5 emit path). Owner-authenticated.
+pub async fn handle_pre_revoke(
+    State(state): State<Arc<KotobaState>>,
+    headers: HeaderMap,
+    Json(req): Json<PreRevokeReq>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    validate_did(&req.tenant_did)?;
+    crate::graph_auth::validate_did(&req.accessor_did, "accessor_did", MAX_DID_LEN)?;
+    require_did_ownership(&headers, &req.tenant_did, &state.operator_did)?;
+
+    state
+        .revoke_pre_key_grant(&req.tenant_did, &req.accessor_did)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("revoke failed: {e}")))?;
+
+    Ok((
+        StatusCode::OK,
+        Json(PreRevokeResp {
+            ok: true,
+            tenant_did: req.tenant_did,
+            accessor_did: req.accessor_did,
+        }),
+    ))
+}
 
 pub async fn handle_account_create(
     State(state): State<Arc<KotobaState>>,
@@ -1021,11 +1067,58 @@ pub const ALL_NSIDS: &[&str] = &[
     NSID_PIN_LIST,
     NSID_PIN_DELETE,
     NSID_USAGE_GET,
+    NSID_PRE_REVOKE,
 ];
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── preRevoke endpoint (ADR §23.7 / §28.5) ──────────────────────────────────
+
+    #[tokio::test]
+    async fn pre_revoke_owner_authenticated_revokes_grant() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        std::env::set_var("KOTOBA_IPFS", "off");
+
+        let state = KotobaState::new(None).unwrap();
+        let state = Arc::new(state.init_pre_key_registry().await);
+        let owner = state.operator_did.clone(); // caller owns the grant
+        let accessor = "did:key:zAccessorRevoke".to_string();
+
+        // Seed a grant in the live registry.
+        let reg = state.pre_key_registry.clone().expect("registry attached");
+        reg.grant(&owner, &accessor, &[3u8; 32], &[7u8; 32])
+            .await
+            .unwrap();
+        assert_eq!(reg.list_accessors(&owner).await, vec![accessor.clone()]);
+
+        let req = || PreRevokeReq {
+            tenant_did: owner.clone(),
+            accessor_did: accessor.clone(),
+        };
+
+        // No Bearer token → 401, grant untouched.
+        let unauth = handle_pre_revoke(State(Arc::clone(&state)), HeaderMap::new(), Json(req())).await;
+        assert!(unauth.is_err(), "missing auth must be rejected");
+        assert_eq!(reg.list_accessors(&owner).await.len(), 1);
+
+        // Owner-authenticated JWT (sub == operator) → revoke succeeds.
+        let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"HS256","typ":"JWT"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"sub":"{owner}","exp":9999999999}}"#));
+        let jwt = format!("{header}.{payload}.sig");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            format!("Bearer {jwt}").parse().unwrap(),
+        );
+        let ok = handle_pre_revoke(State(Arc::clone(&state)), headers, Json(req())).await;
+        assert!(ok.is_ok(), "owner-authenticated revoke must succeed");
+        assert!(
+            reg.list_accessors(&owner).await.is_empty(),
+            "grant must be revoked after authenticated preRevoke"
+        );
+    }
 
     // ── quota_for_tier ────────────────────────────────────────────────────────
 

--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -487,6 +487,10 @@ pub fn build_router(state: Arc<KotobaState>) -> Router {
             &format!("/xrpc/{}", kotobase_xrpc::NSID_USAGE_GET),
             post(kotobase_xrpc::handle_usage_get),
         )
+        .route(
+            &format!("/xrpc/{}", kotobase_xrpc::NSID_PRE_REVOKE),
+            post(kotobase_xrpc::handle_pre_revoke),
+        )
         // ── Common Crawl vector search / RAG ───────────────────────────────
         .route(
             &format!("/xrpc/{}", cc_xrpc::NSID_CC_SEARCH),

--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -285,6 +285,10 @@ pub fn build_router(state: Arc<KotobaState>) -> Router {
             post(xrpc::datomic_transact),
         )
         .route(
+            "/xrpc/ai.gftd.apps.kotoba.node.register",
+            post(xrpc::node_register),
+        )
+        .route(
             &format!("/xrpc/{}", xrpc::NSID_DATOMIC_DATOMS),
             post(xrpc::datomic_datoms),
         )
@@ -629,6 +633,9 @@ pub async fn run() -> anyhow::Result<()> {
 
     let state = server::KotobaState::new(inference_engine)?;
     let state = state.init_crypto().await?;
+    // Make the operator-trusted PRE substrate live (persistent grants).
+    // Additive — does not change the quad read/write path (ADR-2605240001 §28.5).
+    let state = state.init_pre_key_registry().await;
 
     // IPFS daemon liveness probe — non-fatal but logs a clear warning so the
     // operator notices when Kubo isn't reachable.  Skipped when KOTOBA_IPFS=off.

--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -738,6 +738,7 @@ pub async fn run() -> anyhow::Result<()> {
                     pregel_outbound_rx,
                     block_store_arc,
                     quad_store_arc,
+                    state.pre_key_registry.clone(),
                     relay,
                 ));
 

--- a/crates/kotoba-server/src/net_actor.rs
+++ b/crates/kotoba-server/src/net_actor.rs
@@ -21,6 +21,9 @@ const MAX_DELTA_COMMITS_TOTAL_BYTES: usize = 8 * 1024 * 1024;
 
 /// GossipSub topic carrying the full KSE Journal firehose (E: relay role).
 const FIREHOSE_TOPIC: &str = "firehose";
+/// GossipSub topic carrying PRE re-key revocation warrants (ADR §23.7 wire).
+/// Payload = serialized `RekeyRevocationRecord` (applied without a block fetch).
+const REKEY_REVOKE_TOPIC: &str = "rekey/revoke";
 /// Bound on the echo-guard set that stops a relay re-gossiping what it received.
 const FIREHOSE_SEEN_CAP: usize = 8192;
 
@@ -87,10 +90,12 @@ pub async fn run(
     mut pregel_out_rx: tokio::sync::mpsc::Receiver<DistributedMessage>,
     block_store: Arc<dyn BlockStore + Send + Sync>,
     quad_store: Arc<QuadStore>,
+    pre_key_registry: Option<Arc<kotoba_kse::PreKeyRegistry>>,
     relay: bool,
 ) {
     swarm.subscribe("quad/assert").ok();
     swarm.subscribe("quad/retract").ok();
+    swarm.subscribe(REKEY_REVOKE_TOPIC).ok();
     swarm.subscribe_pregel().ok();
 
     // Full gossip topic string as published by KotobaSwarm (has "kotoba/" prefix)
@@ -254,6 +259,14 @@ pub async fn run(
                                             .await;
                                     }
                                     Err(e) => tracing::warn!(err = %e, "firehose: bad JournalEntry envelope — skipped"),
+                                }
+                            } else if kse_name == REKEY_REVOKE_TOPIC {
+                                // PRE re-key revocation warrant (§23.7 wire):
+                                // apply the gossiped record bytes directly — no
+                                // BlockStore fetch needed. No-op if we hold no
+                                // registry or the pair was never granted here.
+                                if let Some(reg) = &pre_key_registry {
+                                    reg.apply_revocation_warrant_bytes(&data).await;
                                 }
                             } else {
                                 let maybe_quad_op = if kse_name == "quad/assert" {

--- a/crates/kotoba-server/src/pre_proxy.rs
+++ b/crates/kotoba-server/src/pre_proxy.rs
@@ -311,4 +311,118 @@ mod tests {
             "expected DidResolve, got {err:?}"
         );
     }
+
+    /// End-to-end operator-trusted PRE round trip (ADR-2605240001 §28.4(a) / §29.9).
+    ///
+    /// Proves the wired pieces compose into a working content-encryption path:
+    ///   1. the node derives `owner_enc_key` from its own opaque vault key
+    ///      (`AgentCrypto::derive_wrapping_key`) — only the node can do this;
+    ///   2. a `data_key` encrypts a real plaintext blob (AES-256-GCM);
+    ///   3. the owner grants the `data_key` to an accessor via the registry;
+    ///   4. the proxy re-seals it to the accessor after CACAO verification;
+    ///   5. the accessor HPKE-opens it and decrypts the blob to plaintext.
+    ///
+    /// This is operator-trusted (the node CAN derive `owner_enc_key`), not
+    /// zero-knowledge — exactly the §28.4(a) Consensys/Infura-layer model.
+    #[tokio::test]
+    async fn operator_trusted_pre_roundtrip_end_to_end() {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        use ed25519_dalek::{Signer, SigningKey};
+        use kotoba_auth::ed25519_pubkey_to_did_key;
+        use kotoba_auth::{Cacao, CacaoHeader, CacaoPayload, CacaoSig, DelegationChain};
+        use kotoba_crypto::aead::{open, seal};
+        use kotoba_crypto::hpke::hpke_open;
+        use kotoba_crypto::{AgentCrypto, VaultKeyedCrypto};
+        use x25519_dalek::StaticSecret;
+        use zeroize::Zeroizing;
+
+        let owner_did = "did:key:zOwnerE2E";
+
+        // ── 1. Node derives owner_enc_key from its opaque vault key ──────────
+        let node_crypto = VaultKeyedCrypto::new(Zeroizing::new([0x5au8; 32]));
+        let owner_enc_key = node_crypto.derive_wrapping_key(owner_did.as_bytes());
+
+        // ── 2. A data_key encrypts a confidential blob (AES-256-GCM) ─────────
+        let data_key = [0x11u8; 32];
+        let plaintext = b"confidential lawfirm case note: settlement amount JPY 12,300,000";
+        let blob = seal(&data_key, plaintext).expect("blob seal");
+
+        // ── Accessor key material (Ed25519 for CACAO, X25519 for HPKE) ───────
+        let ed_sk = SigningKey::from_bytes(&[7u8; 32]);
+        let accessor_did = ed25519_pubkey_to_did_key(ed_sk.verifying_key().as_bytes());
+        let x25519_sk = StaticSecret::from([9u8; 32]);
+        let x25519_pk = x25519_dalek::PublicKey::from(&x25519_sk);
+
+        // ── 3. Owner grants the data_key to the accessor ────────────────────
+        let store = Arc::new(MemoryBlockStore::new());
+        let registry = Arc::new(PreKeyRegistry::new(store));
+        registry
+            .grant(owner_did, &accessor_did, &data_key, &owner_enc_key)
+            .await
+            .expect("grant");
+
+        // CACAO signed by the accessor (empty resources → all caps/graphs).
+        let mut cacao = Cacao {
+            h: CacaoHeader {
+                t: "caip122".into(),
+            },
+            p: CacaoPayload {
+                iss: accessor_did.clone(),
+                aud: "kotoba://test".into(),
+                issued_at: "2026-05-31T00:00:00Z".into(),
+                expiry: None,
+                nonce: "e2e-roundtrip-nonce".into(),
+                domain: "kotoba.test".into(),
+                statement: None,
+                version: "1".into(),
+                resources: vec![],
+            },
+            s: CacaoSig {
+                t: "EdDSA".into(),
+                s: String::new(),
+            },
+        };
+        let sig = ed_sk.sign(cacao.siwe_message().as_bytes());
+        cacao.s.s = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+        let chain = DelegationChain::new(cacao);
+
+        // ── 4. Proxy re-seals the data_key to the accessor (CACAO-verified) ──
+        let resolver = Arc::new(InMemoryDidResolver::new());
+        resolver.insert(
+            &accessor_did,
+            make_doc_with_x25519(&accessor_did, *x25519_pk.as_bytes()),
+        );
+        let proxy = PreProxy::new(registry, resolver);
+        let sealed = proxy
+            .reencrypt_for(
+                &chain,
+                owner_did,
+                &accessor_did,
+                &owner_enc_key,
+                x25519_pk.as_bytes(),
+            )
+            .await
+            .expect("reencrypt_for");
+
+        // ── 5. Accessor HPKE-opens the data_key and decrypts the blob ───────
+        let recovered_key = hpke_open(&x25519_sk, &sealed).expect("hpke_open");
+        assert_eq!(recovered_key.as_slice(), &data_key, "data_key must survive");
+
+        let mut k = [0u8; 32];
+        k.copy_from_slice(&recovered_key);
+        let recovered_pt = open(&k, &blob).expect("blob open");
+        assert_eq!(
+            recovered_pt.as_slice(),
+            plaintext,
+            "accessor must recover the confidential plaintext"
+        );
+
+        // ── Negative: a different node cannot derive the same owner_enc_key ──
+        let other_node = VaultKeyedCrypto::new(Zeroizing::new([0x99u8; 32]));
+        assert_ne!(
+            other_node.derive_wrapping_key(owner_did.as_bytes()).as_ref(),
+            owner_enc_key.as_ref(),
+            "owner_enc_key must be bound to the originating node's vault key"
+        );
+    }
 }

--- a/crates/kotoba-server/src/server.rs
+++ b/crates/kotoba-server/src/server.rs
@@ -789,6 +789,29 @@ impl KotobaState {
             .derive_wrapping_key(owner_did.as_bytes()))
     }
 
+    /// Revoke a PRE re-key grant locally AND propagate the revocation to peers
+    /// over GossipSub (`rekey/revoke` topic) — the §23.7 emit path. The
+    /// gossiped payload is the serialized `RekeyRevocationRecord`, which peers
+    /// apply via `apply_revocation_warrant_bytes` (no BlockStore fetch).
+    /// No-op when no registry is attached; gossip is best-effort (try_send).
+    pub async fn revoke_pre_key_grant(
+        &self,
+        owner_did: &str,
+        accessor_did: &str,
+    ) -> anyhow::Result<()> {
+        let Some(reg) = &self.pre_key_registry else {
+            return Ok(());
+        };
+        let (_evidence_cid, bytes) = reg
+            .revoke_emit_warrant_bytes(owner_did, accessor_did)
+            .await?;
+        // Channel carries raw KSE names (no "kotoba/" prefix); publish adds it.
+        if let Some(tx) = &self.gossip_tx {
+            tx.try_send(("rekey/revoke".to_string(), bytes)).ok();
+        }
+        Ok(())
+    }
+
     /// Look up the visibility of a named graph by its CID.
     ///
     /// Default visibility for unknown graphs is controlled by

--- a/crates/kotoba-server/src/server.rs
+++ b/crates/kotoba-server/src/server.rs
@@ -755,6 +755,40 @@ impl KotobaState {
         self
     }
 
+    /// Build and attach a persistent PRE key registry from this node's own
+    /// block store + shelf (operator-trusted content-encryption grants,
+    /// ADR-2605240001 §28.5 step 1). Grants survive restarts via the shelf.
+    ///
+    /// Additive: this only makes the PRE substrate live (grant/revoke/lookup).
+    /// It does NOT change the existing quad read/write path — encrypt-on-write
+    /// and decrypt-on-read are a separate increment (§28.5 steps 2–3).
+    pub async fn init_pre_key_registry(mut self) -> Self {
+        let registry = Arc::new(
+            PreKeyRegistry::with_shelf(Arc::clone(&self.block_store), Arc::clone(&self.shelf))
+                .await,
+        );
+        self.pre_key_registry = Some(registry);
+        tracing::info!("PRE key registry attached (persistent, shelf-backed)");
+        self
+    }
+
+    /// Derive this node's per-owner wrapping key (`owner_enc_key`) for the
+    /// operator-trusted PRE layer (ADR-2605240001 §28.4(a) / §28.5 step 4).
+    ///
+    /// Bound to the node's opaque vault key via HKDF, so only this node can
+    /// reconstruct it. Intentionally not zero-knowledge from the operator —
+    /// that property belongs to the kotoba/etzhayyim protocol layer, not this
+    /// vendor-hosted (Infura-equivalent) service. Errors if crypto is not yet
+    /// initialised (`init_crypto()` must run first).
+    pub fn pre_wrapping_key(
+        &self,
+        owner_did: &str,
+    ) -> anyhow::Result<zeroize::Zeroizing<[u8; 32]>> {
+        Ok(self
+            .crypto_required()?
+            .derive_wrapping_key(owner_did.as_bytes()))
+    }
+
     /// Look up the visibility of a named graph by its CID.
     ///
     /// Default visibility for unknown graphs is controlled by
@@ -997,6 +1031,41 @@ impl KotobaState {
             ipns_name = %ipns_name,
             "node registered in distributed kotoba/network/nodes"
         );
+    }
+
+    /// Register an external app's wasm node (app name → program CID) so the
+    /// generic XRPC→wasm ingress (`generic_invoke`) can resolve and dispatch it.
+    ///
+    /// Writes `node/did = app` + `node/endpoint = program_cid` into the LOCAL
+    /// quad_store projection of `kotoba/network/nodes` via the same
+    /// `apply_journaled_datom` path the server self-registration uses (and that
+    /// `generic_invoke` reads), so a freshly-registered app node is immediately
+    /// resolvable — unlike a raw `datomic.transact`, whose datoms reach the
+    /// distributed head / datomic view but not this arrangement (ADR-2605312355).
+    pub async fn register_external_node(&self, app: &str, program_cid: &str) {
+        let graph_cid = KotobaCid::from_bytes(b"kotoba/network/nodes");
+        let subject_cid = KotobaCid::from_bytes(format!("node:{app}").as_bytes());
+        let datoms = vec![
+            KqeDatom::assert(
+                subject_cid.clone(),
+                "node/did".to_string(),
+                KqeValue::Text(app.to_string()),
+                graph_cid.clone(),
+            ),
+            KqeDatom::assert(
+                subject_cid.clone(),
+                "node/endpoint".to_string(),
+                KqeValue::Text(program_cid.to_string()),
+                graph_cid.clone(),
+            ),
+        ];
+        for datom in datoms {
+            self.journal_assert_datom(&graph_cid, &datom).await;
+            self.quad_store
+                .apply_journaled_datom(graph_cid.clone(), datom)
+                .await;
+        }
+        tracing::info!(app = %app, program_cid = %program_cid, "registered external wasm node");
     }
 
     /// Publish a Quad assert to the KSE Journal (fine SPO topic) and,

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -6931,6 +6931,35 @@ pub async fn block_get(
     }
 }
 
+// ── WasmNode registration ──────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct NodeRegisterReq {
+    /// app name (the `<app>` in `ai.gftd.apps.<app>.<method>`)
+    pub app: String,
+    /// program CID (the wasm component, e.g. from block.put)
+    pub endpoint: String,
+}
+
+/// POST /xrpc/ai.gftd.apps.kotoba.node.register
+/// Register an external app's wasm node so `generic_invoke` resolves+dispatches it.
+pub async fn node_register(
+    State(state): State<Arc<KotobaState>>,
+    headers: axum::http::HeaderMap,
+    Json(req): Json<NodeRegisterReq>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    crate::graph_auth::require_operator_auth(&headers, &state.operator_did)?;
+    if req.app.trim().is_empty() || req.endpoint.trim().is_empty() {
+        return Err((StatusCode::BAD_REQUEST, "app and endpoint are required".into()));
+    }
+    state.register_external_node(&req.app, &req.endpoint).await;
+    Ok(Json(serde_json::json!({
+        "status": "ok",
+        "app": req.app,
+        "endpoint": req.endpoint,
+    })))
+}
+
 // ── Commit endpoints ──────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
@@ -13695,20 +13724,60 @@ pub async fn generic_invoke(
     let app = parts[3];
 
     let graph_cid = kotoba_core::cid::KotobaCid::from_bytes(b"kotoba/network/nodes");
-    let ipns_name = distributed_graph_ipns_name(&graph_cid);
     let mut program_cid = app.to_string();
 
-    if let Ok(Some(db)) = DistributedDatomReader::new(&*state.block_store, &*state.ipns_registry).current_db_for_name(&ipns_name) {
-        for datom in db.datoms() {
-            if datom.a == "node/did" {
-                if let kotoba_datomic::Value::String(s) = &datom.v {
+    // Resolve app → wasm endpoint CID from the LOCAL quad_store hot arrangement of the
+    // kotoba/network/nodes graph. Both the server self-registration AND external
+    // `datomic.transact` node registrations land here (apply_journaled_datom →
+    // insert_datom into the arrangement), so this reliably surfaces freshly-registered
+    // app nodes — unlike the distributed IPNS head, which did not (ADR-2605312355).
+    // Fall back to the distributed head for federation (an app hosted on a remote peer).
+    {
+        use kotoba_kqe::quad::LegacyQuadObject;
+        let node_quads = state
+            .quad_store
+            .quads_by_predicate_prefix(Some(&graph_cid), "node/")
+            .await;
+        for q in &node_quads {
+            if q.predicate == "node/did" {
+                if let LegacyQuadObject::Text(s) = &q.object {
                     if s == app || s.ends_with(&format!("{app}.gftd.co.jp")) {
-                        if let Some(endpoint) = db.datoms().iter().find(|d| d.e == datom.e && d.a == "node/endpoint") {
-                            if let kotoba_datomic::Value::String(ep) = &endpoint.v {
-                                program_cid = ep.to_string();
+                        if let Some(ep) = node_quads
+                            .iter()
+                            .find(|d| d.subject == q.subject && d.predicate == "node/endpoint")
+                        {
+                            if let LegacyQuadObject::Text(cid) = &ep.object {
+                                program_cid = cid.to_string();
                             }
                         }
                         break;
+                    }
+                }
+            }
+        }
+        tracing::info!(
+            app = %app,
+            node_quads = node_quads.len(),
+            program_cid = %program_cid,
+            resolved = program_cid != app,
+            "generic_invoke: quad_store node resolution"
+        );
+    }
+
+    if program_cid == app {
+        let ipns_name = distributed_graph_ipns_name(&graph_cid);
+        if let Ok(Some(db)) = DistributedDatomReader::new(&*state.block_store, &*state.ipns_registry).current_db_for_name(&ipns_name) {
+            for datom in db.datoms() {
+                if datom.a == "node/did" {
+                    if let kotoba_datomic::Value::String(s) = &datom.v {
+                        if s == app || s.ends_with(&format!("{app}.gftd.co.jp")) {
+                            if let Some(endpoint) = db.datoms().iter().find(|d| d.e == datom.e && d.a == "node/endpoint") {
+                                if let kotoba_datomic::Value::String(ep) = &endpoint.v {
+                                    program_cid = ep.to_string();
+                                }
+                            }
+                            break;
+                        }
                     }
                 }
             }

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -13718,6 +13718,16 @@ pub async fn generic_invoke(
     let mut ctx_cbor = Vec::new();
     ciborium::into_writer(&req_body, &mut ctx_cbor).map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("cbor encode: {e}")))?;
 
+    // Load the registered WasmNode program bytes from the block store by CID.
+    // `program_cid` is the resolved `node/endpoint` value (a wasm CID) when the
+    // app is registered in `kotoba/network/nodes`; when it is the bare app-name
+    // fallback (not a multibase CID) this resolves to None and dispatch returns
+    // `MissingWasmBytes` as before. Fixes the ADR-2605311200 generic_invoke gap.
+    // `block_store.get` yields `Option<bytes::Bytes>`; `Bytes: Deref<[u8]>` so
+    // `.as_deref()` below gives the `Option<&[u8]>` dispatch expects.
+    let program_bytes = kotoba_core::cid::KotobaCid::from_multibase(&program_cid)
+        .and_then(|cid| state.block_store.get(&cid).ok().flatten());
+
     let agent_did = state.operator_did.clone();
     let router = Arc::clone(&state.router);
 
@@ -13727,7 +13737,7 @@ pub async fn generic_invoke(
             kotoba_dht::source_chain::ProgramType::WasmNode,
             &agent_did,
             0,
-            None,
+            program_bytes.as_deref(),
             ctx_cbor,
             None,
             None,

--- a/scripts/build-pywasm.sh
+++ b/scripts/build-pywasm.sh
@@ -47,6 +47,9 @@ OUTPUT="${OUTPUT:-${AGENT_DIR}/${AGENT_MODULE}.wasm}"
 
 # ── Paths ───────────────────────────────────────────────────────────────────
 WIT_PATH="${KOTOBA_WIT_PATH:-${KOTOBA_DIR}/crates/kotoba-runtime/wit/world.wit}"
+# componentize-py resolves wit/deps/ (vendored plain wasi:http@0.2.0 + io/clocks/
+# random/cli/filesystem/sockets) only when -d points at the wit DIRECTORY.
+WIT_DIR="$(dirname "$WIT_PATH")"
 BINDINGS_DIR="${KOTOBA_DIR}/target/pywasm-bindings"
 PY_PKG_DIR="${KOTOBA_DIR}/py"
 
@@ -80,7 +83,7 @@ if [[ ! -f "$BINDINGS_STAMP" ]] || [[ "$(cat "$BINDINGS_STAMP" 2>/dev/null)" != 
     echo "Generating WIT bindings → $BINDINGS_DIR" >&2
     mkdir -p "$BINDINGS_DIR"
     componentize-py \
-        -d "$WIT_PATH" \
+        -d "$WIT_DIR" \
         -w kotoba-node \
         bindings "$BINDINGS_DIR"
     echo "$WIT_MTIME" > "$BINDINGS_STAMP"
@@ -90,7 +93,7 @@ fi
 echo "Building $AGENT_MODULE → $OUTPUT" >&2
 
 componentize-py \
-    -d "$WIT_PATH" \
+    -d "$WIT_DIR" \
     -w kotoba-node \
     componentize "$AGENT_MODULE" \
     -p "$AGENT_DIR" \


### PR DESCRIPTION
## Summary

Takes the kotoba PRE×CACAO content-encryption layer from **dormant scaffolding → wired, verified, operator-trusted system**, plus adjacent kotoba-runtime/kg.query work on this branch.

### PRE×CACAO content encryption (ADR-2605240001 §21/§23/§28/§29)
- **Increment 1** (`94358b1`): operator-trusted PRE substrate live — `AgentCrypto::derive_wrapping_key` (node-derived `owner_enc_key` via HKDF) + persistent `PreKeyRegistry` wired into `serve()`.
- **Increment 2** (`d3ad8d8`): Pattern B claim encryption on the live kg path — opt-in `KOTOBA_ENCRYPT_CLAIM_PREDS`, `seal_field` on write / `open_field` on authorized read, `signal:v1:` opaque Text (no index change). Default empty allowlist = zero regression.
- **Increment 3** (`b19ae30`): re-key revocation propagation over GossipSub (§23.7 wire) — emit via `revoke_pre_key_grant`, receive via net_actor → `apply_revocation_warrant_bytes` (no block fetch).
- **preRevoke endpoint** (`0c9709f`): owner/operator-authenticated XRPC revoke trigger.
- **Verification**: E2E operator-trusted round-trip (`9d38c0a`) + **real handler e2e** (`6366e8e`, kg_ingest→QuadStore→kg_entity: sealed at rest, plaintext absent, authorized read decrypts).

Trust model (§28.4): vendor = operator-trusted (Consensys/Infura); true zero-knowledge (Pattern D) is etzhayyim/protocol scope. Confidentiality re-scored honestly (§21.7): default d=0.644 / opt-in d≈0.70 (not the retracted 0.840).

### Adjacent (same branch)
- `kotoba:kais/http` host import for guest outbound HTTP (`7c82668`) + corrected world.wit comment.
- kg.query enterprise SQL: MySQL/PostgreSQL dialects + fail-loud non-eq WHERE + readable object values (`f3bf3ef`/`c2ae4b0`).
- generic_invoke wasm-node resolution fixes; pywasm wasi 0.2.0 vendoring.

## Tests
kotoba-crypto +4, kotoba-kse revocation +1, kotoba-server pre_proxy/kg/kotobase_xrpc all green (`KOTOBA_IPFS=off`). Merges cleanly into main (no conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)