### PR TITLE
feat(kotoba-net): NAT traversal — AutoNAT + Circuit Relay v2 + DCUtR (clean-room WG/TS-equivalent)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -467,6 +467,19 @@ dependencies = [
 
 [[package]]
 name = "asynchronous-codec"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "asynchronous-codec"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a860072022177f903e59730004fb5dc13db9275b79bb2aef7ba8ce831956c233"
@@ -2737,6 +2750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
+ "allocator-api2",
  "serde",
 ]
 
@@ -4161,8 +4175,10 @@ dependencies = [
  "getrandom 0.2.17",
  "instant",
  "libp2p-allow-block-list",
+ "libp2p-autonat",
  "libp2p-connection-limits",
  "libp2p-core",
+ "libp2p-dcutr",
  "libp2p-dns",
  "libp2p-gossipsub",
  "libp2p-identify",
@@ -4173,6 +4189,7 @@ dependencies = [
  "libp2p-noise",
  "libp2p-ping",
  "libp2p-quic",
+ "libp2p-relay",
  "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-tcp",
@@ -4194,6 +4211,27 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "void",
+]
+
+[[package]]
+name = "libp2p-autonat"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95151726170e41b591735bf95c42b888fe4aa14f65216a9fbf0edcc04510586"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec 0.6.2",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec 0.2.0",
+ "rand 0.8.6",
+ "tracing",
 ]
 
 [[package]]
@@ -4237,6 +4275,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-dcutr"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f7bb7fa2b9e6cad9c30a6f67e3ff5c1e4b658c62b6375e35861a85f9c97bf3"
+dependencies = [
+ "asynchronous-codec 0.6.2",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "lru 0.11.1",
+ "quick-protobuf",
+ "quick-protobuf-codec 0.2.0",
+ "thiserror 1.0.69",
+ "tracing",
+ "void",
+]
+
+[[package]]
 name = "libp2p-dns"
 version = "0.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4258,7 +4319,7 @@ version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d665144a616dadebdc5fff186b1233488cdcd8bfb1223218ff084b6d052c94f7"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.7.0",
  "base64 0.21.7",
  "byteorder",
  "bytes",
