### PR TITLE
kotoba-wasm P2 write path + P3 jco guest spike

### DIFF
--- a/crates/kotoba-wasm/.gitignore
+++ b/crates/kotoba-wasm/.gitignore
@@ -2,3 +2,9 @@
 /pkg-node/
 /web/pkg/
 /target/
+/web/p3-guest-spike/out/
+/web/p3-guest-spike/target/
+/web/p3-guest-spike/node_modules/
+/web/p3-guest-spike/Cargo.lock
+/web/p3-guest-spike/package.json
+/web/p3-guest-spike/package-lock.json

--- a/crates/kotoba-wasm/src/lib.rs
+++ b/crates/kotoba-wasm/src/lib.rs
@@ -107,6 +107,42 @@ impl Node {
         self.arr.datoms_with_attribute_prefix(&self.tx, prefix)
     }
 
+    /// P2 local write: assert a batch of datoms into the arrangement (same
+    /// `[{e,a,v_edn}]` shape as a read). The write lands in the local read
+    /// engine immediately; durability is the caller's IndexedDB/OPFS layer.
+    /// (Simplified Datomic transact — assertions only; tempid/unique-identity
+    /// upsert + retraction semantics are a later increment.)
+    pub fn transact(&mut self, datoms_json: &str) -> Result<usize, String> {
+        self.load_server_datoms(datoms_json)
+    }
+
+    /// Export the full current datom set as the server `[{e,a,v_edn}]` JSON
+    /// shape, so the caller can persist post-write state (seed + local writes)
+    /// and re-`load_server_datoms` it on the next cold start. The exact `e`
+    /// string is not round-trip-identical to the original CID, but is stable
+    /// per entity within the snapshot — which is all the read engine needs.
+    pub fn export_datoms_json(&self) -> String {
+        let datoms = self.arr.datoms(&self.tx);
+        let mut out = String::from("[");
+        for (i, d) in datoms.iter().enumerate() {
+            if i > 0 {
+                out.push(',');
+            }
+            let v_edn = match &d.v {
+                Value::Text(s) => serde_json::to_string(s).unwrap_or_else(|_| "\"\"".into()),
+                Value::Integer(n) => n.to_string(),
+                Value::Float(f) => f.to_string(),
+                Value::Cid(c) => serde_json::to_string(&format!("{c:?}")).unwrap(),
+                other => serde_json::to_string(&format!("{other:?}")).unwrap(),
+            };
+            let e = serde_json::to_string(&format!("{:?}", d.e)).unwrap();
+            let a = serde_json::to_string(&d.a).unwrap();
+            out.push_str(&format!("{{\"e\":{e},\"a\":{a},\"v_edn\":{v_edn},\"added\":true}}"));
+        }
+        out.push(']');
+        out
+    }
+
     /// yoro-style actor search: scan `:yoro.profile/*` Datoms, group by entity,
     /// and return profiles whose did/handle/displayName/description contains `q`
     /// (case-insensitive). Empty `q` returns all. This mirrors
@@ -207,6 +243,19 @@ mod wasm {
                 .map_err(|e| JsValue::from_str(&e))
         }
 
+        /// P2 local write — assert `[{e,a,v_edn}]` datoms into the local engine.
+        pub fn transact(&mut self, datoms_json: &str) -> Result<usize, JsValue> {
+            self.inner
+                .transact(datoms_json)
+                .map_err(|e| JsValue::from_str(&e))
+        }
+
+        /// Export current state as `[{e,a,v_edn}]` for IndexedDB/OPFS persistence.
+        #[wasm_bindgen(js_name = exportDatoms)]
+        pub fn export_datoms(&self) -> String {
+            self.inner.export_datoms_json()
+        }
+
         /// `searchActors(q)` → JSON `{ actors: [...] }` (same shape as the XRPC).
         #[wasm_bindgen(js_name = searchActors)]
         pub fn search_actors(&self, q: &str) -> Result<String, JsValue> {
@@ -256,5 +305,25 @@ mod tests {
         let hit = n.search_actors("watatsuna");
         assert_eq!(hit.len(), 1);
         assert_eq!(hit[0].did, "did:web:etzhayyim.com:actor:watatsuna");
+    }
+
+    #[test]
+    fn transact_then_export_roundtrips_into_a_fresh_node() {
+        let mut n = Node::new();
+        // P2 local write
+        let tx = r#"[
+          {"e":"e1","a":":yoro.profile/did","v_edn":"\"did:web:etzhayyim.com:actor:newcomer\""},
+          {"e":"e1","a":":yoro.profile/displayName","v_edn":"\"新人 Newcomer\""}
+        ]"#;
+        assert_eq!(n.transact(tx).unwrap(), 2);
+        assert_eq!(n.search_actors("newcomer").len(), 1);
+
+        // Export → re-import into a fresh node (persistence round-trip).
+        let dump = n.export_datoms_json();
+        let mut restored = Node::new();
+        restored.load_server_datoms(&dump).unwrap();
+        let hit = restored.search_actors("Newcomer");
+        assert_eq!(hit.len(), 1);
+        assert_eq!(hit[0].display_name, "新人 Newcomer");
     }
 }

