### PR TITLE
kotoba-wasm P3 — real kotoba-guest runs browser-native via jco

### DIFF
--- a/crates/kotoba-wasm/.gitignore
+++ b/crates/kotoba-wasm/.gitignore
@@ -8,3 +8,8 @@
 /web/p3-guest-spike/Cargo.lock
 /web/p3-guest-spike/package.json
 /web/p3-guest-spike/package-lock.json
+/web/p3-kotoba-guest/out/
+/web/p3-kotoba-guest/pkg/
+/web/p3-kotoba-guest/node_modules/
+/web/p3-kotoba-guest/package.json
+/web/p3-kotoba-guest/package-lock.json

--- a/crates/kotoba-wasm/web/p3-kotoba-guest/README.md
+++ b/crates/kotoba-wasm/web/p3-kotoba-guest/README.md
@@ -1,0 +1,75 @@
+# P3 — the REAL kotoba-guest, browser-native via jco (ADR-2606013600 D4)
+
+Beyond the toy spike (`../p3-guest-spike/`): this runs the **actual production
+`crates/kotoba-guest`** — the `kotoba-node` world, the SAME WASM Component the
+native `kotoba-runtime::WasmExecutor` (wasmtime) executes — on the JS
+WebAssembly engine via `jco`, with its host interfaces wired to the in-wasm
+`KotobaNode` read/write engine. One guest ABI, two runtimes.
+
+## What the guest does (`kotoba-guest::run`)
+
+`run(ctx_cbor) -> output_cbor`, one BSP superstep:
+1. `auth.current-did()` → executing member DID
+2. `kqe.assert-quad({graph, subject=did, predicate:"kotoba/task", object-cbor=args})`
+3. `kse.publish("kotoba/<graph>/invoked", args)` → topic CID
+4. returns CBOR `{status, quads_asserted, agent_did, topic_cid}`
+
+## Host wiring (`hosts/`)
+
+jco maps each imported interface to a JS module:
+
+| WIT import | JS shim | backing |
+|---|---|---|
+| `kotoba:kais/kqe` | `hosts/kqe.js` | `assert-quad` → `KotobaNode.transact` (real read engine) |
+| `kotoba:kais/kse` | `hosts/kse.js` | local journal stub (topic CID) |
+| `kotoba:kais/auth` | `hosts/auth.js` | member DID (read-only) |
+| `kotoba:kais/llm` | — | not imported by this guest (Murakumo-only, ADR-2605215000) |
+
+`hosts/node.js` holds the shared `KotobaNode`; the kqe shim writes into it and the
+harness reads it back to prove the guest's quad landed.
+
+## Reproduce (verified in node — same engine model as the browser)
+
+```sh
+# 1) build the REAL guest (own workspace; move ~/.config/wasm-pkg/config.toml
+#    aside if it carries the old `default = "ghcr.io"` schema)
+cd ../../../../crates/kotoba-guest
+PATH="$HOME/.cargo/bin:$PATH" cargo component build --release --target wasm32-wasip2
+
+# 2) build the KotobaNode node bindings (read/write engine)
+cd ../kotoba-wasm && wasm-pack build --target nodejs --out-dir pkg-node --release
+cp pkg-node/* web/p3-kotoba-guest/pkg/
+
+# 3) transpile the guest, mapping the kotoba host interfaces to the JS shims
+cd web/p3-kotoba-guest
+npm install cbor-x @bytecodealliance/preview2-shim
+npx @bytecodealliance/jco transpile \
+  ../../../../target/wasm32-wasip2/release/kotoba_guest.wasm -o out --name kguest \
+  --map 'kotoba:kais/kqe=../hosts/kqe.js' \
+  --map 'kotoba:kais/kse=../hosts/kse.js' \
+  --map 'kotoba:kais/auth=../hosts/auth.js'
+
+# 4) run the guest; verify it executed + wrote into KotobaNode
+node run.mjs
+```
+
+Verified output:
+
+```
+real kotoba-guest run() → {"status":"ok","quads_asserted":1,
+  "agent_did":"did:web:etzhayyim.com:actor:tsumugi","topic_cid":"bafy-kse-kotobayorosocial"}
+KotobaNode got quad via guest kqe.assert-quad → {... "a":"kotoba/task","v_edn":"superstep-args" ...}
+P3 REAL-GUEST VERIFY: PASS ✅
+```
+
+## Remaining for full browser Pregel
+
+- A JS BSP driver (multi-superstep loop) — the pure-Rust `WasmPregelRunner`
+  contract, in JS: feed `run()`'s `output_cbor` back as the next `ctx_cbor` while
+  `status == "continue"`, accumulating quads.
+- Run it under a real browser (this harness is node; the engine + jco glue are
+  identical) and wire `kse`/`auth` to OPFS + the member identity rather than stubs.
+- CBOR `object-cbor` decode: this shim treats the payload as text; full fidelity
+  uses the CBOR QuadObject codec.
+
+Build artifacts (`out/`, `pkg/`, `node_modules/`) are gitignored.