@@ -4274,7 +4335,7 @@ dependencies = [
  "libp2p-swarm",
  "prometheus-client",
  "quick-protobuf",
- "quick-protobuf-codec",
+ "quick-protobuf-codec 0.3.1",
  "rand 0.8.6",
  "regex",
  "sha2 0.10.9",
@@ -4289,7 +4350,7 @@ version = "0.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5d635ebea5ca0c3c3e77d414ae9b67eccf2a822be06091b9c1a0d13029a1e2f"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.7.0",
  "either",
  "futures",
  "futures-bounded",
@@ -4297,9 +4358,9 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "lru",
+ "lru 0.12.5",
  "quick-protobuf",
- "quick-protobuf-codec",
+ "quick-protobuf-codec 0.3.1",
  "smallvec",
  "thiserror 1.0.69",
  "tracing",
@@ -4331,7 +4392,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cc5767727d062c4eac74dd812c998f0e488008e82cce9c33b463d38423f9ad2"
 dependencies = [
  "arrayvec",
- "asynchronous-codec",
+ "asynchronous-codec 0.7.0",
  "bytes",
  "either",
  "fnv",
@@ -4343,7 +4404,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "quick-protobuf",
- "quick-protobuf-codec",
+ "quick-protobuf-codec 0.3.1",
  "rand 0.8.6",
  "sha2 0.10.9",
  "smallvec",
@@ -4383,11 +4444,13 @@ dependencies = [
  "futures",
  "instant",
  "libp2p-core",
+ "libp2p-dcutr",
  "libp2p-gossipsub",
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
  "libp2p-ping",
+ "libp2p-relay",
  "libp2p-swarm",
  "pin-project",
  "prometheus-client",
@@ -4399,7 +4462,7 @@ version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecd0545ce077f6ea5434bcb76e8d0fe942693b4380aaad0d34a358c2bd05793"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.7.0",
  "bytes",
  "curve25519-dalek",
  "futures",
@@ -4462,6 +4525,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-relay"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d1c667cfabf3dd675c8e3cea63b7b98434ecf51721b7894cbb01d29983a6a9b"
+dependencies = [
+ "asynchronous-codec 0.7.0",
+ "bytes",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec 0.3.1",
+ "rand 0.8.6",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tracing",
+ "void",
+ "web-time",
+]
+
+[[package]]
 name = "libp2p-request-response"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4495,7 +4583,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm-derive",
- "lru",
+ "lru 0.12.5",
  "multistream-select",
  "once_cell",
  "rand 0.8.6",
@@ -4637,6 +4725,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a83fb7698b3643a0e34f9ae6f2e8f0178c0fd42f8b59d493aa271ff3a5bf21"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "lru"
@@ -5822,11 +5919,24 @@ dependencies = [
 
 [[package]]
 name = "quick-protobuf-codec"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ededb1cd78531627244d51dd0c7139fbe736c7d57af0092a76f0ffb2f56e98"
+dependencies = [
+ "asynchronous-codec 0.6.2",
+ "bytes",
+ "quick-protobuf",
+ "thiserror 1.0.69",
+ "unsigned-varint 0.7.2",
+]
+
+[[package]]
+name = "quick-protobuf-codec"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
 dependencies = [
- "asynchronous-codec",
+ "asynchronous-codec 0.7.0",
  "bytes",
  "quick-protobuf",
  "thiserror 1.0.69",
@@ -7799,6 +7909,10 @@ name = "unsigned-varint"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
+dependencies = [
+ "asynchronous-codec 0.6.2",
+ "bytes",
+]
 
 [[package]]
 name = "unsigned-varint"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3869,6 +3869,7 @@ dependencies = [
  "bytes",
  "ciborium",
  "futures",
+ "hex",
  "kotoba-core",
  "kotoba-kse",
  "libp2p",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,11 @@ reqwest          = { version = "0.12", default-features = false, features = ["js
 libp2p = { version = "0.53", features = [
     "quic", "noise", "yamux", "gossipsub", "kad",
     "identify", "ping", "macros", "request-response",
+    # NAT traversal (clean-room WireGuard/Tailscale-equivalent over libp2p):
+    # Circuit Relay v2 (DERP-equivalent fallback), DCUtR (hole punching),
+    # AutoNAT (reachability detection). Keeps the no-central-master invariant —
+    # relays are peers, discovery stays on Kademlia. See kotoba-net::nat.
+    "relay", "dcutr", "autonat",
 ] }
 ipld-core = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,8 @@ libp2p = { version = "0.53", features = [
     # AutoNAT (reachability detection). Keeps the no-central-master invariant —
     # relays are peers, discovery stays on Kademlia. See kotoba-net::nat.
     "relay", "dcutr", "autonat",
+    # DNS multiaddr resolution (so public relays can be addressed by /dns4/host).
+    "dns",
 ] }
 ipld-core = "0.4"
 

--- a/crates/kotoba-net/Cargo.toml
+++ b/crates/kotoba-net/Cargo.toml
@@ -21,6 +21,7 @@ serde_bytes = { workspace = true }
 ciborium = { workspace = true }
 async-trait = { workspace = true }
 base64 = { workspace = true }
+hex = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/kotoba-net/src/behaviour.rs
+++ b/crates/kotoba-net/src/behaviour.rs
@@ -1,11 +1,24 @@
 use crate::bitswap::BitswapCodec;
-use libp2p::{gossipsub, identify, kad, ping, request_response, swarm::NetworkBehaviour};
+use libp2p::swarm::behaviour::toggle::Toggle;
+use libp2p::{
+    autonat, dcutr, gossipsub, identify, kad, ping, relay, request_response,
+    swarm::NetworkBehaviour,
+};
 
 /// Combined NetworkBehaviour for KOTOBA nodes.
 ///
 /// The `#[derive(NetworkBehaviour)]` macro (libp2p "macros" feature) auto-generates:
 ///   - `KotobaBehaviourEvent` enum with one variant per field
 ///   - `poll()` / `handle_pending_inbound_connection()` / etc. delegation
+///
+/// NAT traversal (clean-room WireGuard/Tailscale-equivalent, all over libp2p — no
+/// vendored VPN code, no central coordination server):
+///   - `autonat`      — reachability detection (am I publicly dialable?)
+///   - `relay_client` — Circuit Relay v2 client (DERP-equivalent fallback path)
+///   - `dcutr`        — Direct Connection Upgrade through Relay (hole punching)
+///   - `relay_server` — optional Circuit Relay v2 *server*, off by default via
+///     `Toggle` (only public nodes enable it). A relay is just another peer —
+///     discovery stays on Kademlia, so the no-central-master invariant holds.
 #[derive(NetworkBehaviour)]
 pub struct KotobaBehaviour {
     pub gossipsub: gossipsub::Behaviour,
@@ -13,4 +26,9 @@ pub struct KotobaBehaviour {
     pub identify: identify::Behaviour,
     pub ping: ping::Behaviour,
     pub bitswap: request_response::Behaviour<BitswapCodec>,
+    // ── NAT traversal ────────────────────────────────────────────────
+    pub autonat: autonat::Behaviour,
+    pub relay_client: relay::client::Behaviour,
+    pub dcutr: dcutr::Behaviour,
+    pub relay_server: Toggle<relay::Behaviour>,
 }

--- a/crates/kotoba-net/src/lib.rs
+++ b/crates/kotoba-net/src/lib.rs
@@ -10,5 +10,5 @@ pub use bitswap::{BitswapCodec, BitswapRequest, BitswapResponse, BITSWAP_PROTOCO
 pub use libp2p::{Multiaddr, PeerId};
 pub use pregel_msg::{PregelNetMessage, PREGEL_GOSSIP_TOPIC};
 pub use protocol::{KOTOBA_BITSWAP_PROTOCOL, KOTOBA_SYNC_PROTOCOL};
-pub use swarm::{KotobaNetEvent, KotobaSwarm, NatConfig};
+pub use swarm::{ed25519_keypair_from_hex, KotobaNetEvent, KotobaSwarm, NatConfig};
 pub use transport::{default_listen_addr, quic_addr};

--- a/crates/kotoba-net/src/lib.rs
+++ b/crates/kotoba-net/src/lib.rs
@@ -10,5 +10,5 @@ pub use bitswap::{BitswapCodec, BitswapRequest, BitswapResponse, BITSWAP_PROTOCO
 pub use libp2p::{Multiaddr, PeerId};
 pub use pregel_msg::{PregelNetMessage, PREGEL_GOSSIP_TOPIC};
 pub use protocol::{KOTOBA_BITSWAP_PROTOCOL, KOTOBA_SYNC_PROTOCOL};
-pub use swarm::{KotobaNetEvent, KotobaSwarm};
+pub use swarm::{KotobaNetEvent, KotobaSwarm, NatConfig};
 pub use transport::{default_listen_addr, quic_addr};

--- a/crates/kotoba-net/src/swarm.rs
+++ b/crates/kotoba-net/src/swarm.rs
@@ -25,11 +25,27 @@ pub type KotobaSwarmType = Swarm<KotobaBehaviour>;
 /// let DCUtR upgrade relayed links to direct hole-punched connections. Only a
 /// publicly reachable fleet node should set `relay_server = true` so it can
 /// relay for others — a relay is just another peer (no central master).
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 pub struct NatConfig {
     /// Run the Circuit Relay v2 *server*. Enable only on publicly reachable
     /// nodes (public IP or port-forward). Off by default.
     pub relay_server: bool,
+}
+
+/// Build a stable libp2p Ed25519 identity from a 32-byte hex seed (e.g. the
+/// `KOTOBA_P2P_ED25519_HEX` env var) so a node keeps the same `PeerId` — and
+/// therefore the same relay reservations and addresses — across restarts.
+///
+/// Kept deliberately separate from the CACAO/DID *agent* key: the networking
+/// identity and the signing identity are different roles.
+pub fn ed25519_keypair_from_hex(seed_hex: &str) -> Result<Keypair> {
+    let mut bytes = hex::decode(seed_hex.trim())
+        .map_err(|e| anyhow::anyhow!("p2p ed25519 seed: invalid hex: {e}"))?;
+    if bytes.len() != 32 {
+        anyhow::bail!("p2p ed25519 seed: expected 32 bytes, got {}", bytes.len());
+    }
+    Keypair::ed25519_from_bytes(&mut bytes)
+        .map_err(|e| anyhow::anyhow!("p2p ed25519 seed: {e}"))
 }
 
 /// High-level wrapper around the libp2p Swarm.
@@ -153,6 +169,7 @@ impl KotobaSwarm {
         let mut swarm = libp2p::SwarmBuilder::with_existing_identity(keypair)
             .with_tokio()
             .with_quic()
+            .with_dns()?
             .with_relay_client(libp2p::noise::Config::new, libp2p::yamux::Config::default)?
             .with_behaviour(move |_keypair, relay_client| {
                 Ok(KotobaBehaviour {
@@ -198,6 +215,17 @@ impl KotobaSwarm {
         let circuit = relay_addr.with(Protocol::P2pCircuit);
         self.swarm.listen_on(circuit)?;
         Ok(())
+    }
+
+    /// Convenience over [`KotobaSwarm::reserve_relay`] for the `peerid@multiaddr`
+    /// config form (e.g. `KOTOBA_RELAY_PEERS`): appends the relay's
+    /// `/p2p/<peer>` to a bare transport multiaddr before reserving.
+    pub fn reserve_relay_with_peer(
+        &mut self,
+        relay_peer: PeerId,
+        relay_addr: Multiaddr,
+    ) -> Result<()> {
+        self.reserve_relay(relay_addr.with(Protocol::P2p(relay_peer)))
     }
 
     /// Dial `target` through a relay. Once the relayed connection is up, DCUtR
@@ -698,5 +726,24 @@ mod tests {
         } else {
             panic!("wrong variant");
         }
+    }
+
+    #[test]
+    fn ed25519_keypair_from_hex_is_deterministic() {
+        // Same 32-byte seed → same PeerId (stable identity across restarts).
+        let seed = "11".repeat(32); // 32 bytes
+        let a = ed25519_keypair_from_hex(&seed).expect("valid seed");
+        let b = ed25519_keypair_from_hex(&seed).expect("valid seed");
+        assert_eq!(
+            PeerId::from_public_key(&a.public()),
+            PeerId::from_public_key(&b.public()),
+            "same seed must yield the same PeerId"
+        );
+    }
+
+    #[test]
+    fn ed25519_keypair_from_hex_rejects_bad_input() {
+        assert!(ed25519_keypair_from_hex("deadbeef").is_err(), "too short");
+        assert!(ed25519_keypair_from_hex(&"zz".repeat(32)).is_err(), "non-hex");
     }
 }

--- a/crates/kotoba-net/src/swarm.rs
+++ b/crates/kotoba-net/src/swarm.rs
@@ -1,9 +1,12 @@
 use anyhow::Result;
 use futures::StreamExt;
+use libp2p::swarm::behaviour::toggle::Toggle;
 use libp2p::{
-    gossipsub, identify,
+    autonat, dcutr, gossipsub, identify,
     identity::Keypair,
-    kad, ping, request_response,
+    kad,
+    multiaddr::Protocol,
+    ping, relay, request_response,
     swarm::{Swarm, SwarmEvent},
     Multiaddr, PeerId,
 };
@@ -13,6 +16,21 @@ use crate::bitswap::{BitswapRequest, BitswapResponse, WantSince, BITSWAP_PROTOCO
 use crate::protocol::KOTOBA_SYNC_PROTOCOL;
 
 pub type KotobaSwarmType = Swarm<KotobaBehaviour>;
+
+/// NAT-traversal configuration (clean-room WireGuard/Tailscale-equivalent over
+/// libp2p — AutoNAT + Circuit Relay v2 + DCUtR).
+///
+/// Edge / donated nodes (behind home NAT) use the defaults: they probe their
+/// reachability with AutoNAT, take a relay reservation as a fallback path, and
+/// let DCUtR upgrade relayed links to direct hole-punched connections. Only a
+/// publicly reachable fleet node should set `relay_server = true` so it can
+/// relay for others — a relay is just another peer (no central master).
+#[derive(Debug, Clone, Default)]
+pub struct NatConfig {
+    /// Run the Circuit Relay v2 *server*. Enable only on publicly reachable
+    /// nodes (public IP or port-forward). Off by default.
+    pub relay_server: bool,
+}
 
 /// High-level wrapper around the libp2p Swarm.
 pub struct KotobaSwarm {
@@ -42,6 +60,21 @@ pub enum KotobaNetEvent {
         peer: PeerId,
         response: BitswapResponse,
     },
+    /// AutoNAT determined our public reachability. `public = true` ⇒ directly
+    /// dialable; `false` ⇒ behind a NAT, so a relay reservation is needed.
+    NatStatusChanged {
+        public: bool,
+    },
+    /// A relayed connection to `peer` was upgraded to a direct (hole-punched)
+    /// connection by DCUtR.
+    DirectConnectionUpgraded {
+        peer: PeerId,
+    },
+    /// A Circuit Relay v2 reservation was accepted by `relay` — this node is now
+    /// reachable at `<relay-addr>/p2p-circuit/p2p/<self>`.
+    RelayReservationAccepted {
+        relay: PeerId,
+    },
 }
 
 impl KotobaSwarm {
@@ -49,11 +82,29 @@ impl KotobaSwarm {
     /// `listen_addr` example: `"/ip4/0.0.0.0/udp/0/quic-v1"`.
     pub async fn new(listen_addr: Multiaddr) -> Result<Self> {
         let keypair = Keypair::generate_ed25519();
-        Self::with_keypair(keypair, listen_addr).await
+        Self::with_config(keypair, listen_addr, NatConfig::default()).await
     }
 
-    /// Create with an existing keypair (for persistent node identity).
+    /// Like [`KotobaSwarm::new`] (fresh identity) but with an explicit
+    /// NAT-traversal config — e.g. to enable the Circuit Relay v2 server on a
+    /// publicly reachable node.
+    pub async fn new_with_config(listen_addr: Multiaddr, nat: NatConfig) -> Result<Self> {
+        let keypair = Keypair::generate_ed25519();
+        Self::with_config(keypair, listen_addr, nat).await
+    }
+
+    /// Create with an existing keypair (for persistent node identity), default
+    /// NAT config (relay client + AutoNAT + DCUtR on, relay server off).
     pub async fn with_keypair(keypair: Keypair, listen_addr: Multiaddr) -> Result<Self> {
+        Self::with_config(keypair, listen_addr, NatConfig::default()).await
+    }
+
+    /// Create with an existing keypair and an explicit NAT-traversal config.
+    pub async fn with_config(
+        keypair: Keypair,
+        listen_addr: Multiaddr,
+        nat: NatConfig,
+    ) -> Result<Self> {
         let local_peer_id = PeerId::from_public_key(&keypair.public());
 
         // GossipSub — lenient validation thresholds for dev
@@ -84,18 +135,38 @@ impl KotobaSwarm {
             request_response::Config::default(),
         );
 
-        let behaviour = KotobaBehaviour {
-            gossipsub,
-            kademlia,
-            identify,
-            ping,
-            bitswap,
+        // ── NAT traversal behaviours (clean-room WG/TS-equivalent) ──────────
+        let autonat = autonat::Behaviour::new(local_peer_id, autonat::Config::default());
+        let dcutr = dcutr::Behaviour::new(local_peer_id);
+        let relay_server = if nat.relay_server {
+            Toggle::from(Some(relay::Behaviour::new(
+                local_peer_id,
+                relay::Config::default(),
+            )))
+        } else {
+            Toggle::from(None)
         };
 
+        // `with_relay_client` injects the Circuit Relay v2 client behaviour into
+        // the builder closure; the relayed connection is secured with Noise and
+        // multiplexed with Yamux (same upgrades as the base QUIC transport).
         let mut swarm = libp2p::SwarmBuilder::with_existing_identity(keypair)
             .with_tokio()
             .with_quic()
-            .with_behaviour(|_| Ok(behaviour))?
+            .with_relay_client(libp2p::noise::Config::new, libp2p::yamux::Config::default)?
+            .with_behaviour(move |_keypair, relay_client| {
+                Ok(KotobaBehaviour {
+                    gossipsub,
+                    kademlia,
+                    identify,
+                    ping,
+                    bitswap,
+                    autonat,
+                    relay_client,
+                    dcutr,
+                    relay_server,
+                })
+            })?
             // libp2p defaults idle_connection_timeout to 0 → idle connections close
             // immediately (KeepAliveTimeout) before GossipSub can graft them into a
             // mesh, so the firehose relay never propagates. Hold idle connections
@@ -111,6 +182,40 @@ impl KotobaSwarm {
             swarm,
             local_peer_id,
         })
+    }
+
+    // ------------------------------------------------------------------
+    // NAT traversal helpers (Circuit Relay v2 + DCUtR + AutoNAT)
+    // ------------------------------------------------------------------
+
+    /// Take a Circuit Relay v2 reservation on `relay_addr` so this (NAT'd) node
+    /// becomes reachable at `<relay_addr>/p2p-circuit/p2p/<self>`. Peers that
+    /// dial the circuit then get upgraded to a direct connection by DCUtR.
+    ///
+    /// `relay_addr` MUST already include the relay's `/p2p/<relay-peer-id>`
+    /// suffix (e.g. `/ip4/1.2.3.4/udp/4001/quic-v1/p2p/<relay-id>`).
+    pub fn reserve_relay(&mut self, relay_addr: Multiaddr) -> Result<()> {
+        let circuit = relay_addr.with(Protocol::P2pCircuit);
+        self.swarm.listen_on(circuit)?;
+        Ok(())
+    }
+
+    /// Dial `target` through a relay. Once the relayed connection is up, DCUtR
+    /// attempts to upgrade it to a direct (hole-punched) link automatically.
+    ///
+    /// `relay_addr` MUST include the relay's `/p2p/<relay-peer-id>` suffix.
+    pub fn dial_via_relay(&mut self, relay_addr: Multiaddr, target: PeerId) -> Result<()> {
+        let addr = relay_addr
+            .with(Protocol::P2pCircuit)
+            .with(Protocol::P2p(target));
+        self.swarm.dial(addr)?;
+        Ok(())
+    }
+
+    /// Register a confirmed external (publicly reachable) address — e.g. one
+    /// learned from AutoNAT — so it is advertised to peers via identify.
+    pub fn add_external_address(&mut self, addr: Multiaddr) {
+        self.swarm.add_external_address(addr);
     }
 
     /// Subscribe to a GossipSub topic mapped from a KSE topic name.
@@ -273,7 +378,42 @@ impl KotobaSwarm {
                     return Some(KotobaNetEvent::BitswapResponse { peer, response });
                 }
 
-                _ => { /* ignore ping, identify::Sent, bitswap failures, etc. */ }
+                // AutoNAT: reachability verdict changed (public vs behind-NAT)
+                SwarmEvent::Behaviour(KotobaBehaviourEvent::Autonat(
+                    autonat::Event::StatusChanged { new, .. },
+                )) => {
+                    let public = matches!(new, autonat::NatStatus::Public(_));
+                    tracing::info!(?new, "kotoba-net: autonat reachability changed");
+                    return Some(KotobaNetEvent::NatStatusChanged { public });
+                }
+
+                // DCUtR: a relayed link was upgraded to a direct (hole-punched) one
+                SwarmEvent::Behaviour(KotobaBehaviourEvent::Dcutr(dcutr::Event {
+                    remote_peer_id,
+                    result,
+                })) => match result {
+                    Ok(_) => {
+                        tracing::info!(peer = %remote_peer_id, "kotoba-net: dcutr hole-punch succeeded");
+                        return Some(KotobaNetEvent::DirectConnectionUpgraded {
+                            peer: remote_peer_id,
+                        });
+                    }
+                    Err(e) => {
+                        tracing::debug!(peer = %remote_peer_id, err = ?e, "kotoba-net: dcutr hole-punch failed");
+                    }
+                },
+
+                // Relay client: our reservation on a relay was accepted
+                SwarmEvent::Behaviour(KotobaBehaviourEvent::RelayClient(
+                    relay::client::Event::ReservationReqAccepted { relay_peer_id, .. },
+                )) => {
+                    tracing::info!(relay = %relay_peer_id, "kotoba-net: relay reservation accepted");
+                    return Some(KotobaNetEvent::RelayReservationAccepted {
+                        relay: relay_peer_id,
+                    });
+                }
+
+                _ => { /* ignore ping, identify::Sent, relay server, bitswap failures, etc. */ }
             }
         }
     }
@@ -488,6 +628,73 @@ mod tests {
             assert_eq!(topic, "kotoba/test");
             assert_eq!(data, vec![1u8, 2, 3]);
             assert_eq!(source, Some(peer));
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    // ── NAT traversal (AutoNAT + Circuit Relay v2 + DCUtR) ────────────────────
+
+    #[test]
+    fn nat_config_default_has_relay_server_off() {
+        let cfg = NatConfig::default();
+        assert!(!cfg.relay_server, "relay server must be opt-in");
+    }
+
+    #[tokio::test]
+    async fn swarm_with_relay_server_enabled_builds() {
+        // A public node enables the Circuit Relay v2 *server* so it can relay
+        // for NAT'd peers. Construction wires relay_client + dcutr + autonat +
+        // the toggled relay server without panicking.
+        let addr: Multiaddr = "/ip4/127.0.0.1/udp/0/quic-v1".parse().unwrap();
+        let keypair = Keypair::generate_ed25519();
+        let swarm = KotobaSwarm::with_config(keypair, addr, NatConfig { relay_server: true })
+            .await
+            .expect("relay-server swarm init");
+        assert!(!swarm.local_peer_id.to_string().is_empty());
+    }
+
+    #[tokio::test]
+    async fn reserve_relay_appends_p2p_circuit_without_panic() {
+        // An edge node asks a relay for a reservation. We can't complete the
+        // handshake without a live relay, but listen_on must accept the
+        // /p2p-circuit-suffixed multiaddr (smoke: no panic, no error).
+        let addr: Multiaddr = "/ip4/127.0.0.1/udp/0/quic-v1".parse().unwrap();
+        let mut swarm = KotobaSwarm::new(addr).await.expect("swarm init");
+        let relay_addr: Multiaddr =
+            format!("/ip4/127.0.0.1/udp/4999/quic-v1/p2p/{}", PeerId::random())
+                .parse()
+                .unwrap();
+        swarm.reserve_relay(relay_addr).expect("reserve_relay accepts circuit addr");
+    }
+
+    #[test]
+    fn kotoba_net_event_nat_status_changed_holds_public() {
+        let event = KotobaNetEvent::NatStatusChanged { public: true };
+        if let KotobaNetEvent::NatStatusChanged { public } = event {
+            assert!(public);
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    #[test]
+    fn kotoba_net_event_relay_reservation_holds_relay() {
+        let relay = PeerId::random();
+        let event = KotobaNetEvent::RelayReservationAccepted { relay };
+        if let KotobaNetEvent::RelayReservationAccepted { relay: r } = event {
+            assert_eq!(r, relay);
+        } else {
+            panic!("wrong variant");
+        }
+    }
+
+    #[test]
+    fn kotoba_net_event_direct_connection_upgraded_holds_peer() {
+        let peer = PeerId::random();
+        let event = KotobaNetEvent::DirectConnectionUpgraded { peer };
+        if let KotobaNetEvent::DirectConnectionUpgraded { peer: p } = event {
+            assert_eq!(p, peer);
         } else {
             panic!("wrong variant");
         }

--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -1361,7 +1361,22 @@ pub async fn run() -> anyhow::Result<()> {
             .any(|r| matches!(r, server::NodeRole::Relay));
         let nat_cfg = kotoba_net::NatConfig { relay_server };
 
-        match KotobaSwarm::new_with_config(listen_addr, nat_cfg).await {
+        // Persistent libp2p identity: a 32-byte hex seed in KOTOBA_P2P_ED25519_HEX
+        // pins the PeerId (and relay reservations / addresses) across restarts.
+        // Kept separate from the CACAO/DID agent key by design. Absent/invalid →
+        // ephemeral per-boot identity (previous behaviour).
+        let swarm_result = match std::env::var("KOTOBA_P2P_ED25519_HEX") {
+            Ok(seed_hex) => match kotoba_net::ed25519_keypair_from_hex(&seed_hex) {
+                Ok(kp) => KotobaSwarm::with_config(kp, listen_addr, nat_cfg).await,
+                Err(e) => {
+                    tracing::warn!("KOTOBA_P2P_ED25519_HEX invalid ({e}); using ephemeral identity");
+                    KotobaSwarm::new_with_config(listen_addr, nat_cfg).await
+                }
+            },
+            Err(_) => KotobaSwarm::new_with_config(listen_addr, nat_cfg).await,
+        };
+
+        match swarm_result {
             Ok(mut swarm) => {
                 if let Ok(peers_str) = std::env::var("KOTOBA_BOOTSTRAP_PEERS") {
                     let mut bootstrapped = false;
@@ -1388,6 +1403,40 @@ pub async fn run() -> anyhow::Result<()> {
                     if bootstrapped {
                         swarm.bootstrap().ok();
                         tracing::info!("Kademlia bootstrap triggered");
+                    }
+                }
+
+                // Edge/NAT'd nodes: take a Circuit Relay v2 reservation on each
+                // configured relay (`peerid@multiaddr`, comma-separated) so peers
+                // can reach us via the relay; DCUtR then upgrades to a direct link.
+                if let Ok(relays_str) = std::env::var("KOTOBA_RELAY_PEERS") {
+                    for entry in relays_str.split(',') {
+                        let entry = entry.trim();
+                        if entry.is_empty() {
+                            continue;
+                        }
+                        if let Some((pid_str, addr_str)) = entry.split_once('@') {
+                            match (
+                                pid_str.trim().parse::<kotoba_net::PeerId>(),
+                                addr_str.trim().parse::<kotoba_net::Multiaddr>(),
+                            ) {
+                                (Ok(peer_id), Ok(addr)) => {
+                                    swarm.add_peer(peer_id, addr.clone());
+                                    match swarm.reserve_relay_with_peer(peer_id, addr.clone()) {
+                                        Ok(()) => tracing::info!(
+                                            %peer_id, %addr,
+                                            "reserving Circuit Relay v2 slot"
+                                        ),
+                                        Err(e) => tracing::warn!(
+                                            %peer_id, %addr,
+                                            "relay reservation failed: {e}"
+                                        ),
+                                    }
+                                }
+                                (Err(e), _) => tracing::warn!("invalid relay peer_id: {e}"),
+                                (_, Err(e)) => tracing::warn!("invalid relay multiaddr: {e}"),
+                            }
+                        }
                     }
                 }
 

--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -1351,7 +1351,17 @@ pub async fn run() -> anyhow::Result<()> {
             .unwrap_or(0);
         let listen_addr = kotoba_net::quic_addr(listen_port);
 
-        match KotobaSwarm::new(listen_addr).await {
+        // A node with the `relay` role is a designated public helper: it bridges
+        // the firehose gossip AND runs the libp2p Circuit Relay v2 server so NAT'd
+        // (donated/edge) peers can reach the mesh through it. AutoNAT + DCUtR +
+        // relay-client are always on, so edge nodes need no extra config.
+        let relay_server = state
+            .node_roles
+            .iter()
+            .any(|r| matches!(r, server::NodeRole::Relay));
+        let nat_cfg = kotoba_net::NatConfig { relay_server };
+
+        match KotobaSwarm::new_with_config(listen_addr, nat_cfg).await {
             Ok(mut swarm) => {
                 if let Ok(peers_str) = std::env::var("KOTOBA_BOOTSTRAP_PEERS") {
                     let mut bootstrapped = false;
@@ -1387,10 +1397,9 @@ pub async fn run() -> anyhow::Result<()> {
                 let journal_arc = Arc::clone(&state.journal);
                 let block_store_arc = Arc::clone(&state.block_store);
                 let quad_store_arc = Arc::clone(&state.quad_store);
-                let relay = state
-                    .node_roles
-                    .iter()
-                    .any(|r| matches!(r, server::NodeRole::Relay));
+                // Same `relay` role drives both the firehose bridge and the
+                // libp2p relay server (computed above as `relay_server`).
+                let relay = relay_server;
 
                 tokio::spawn(net_actor::run(
                     swarm,


### PR DESCRIPTION
## What

Fills the public-internet **NAT-traversal gap** in `kotoba-net` so donated/edge nodes (e7m, kotoba pod behind home NAT) can join the libp2p mesh — the function a **WireGuard/Tailscale** overlay would provide, implemented **entirely over libp2p 0.53** (no vendored VPN code, no central coordination server).

A relay is just another peer; discovery stays on **Kademlia**, so the *no-central-master* invariant holds (clean-room architecture, ADR-2605240001).

## How

**`kotoba-net`**
- `KotobaBehaviour` gains `autonat` (reachability detection), `relay_client` (Circuit Relay v2 — DERP-equivalent fallback), `dcutr` (hole punching), and `relay_server` (`Toggle`, off by default — only public nodes enable it).
- Builder uses `.with_dns()?.with_relay_client(noise, yamux)?` so relayed connections reuse the base QUIC transport's Noise+Yamux upgrades and public relays can be addressed by `/dns4/host/...`.
- New API: `NatConfig`, `with_config` / `new_with_config`, `reserve_relay` / `reserve_relay_with_peer`, `dial_via_relay`, `add_external_address`, `ed25519_keypair_from_hex`; events `NatStatusChanged`, `DirectConnectionUpgraded`, `RelayReservationAccepted` (existing `_ => {}` catch-all keeps consumers unchanged).

**`kotoba-server`**
- `KOTOBA_NODE_ROLES=relay` now also runs the libp2p Circuit Relay v2 **server** (public helper node).
- `KOTOBA_P2P_ED25519_HEX` pins a **persistent PeerId** across restarts (separate from the CACAO/DID agent key by design; absent/invalid → ephemeral as before).
- `KOTOBA_RELAY_PEERS` (`peerid@multiaddr`, comma-separated) → edge nodes take a relay reservation at startup; DCUtR then upgrades to a direct link. **Edge/donated nodes need only this env to join over NAT.**

## Invariants preserved

- No central master — relays are peers, discovery on Kademlia.
- No vendored WireGuard/Tailscale code; libp2p (Apache/MIT) only.
- Networking identity kept separate from the CACAO/DID signing identity.

## Honest R0 / follow-ups

- Automatic relay **discovery** from the DHT (currently relays are configured via `KOTOBA_RELAY_PEERS`).
- Advertising a public relay node's reachable address to the mesh.

## Tests

- `kotoba-net`: **69 unit + 2 integration green**, clippy clean.
- `kotoba-server`: builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)