--- a/crates/kotoba-wasm/web/p3-guest-spike/Cargo.toml
+++ b/crates/kotoba-wasm/web/p3-guest-spike/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "pregel-spike"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wit-bindgen = "0.36"
+
+[package.metadata.component]
+package = "spike:pregel"
+
+[package.metadata.component.target]
+world = "pregel"

--- a/crates/kotoba-wasm/web/p3-guest-spike/README.md
+++ b/crates/kotoba-wasm/web/p3-guest-spike/README.md
@@ -1,0 +1,69 @@
+# P3 spike — browser-native Pregel/UDF guest via jco (ADR-2606013600 D4)
+
+Proves the P3 claim: **a WASM Component Model guest runs on the browser's native
+WebAssembly engine via `jco`, calling back into JS-implemented host functions** —
+no `wasmtime` in the browser. The same component runs under wasmtime natively
+and under the browser engine here; one guest ABI, two runtimes.
+
+`wasmtime` does not target wasm32, so "run wasmtime in the browser" is a
+non-goal. Instead the guest `.wasm` (built once with `cargo component`) is
+transpiled by `jco` into an ES module that the browser's own WebAssembly engine
+executes; the host imports it needs are satisfied by JS shims wired to the
+in-browser `KotobaNode`.
+
+## What this spike contains
+
+- `wit/world.wit` — a minimal `pregel` world: imports one host fn `host-get`,
+  exports `run(input) -> string` (a single BSP superstep contract).
+- `src/lib.rs` — the guest: `run()` calls `host-get` and returns a result.
+- `host.js` — the host shim. Here it returns `kotoba-host[<key>]`; in production
+  this is where the kotoba host WIT interfaces call back into `KotobaNode`.
+- `runner.mjs` — a node harness that loads the transpiled module and calls `run`.
+
+## Reproduce (verified)
+
+```sh
+# 1) build the Component (own workspace — uses wasm32-wasip2)
+#    NOTE: ~/.config/wasm-pkg/config.toml may carry an old `default = "ghcr.io"`
+#    schema that newer cargo-component rejects; move it aside for the build.
+PATH="$HOME/.cargo/bin:$PATH" cargo component build --release --target wasm32-wasip2
+
+# 2) transpile the Component to JS (browser/node WebAssembly engine + jco)
+npm install @bytecodealliance/preview2-shim
+npx @bytecodealliance/jco transpile \
+  target/wasm32-wasip2/release/pregel_spike.wasm -o out --name pregel \
+  --map 'host-get=./host.js'
+cp host.js out/host.js
+
+# 3) run the guest on the JS engine with the host import wired
+node runner.mjs
+```
+
+Verified output:
+
+```
+guest run() returned: "pregel-superstep(input=vertex-42) host-said=kotoba-host[vertex-42]"
+P3 jco SPIKE: PASS ✅ (Component Model guest ran on the JS WebAssembly engine + called back into the JS host)
+```
+
+## Productionizing into the kotoba browser node
+
+The spike wires ONE host fn. For real `kotoba-guest` Pregel/UDF in the browser:
+
+1. Build the existing `crates/kotoba-guest` (the `kotoba-node` world) with
+   `cargo component build --target wasm32-wasip2` — the SAME component the native
+   `kotoba-runtime::WasmExecutor` already runs. No fork.
+2. `jco transpile` it; satisfy WASI-P2 with `@bytecodealliance/preview2-shim`.
+3. Implement the kotoba host WIT interfaces in JS, wired to `KotobaNode`:
+   - `kotoba:kais/kqe.{assert-quad,retract-quad,query,get-objects,get-head}`
+     → the in-wasm arrangement (read) / local transact (write).
+   - `kotoba:kais/kse.{publish,drain}` → a local journal (OPFS).
+   - `kotoba:kais/auth.*` → the member DID / CACAO (read-only).
+   - `kotoba:kais/llm.*` → **disabled** in the storage node (Murakumo-only,
+     ADR-2605215000).
+4. Rust side: add a `GuestRuntime` trait; the pure-Rust `WasmPregelRunner` (BSP
+   orchestrator) stays unchanged and drives either `WasmtimeRuntime` (native) or
+   `BrowserComponentRuntime` (this jco path) per target.
+
+The `out/`, `target/`, and `node_modules/` build artifacts are gitignored; this
+directory holds the source + the verified recipe only.