--- a/crates/kotoba-wasm/web/p3-kotoba-guest/hosts/auth.js
+++ b/crates/kotoba-wasm/web/p3-kotoba-guest/hosts/auth.js
@@ -1,0 +1,4 @@
+// kotoba:kais/auth — member identity (read-only).
+export function currentDid() { return 'did:web:etzhayyim.com:actor:tsumugi'; }
+export function verifyCacao() { return ''; }
+export function hasCapability() { return false; }

--- a/crates/kotoba-wasm/web/p3-kotoba-guest/hosts/kqe.js
+++ b/crates/kotoba-wasm/web/p3-kotoba-guest/hosts/kqe.js
@@ -1,0 +1,11 @@
+import { node } from './node.js';
+// kotoba:kais/kqe — the guest's only call here is assert-quad, wired into the
+// in-wasm KotobaNode read engine (object payload decoded as text for storage).
+export function assertQuad(q) {
+  const val = new TextDecoder().decode(q.objectCbor);
+  node.transact(JSON.stringify([{ e: q.subject, a: q.predicate, v_edn: JSON.stringify(val) }]));
+}
+export function retractQuad() {}
+export function query() { return []; }
+export function getObjects() { return []; }
+export function getHead() { return undefined; }

--- a/crates/kotoba-wasm/web/p3-kotoba-guest/hosts/kse.js
+++ b/crates/kotoba-wasm/web/p3-kotoba-guest/hosts/kse.js
@@ -1,0 +1,5 @@
+// kotoba:kais/kse — local journal stub (returns a deterministic topic CID).
+export function publish(topic, _payload) {
+  return 'bafy-kse-' + topic.replace(/[^a-z0-9]/gi, '').slice(0, 16);
+}
+export function drain() { return []; }

--- a/crates/kotoba-wasm/web/p3-kotoba-guest/hosts/node.js
+++ b/crates/kotoba-wasm/web/p3-kotoba-guest/hosts/node.js
@@ -1,0 +1,4 @@
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { KotobaNode } = require('../pkg/kotoba_wasm.js');
+export const node = new KotobaNode();

--- a/crates/kotoba-wasm/web/p3-kotoba-guest/run.mjs
+++ b/crates/kotoba-wasm/web/p3-kotoba-guest/run.mjs
@@ -1,0 +1,19 @@
+import { encode, decode } from 'cbor-x';
+import { run } from './out/kguest.js';
+import { node } from './hosts/node.js';
+
+const ctx = { graph: 'yoro-social-v1', session_cid: null, args_cbor: new TextEncoder().encode('superstep-args') };
+const outCbor = run(encode(ctx));
+const out = decode(outCbor);
+console.log('real kotoba-guest run() →', JSON.stringify(out));
+
+const dump = JSON.parse(node.exportDatoms());
+const task = dump.find(d => d.a === 'kotoba/task');
+console.log('KotobaNode got quad via guest kqe.assert-quad →', task ? JSON.stringify(task) : 'NONE');
+
+const ok = out && out.status === 'ok' && out.quads_asserted === 1
+  && out.agent_did === 'did:web:etzhayyim.com:actor:tsumugi'
+  && out.topic_cid && out.topic_cid.startsWith('bafy-kse-')
+  && task && task.a === 'kotoba/task' && task.v_edn.includes('superstep-args');
+console.log(ok ? '\nP3 REAL-GUEST VERIFY: PASS ✅ (production kotoba-guest ran via jco; auth+kqe+kse host wired; kqe.assert-quad landed in KotobaNode)' : '\nP3 REAL-GUEST: FAIL ❌');
+process.exit(ok ? 0 : 1);


### PR DESCRIPTION
Follow-on to #15. One commit (`8c11c6b`): the **actual production `kotoba-guest`**
(the kotoba-node world — the SAME Component the native wasmtime WasmExecutor runs)
built to wasm32-wasip2, transpiled by jco, and executed on the JS WebAssembly
engine with all its host interfaces implemented in JS:

- `kotoba:kais/kqe.assert-quad` → `KotobaNode.transact` (the real in-wasm engine)
- `kotoba:kais/kse.publish` → local journal stub
- `kotoba:kais/auth.current-did` → member DID
- `kotoba:kais/llm` not imported (Murakumo-only)

Verified (node; identical engine + jco glue to the browser):
`run(ctx_cbor) → {status:"ok", quads_asserted:1, agent_did, topic_cid}` and the
guest's `kqe.assert-quad` landed in `KotobaNode` (`a="kotoba/task"`).

`web/p3-kotoba-guest/` holds the JS host shims + node harness + verified recipe.
One guest ABI, two runtimes (wasmtime native / browser engine via jco).

🤖 Generated with [Claude Code](https://claude.com/claude-code)