--- a/crates/kotoba-wasm/web/p3-guest-spike/host.js
+++ b/crates/kotoba-wasm/web/p3-guest-spike/host.js
@@ -1,0 +1,4 @@
+export default function hostGet(key) {
+  // In the browser this calls back into the KotobaNode (kqe read, etc.).
+  return `kotoba-host[${key}]`;
+}

--- a/crates/kotoba-wasm/web/p3-guest-spike/runner.mjs
+++ b/crates/kotoba-wasm/web/p3-guest-spike/runner.mjs
@@ -1,0 +1,6 @@
+import { run } from './out/pregel.js';
+const r = run('vertex-42');
+console.log('guest run() returned:', JSON.stringify(r));
+const ok = typeof r === 'string' && r.includes('pregel-superstep(input=vertex-42)') && r.includes('kotoba-host[vertex-42]');
+console.log(ok ? '\nP3 jco SPIKE: PASS ✅ (Component Model guest ran on the JS WebAssembly engine + called back into the JS host)' : '\nP3 jco SPIKE: FAIL ❌');
+process.exit(ok ? 0 : 1);

--- a/crates/kotoba-wasm/web/p3-guest-spike/src/lib.rs
+++ b/crates/kotoba-wasm/web/p3-guest-spike/src/lib.rs
@@ -1,0 +1,19 @@
+#[cfg(target_arch = "wasm32")]
+mod bindings {
+    wit_bindgen::generate!({ world: "pregel", path: "wit" });
+}
+
+#[cfg(target_arch = "wasm32")]
+struct Component;
+
+#[cfg(target_arch = "wasm32")]
+impl bindings::Guest for Component {
+    fn run(input: String) -> String {
+        // A trivial "superstep": call back into the host, then return a result.
+        let from_host = bindings::host_get(&input);
+        format!("pregel-superstep(input={input}) host-said={from_host}")
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+bindings::export!(Component with_types_in bindings);

--- a/crates/kotoba-wasm/web/p3-guest-spike/wit/world.wit
+++ b/crates/kotoba-wasm/web/p3-guest-spike/wit/world.wit
@@ -1,0 +1,9 @@
+package spike:pregel@0.1.0;
+
+/// Minimal Pregel-superstep guest: imports one host fn, exports run().
+world pregel {
+  /// host callback (the kotoba host wires this to the wasm read node).
+  import host-get: func(key: string) -> string;
+  /// one BSP superstep: compute over input, may call the host.
+  export run: func(input: string) -> string;
+}


### PR DESCRIPTION
Follow-on to #14 (kotoba browser node). Two commits:

- **P2 local write** (`5d6d5ba`): `KotobaNode.transact(json)` asserts datoms into
  the in-wasm kqe engine; `exportDatoms()` dumps current state back to
  `[{e,a,v_edn}]` for IndexedDB/OPFS persistence. 3 native tests
  (read + hydrate + transact→export→re-import round-trip); wasm32 green.
- **P3 spike** (`b09f187`): proves browser-native Pregel/UDF — a Component Model
  guest built with `cargo component` (wasm32-wasip2), transpiled by `jco`, runs on
  the JS WebAssembly engine and calls back into a JS host (no wasmtime in the
  browser). `web/p3-guest-spike/` has the source + verified reproduce recipe.
  Verified: `run("vertex-42") = "pregel-superstep(input=vertex-42) host-said=kotoba-host[vertex-42]"`.

Productionization recipe (P3 README): build the real `kotoba-guest` (kotoba-node
world) → jco → implement `kotoba:kais/{kqe,kse,auth}` host interfaces over
KotobaNode (llm disabled, Murakumo-only) → add a `GuestRuntime` trait so the
pure-Rust `WasmPregelRunner` drives WasmtimeRuntime (native) or
BrowserComponentRuntime (jco) per target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)