### PR TITLE
docs: latest architecture SVG + README prune (CommitDag-as-WAL, kotoba-as-own-pinner)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,43 +137,50 @@ exactly how to silence or fix it.
 
 ## Architecture
 
-How a write becomes content-addressed blocks, how a read serves from the hot
-arrangement or the cold ProllyTree, and how the Datom log is tiered across
-memory → IPFS → off-host B2:
+The canonical spine is one content-addressed chain — **Datom log → ProllyTree
+indexes → CommitDag → blocks** — with IPFS and B2 as export tiers, not the
+system of record:
 
 ![kotoba Datomic-over-IPFS architecture](docs/kotoba-datomic-architecture.svg)
 
-**① Insert** — `kg.ingest`/`transact` → `QuadStore::assert_datom`
-(`kotoba-graph/src/quad_store.rs`) updates the hot **Arrangement** (4 in-memory
-indexes EAVT/AEVT/AVET/VAET, `kotoba-kqe`) and records the exact 5-tuple
-`Datom{e,a,v,t,added}` in `pending_datoms`; the **Journal** WAL
-(`kotoba-kse/src/journal.rs`) appends a Merkle-chained `JournalEntry{seq,cid,prev}`
-to the block store for crash recovery.
+**① Canonical write path** — `kg.ingest`/`transact` →
+`QuadStore::assert_datom` (`kotoba-graph/src/quad_store.rs`) records the exact
+5-tuple `Datom{e,a,v,t,added}` in `pending_datoms`; a short window later
+`commit()` builds the EAVT/AEVT/AVET/VAET (+ `datom_*` + append-only **TEA**)
+**ProllyTrees** (`kotoba-core/src/prolly.rs`) — probabilistic chunking
+(`blake3(key)&0xFF==0`) + path-copy so each commit writes only the delta; nodes
+are **DAG-CBOR/IPLD** (`Internal [(k, child-CID)]` tag-42 links) addressed by
+`sha2-256(dag-cbor) → CIDv1`. Blocks pack into one **CARv1** bundle and a
+`Commit{root,index_roots,prev,seq}` block is appended to the **CommitDag**.
+**The CommitDag is the write-ahead log** — an immutable, parent-linked,
+content-addressed chain whose durability boundary is the atomic head-ref update
+(git / Datomic semantics); restart loads the head + checkpoint and walks commits
+since, no second-log replay.
+> Pruned (per [ADR-2606041151](../../90-docs/adr/2606041151-kotoba-commitdag-as-wal-and-incremental-query-tier.md)):
+> the old per-assert **Journal WAL** (4-topic double-write) and **Kubo-as-durable-tier**
+> — the CommitDag already is the WAL; the Journal was a redundant double-write and the
+> ~30 s startup-replay bottleneck.
 
-**③ Commit** — `QuadStore::commit()` builds the EAVT/AEVT/AVET/VAET (+ `datom_*`
-+ append-only TEA) **ProllyTrees** in parallel (`kotoba-core/src/prolly.rs`):
-probabilistic chunking (`blake3(key)&0xFF==0`, ~1/256) + path-copy so each commit
-writes only the delta. Nodes are **DAG-CBOR/IPLD** (`Leaf [(k,v)]` /
-`Internal [(k, child-CID)]` with tag-42 CID links), each addressed by
-`sha2-256(dag-cbor) → CIDv1`. All blocks pack into one **CARv1** bundle; a
-`Commit{root,index_roots,prev,author,seq}` block (CID = `blake3(cbor)`) is added
-to the **CommitDag** heads, and `committed_seq` is checkpointed so restart
-replays the delta only.
+**② Query — Datomic first-tier** — the 4-index model is tier-1: BGP routing does
+direct index scans (EAVT point lookup ~180 ns, AVET, VAET reverse) over the
+ProllyTree, and an incremental **MaterializedView** (`kotoba-kqe/src/mv.rs`,
+maintained per commit Δ) serves recurring/Datalog queries without re-evaluating
+from scratch. `kg.sparql` (SELECT/ASK/DESCRIBE/CONSTRUCT/UPDATE/SERVICE) is the
+auxiliary RDF surface over the same indexes; `db_before`/TEA give Datomic-style
+`as-of` time travel. All queries run over the IPFS-backed substrate — the hot
+Arrangement is only an optimisation (cache).
 
-**④ Block store** — `TieredBlockStore<BudgetedMemory, KuboIpfs>`
-(`kotoba-store`): a HOT LRU memory tier (µs) over a COLD **Kubo IPFS** tier
-(`/api/v0/block`, multihash-keyed, flatfs repo). `put_many_durable` writes hot
-synchronously and batches cold. An **off-host cold pin to Backblaze B2**
-(`50-infra/kotoba-b2-pin`, DataLad + git-annex S3) mirrors every block for
-disaster recovery — `restore` re-imports via `ipfs block put`.
+**③ Block store — kotoba is its own IPFS block store + pinner** — the durable hot
+tier is an embedded, in-process store (direct disk, µs–ms) and kotoba holds pins
+itself (a flag in its own store, no `pin/add` RPC), removing the HTTP-RPC hop
+(~35× ingest). Sealed commits **export asynchronously**, off the hot path:
+**Kubo IPFS** (bitswap + DHT; optionally a networked pin service for the donated
+mesh) and an **off-host cold pin to Backblaze B2**
+(`50-infra/kotoba-b2-pin`, DataLad + git-annex S3 — mirrors every block,
+`restore` re-imports via `ipfs block put`,
+[ADR-2606041130](../../90-docs/adr/2606041130-kotoba-b2-blockstore-cold-pin.md)).
 
-**② Query** — `kg.query`/`kg.sparql` compile (SPARQL/Cypher/SQL) to a
-`DatalogProgram` evaluated **semi-naive** over the hot Arrangement (µs–ms); the
-cold path scans the ProllyTree (`scan_prefix`, index-selected EAVT/AEVT/AVET/VAET)
-fetching blocks from the tiered store, with `db_before`/TEA giving Datomic-style
-`as-of` time travel.
-
-**⑤ Anchors** — the **Datom log is the canonical state**
+**④ Anchors** — the **Datom log is the canonical state**
 ([ADR-2605312345](../../90-docs/adr/2605312345-kotoba-datom-first-class-canonical-state.md));
 IPNS signed heads pin per-graph roots (durable across restart), Base L2 anchors
 the commit-DAG root for tamper-evidence, and AT-Proto MST is the ingress/interop

--- a/docs/kotoba-datomic-architecture.svg
+++ b/docs/kotoba-datomic-architecture.svg
@@ -1,219 +1,147 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1300 1000" font-family="-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1300 900" font-family="-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif">
   <defs>
-    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0 0 L10 5 L0 10 z" fill="#475569"/>
-    </marker>
-    <marker id="arrW" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0 0 L10 5 L0 10 z" fill="#2563eb"/>
-    </marker>
-    <marker id="arrR" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M0 0 L10 5 L0 10 z" fill="#16a34a"/>
-    </marker>
+    <marker id="a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#475569"/></marker>
+    <marker id="ag" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#15803d"/></marker>
+    <marker id="ap" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#7c3aed"/></marker>
+    <marker id="ac" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0 0 L10 5 L0 10 z" fill="#0e7490"/></marker>
     <style>
-      .t  { font-size:13px; fill:#0f172a; }
-      .s  { font-size:11px; fill:#475569; }
-      .mono { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:10.5px; fill:#334155; }
-      .h  { font-size:13px; font-weight:700; }
-      .lane { font-size:12px; font-weight:700; letter-spacing:.06em; }
-      .box { rx:8; }
-      .ew { stroke:#2563eb; }       /* write edges */
-      .er { stroke:#16a34a; }       /* read edges  */
-      .e  { stroke:#475569; }       /* neutral     */
+      .t{font-size:13px;fill:#0f172a}.s{font-size:11px;fill:#475569}
+      .mono{font-family:ui-monospace,Menlo,monospace;font-size:10.5px;fill:#334155}
+      .h{font-size:14px;font-weight:700}.lane{font-size:12px;font-weight:700;letter-spacing:.05em}
+      .badge{font-size:9.5px;font-weight:700}
     </style>
   </defs>
 
-  <!-- title -->
   <text x="650" y="30" text-anchor="middle" font-size="20" font-weight="700" fill="#0f172a">kotoba — Datomic-over-IPFS storage engine</text>
-  <text x="650" y="50" text-anchor="middle" class="s">Datom log (canonical) · EAVT/AEVT/AVET/VAET ProllyTree indexes · DAG-CBOR/IPLD blocks · tiered IPFS + B2 cold pin</text>
+  <text x="650" y="50" text-anchor="middle" class="s">canonical spine = Datom log → ProllyTree (EAVT/AEVT/AVET/VAET) → CommitDag (the WAL) → kotoba's own block store · async export to IPFS + B2</text>
 
-  <!-- ===================== CLIENTS ===================== -->
-  <rect x="70"  y="72" width="500" height="56" rx="8" fill="#eff6ff" stroke="#2563eb"/>
-  <text x="86" y="92" class="h" fill="#1d4ed8">WRITE / INSERT API  ·  kotoba-server/src/kg.rs</text>
-  <text x="86" y="112" class="mono">kg.ingest · kg.ingest_batch · transact · quad.put  →  Datom{e,a,v,t,added}</text>
+  <!-- ===== CLIENTS ===== -->
+  <rect x="70"  y="72" width="500" height="52" rx="8" fill="#f0fdf4" stroke="#16a34a"/>
+  <text x="86" y="92" class="h" fill="#15803d">WRITE  ·  kg.ingest / transact / quad.put</text>
+  <text x="86" y="111" class="mono">→ Datom{e,a,v,t,added}</text>
+  <rect x="730" y="72" width="500" height="52" rx="8" fill="#faf5ff" stroke="#7c3aed"/>
+  <text x="746" y="92" class="h" fill="#6d28d9">READ  ·  kg.query / kg.sparql / cypher</text>
+  <text x="746" y="111" class="mono">CACAO quad:read gate</text>
 
-  <rect x="730" y="72" width="500" height="56" rx="8" fill="#f0fdf4" stroke="#16a34a"/>
-  <text x="746" y="92" class="h" fill="#15803d">READ / QUERY API  ·  kotoba-server/src/kg.rs</text>
-  <text x="746" y="112" class="mono">kg.query · kg.sparql · cypher · SQL dialects   (CACAO quad:read gate)</text>
+  <!-- ===== ① CANONICAL WRITE SPINE ===== -->
+  <rect x="40" y="150" width="690" height="300" rx="12" fill="#f0fdf4" stroke="#16a34a"/>
+  <text x="60" y="174" class="lane" fill="#15803d">① CANONICAL WRITE PATH — content-addressed, reconstructible</text>
 
-  <!-- ===================== INSERT PATH ===================== -->
-  <rect x="70" y="160" width="500" height="150" rx="10" fill="#ffffff" stroke="#2563eb" stroke-dasharray="3 3"/>
-  <text x="86" y="180" class="lane" fill="#1d4ed8">① INSERT PATH</text>
+  <rect x="60" y="188" width="300" height="74" rx="8" fill="#ffffff" stroke="#16a34a"/>
+  <text x="74" y="208" class="h">Datom + micro-batch commit</text>
+  <text x="74" y="226" class="mono">assert → pending_datoms (in-flight)</text>
+  <text x="74" y="241" class="s">short window → commit(): no separate</text>
+  <text x="74" y="254" class="s">durable WAL — the commit IS the log</text>
 
-  <rect x="86" y="192" width="468" height="34" rx="7" fill="#eff6ff" stroke="#93c5fd"/>
-  <text x="98" y="206" class="t">QuadStore.assert_datom</text>
-  <text x="98" y="220" class="mono">kotoba-graph/src/quad_store.rs · updates hot Arrangement + pending_datoms</text>
+  <rect x="380" y="188" width="330" height="74" rx="8" fill="#ffffff" stroke="#16a34a"/>
+  <text x="394" y="208" class="h">ProllyTree indexes (4 + TEA)</text>
+  <text x="394" y="226" class="mono">EAVT·AEVT·AVET·VAET  DAG-CBOR/IPLD</text>
+  <text x="394" y="241" class="s">probabilistic chunk + path-copy delta;</text>
+  <text x="394" y="254" class="mono">node CID = sha2-256(dag-cbor), tag-42 links</text>
 
-  <rect x="86" y="232" width="230" height="68" rx="7" fill="#eff6ff" stroke="#93c5fd"/>
-  <text x="98" y="250" class="t">Hot Arrangement (in-mem)</text>
-  <text x="98" y="266" class="mono">kotoba-kqe/arrangement.rs</text>
-  <text x="98" y="280" class="mono">spo·pso·pos·ocp  =</text>
-  <text x="98" y="293" class="mono">EAVT·AEVT·AVET·VAET</text>
+  <rect x="60" y="280" width="300" height="74" rx="8" fill="#ffffff" stroke="#16a34a" stroke-width="2"/>
+  <text x="74" y="300" class="h" fill="#15803d">CommitDag = the WAL</text>
+  <text x="74" y="318" class="mono">Commit{root,index_roots,prev,seq}</text>
+  <text x="74" y="333" class="s">immutable · parent-linked · durability =</text>
+  <text x="74" y="346" class="s">atomic head-ref (git / Datomic semantics)</text>
 
-  <rect x="324" y="232" width="230" height="68" rx="7" fill="#eef2ff" stroke="#a5b4fc"/>
-  <text x="336" y="250" class="t">Journal · WAL (Merkle)</text>
-  <text x="336" y="266" class="mono">kotoba-kse/src/journal.rs</text>
-  <text x="336" y="280" class="mono">JournalEntry{seq,cid,prev}</text>
-  <text x="336" y="293" class="mono">→ BlockStore.put (durable)</text>
+  <rect x="380" y="280" width="330" height="74" rx="8" fill="#ffffff" stroke="#16a34a"/>
+  <text x="394" y="300" class="h">CAR bundle + checkpoint</text>
+  <text x="394" y="318" class="mono">car_bundle.rs · one streaming PUT</text>
+  <text x="394" y="333" class="s">checkpoint(committed_seq) → restart loads</text>
+  <text x="394" y="346" class="s">the head + walks commits since (no replay)</text>
 
-  <!-- ===================== QUERY PATH ===================== -->
-  <rect x="730" y="160" width="500" height="150" rx="10" fill="#ffffff" stroke="#16a34a" stroke-dasharray="3 3"/>
-  <text x="746" y="180" class="lane" fill="#15803d">② QUERY PATH</text>
+  <!-- pruned note -->
+  <rect x="60" y="372" width="650" height="62" rx="8" fill="#fff7ed" stroke="#fb923c" stroke-dasharray="5 4"/>
+  <text x="74" y="392" class="t" fill="#c2410c">PRUNED — Journal WAL (per-assert 4-topic double-write) &amp; Kubo-as-durable-tier</text>
+  <text x="74" y="409" class="s">the CommitDag already is a write-ahead log; the separate Journal WAL was a redundant double-write +</text>
+  <text x="74" y="423" class="s">the ~30 s Kubo-HTTP replay bottleneck. Demoted to an optional in-flight scratch / removed. (ADR-2606041151)</text>
 
-  <rect x="746" y="192" width="468" height="34" rx="7" fill="#f0fdf4" stroke="#86efac"/>
-  <text x="758" y="206" class="t">Compile → DatalogProgram</text>
-  <text x="758" y="220" class="mono">SparqlCompiler / CypherCompiler / SQL dialect  →  kotoba-kqe</text>
+  <path d="M360 225 L380 225" stroke="#15803d" stroke-width="2" fill="none" marker-end="url(#ag)"/>
+  <path d="M210 262 L210 280" stroke="#15803d" stroke-width="2" fill="none" marker-end="url(#ag)"/>
+  <path d="M360 317 L380 317" stroke="#15803d" stroke-width="2" fill="none" marker-end="url(#ag)"/>
 
-  <rect x="746" y="232" width="230" height="68" rx="7" fill="#f0fdf4" stroke="#86efac"/>
-  <text x="758" y="250" class="t">Hot eval (semi-naive)</text>
-  <text x="758" y="266" class="mono">evaluate_delta() over the</text>
-  <text x="758" y="280" class="mono">hot Arrangement — µs–ms</text>
-  <text x="758" y="293" class="mono">current_graph_deltas()</text>
+  <!-- ===== ② QUERY TIERS ===== -->
+  <rect x="760" y="150" width="470" height="300" rx="12" fill="#faf5ff" stroke="#7c3aed"/>
+  <text x="780" y="174" class="lane" fill="#6d28d9">② QUERY — Datomic first-tier</text>
 
-  <rect x="984" y="232" width="230" height="68" rx="7" fill="#f0fdf4" stroke="#86efac"/>
-  <text x="996" y="250" class="t">Cold scan + as-of</text>
-  <text x="996" y="266" class="mono">ProllyTree.scan_prefix()</text>
-  <text x="996" y="280" class="mono">index select EAVT/AEVT/…</text>
-  <text x="996" y="293" class="mono">db_before · TEA history</text>
+  <rect x="780" y="188" width="430" height="70" rx="8" fill="#ffffff" stroke="#16a34a"/>
+  <circle cx="800" cy="210" r="10" fill="#16a34a"/><text x="800" y="214" text-anchor="middle" fill="#fff" class="badge">1</text>
+  <text x="818" y="208" class="h">Datomic index scan + MaterializedView</text>
+  <text x="794" y="226" class="mono">EAVT 180ns · AVET · VAET · BGP routing</text>
+  <text x="794" y="241" class="s">+ incremental MV (IVM) maintained per commit Δ</text>
+  <text x="794" y="252" class="badge" fill="#2563eb">mv.rs — wire into server (ADR-2606041151 B)</text>
 
-  <!-- ===================== COMMIT ENGINE ===================== -->
-  <rect x="70" y="350" width="1160" height="210" rx="12" fill="#faf5ff" stroke="#7c3aed"/>
-  <text x="90" y="372" class="lane" fill="#6d28d9">③ COMMIT ENGINE  ·  QuadStore.commit()  ·  kotoba-graph/src/quad_store.rs</text>
+  <rect x="780" y="268" width="430" height="60" rx="8" fill="#ffffff" stroke="#a78bfa"/>
+  <circle cx="800" cy="290" r="10" fill="#a78bfa"/><text x="800" y="294" text-anchor="middle" fill="#fff" class="badge">2</text>
+  <text x="818" y="288" class="h">SPARQL-BGP cold scan (auxiliary)</text>
+  <text x="794" y="306" class="mono">kg.sparql → ProllyTree scan_prefix</text>
+  <text x="794" y="320" class="s">SELECT/ASK/DESCRIBE/CONSTRUCT/UPDATE/SERVICE</text>
 
-  <rect x="90" y="386" width="270" height="158" rx="8" fill="#ffffff" stroke="#a78bfa"/>
-  <text x="104" y="406" class="h">ProllyTree builder</text>
-  <text x="104" y="424" class="mono">kotoba-core/src/prolly.rs</text>
-  <text x="104" y="442" class="s">parallel build / apply_batch:</text>
-  <text x="104" y="458" class="mono">EAVT · AEVT · AVET · VAET</text>
-  <text x="104" y="472" class="mono">+ datom_eavt/aevt/avet</text>
-  <text x="104" y="486" class="mono">+ TEA (append-only ledger)</text>
-  <text x="104" y="506" class="s">probabilistic chunking</text>
-  <text x="104" y="520" class="mono">blake3(key)&amp;0xFF==0 (~1/256)</text>
-  <text x="104" y="534" class="s">path-copy = delta-sized writes</text>
+  <rect x="780" y="338" width="430" height="60" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="794" y="358" class="h">as-of / time-travel</text>
+  <text x="794" y="376" class="mono">db_before · TEA append-only history</text>
+  <text x="794" y="390" class="s">非終末論 — every state addressable by commit</text>
 
-  <rect x="378" y="386" width="270" height="158" rx="8" fill="#ffffff" stroke="#a78bfa"/>
-  <text x="392" y="406" class="h">DAG-CBOR / IPLD node</text>
-  <text x="392" y="424" class="mono">ProllyNode{Leaf|Internal}</text>
-  <text x="392" y="442" class="s">Leaf: [(key,value)] bytes</text>
-  <text x="392" y="456" class="s">Internal: [(key, child CID)]</text>
-  <text x="392" y="470" class="mono">child links = IPLD tag-42 CID</text>
-  <text x="392" y="490" class="s">node CID:</text>
-  <text x="392" y="504" class="mono">sha2-256(dag-cbor) → CIDv1</text>
-  <text x="392" y="518" class="mono">codec 0x71 (dag-cbor)</text>
-  <text x="392" y="534" class="s">content-addressed, immutable</text>
+  <rect x="780" y="408" width="430" height="30" rx="7" fill="#faf5ff" stroke="#7c3aed" stroke-dasharray="4 3"/>
+  <text x="794" y="427" class="s" fill="#6d28d9">all queries run over the IPFS-backed substrate; the hot Arrangement is only an optimisation (cache)</text>
 
-  <rect x="666" y="386" width="270" height="158" rx="8" fill="#ffffff" stroke="#a78bfa"/>
-  <text x="680" y="406" class="h">Commit + CAR bundle</text>
-  <text x="680" y="424" class="mono">kotoba-graph/src/commit.rs</text>
-  <text x="680" y="444" class="mono">Commit{graph,tx_cid,root,</text>
-  <text x="680" y="458" class="mono">  prev,author,seq,index_roots}</text>
-  <text x="680" y="478" class="s">all tree blocks →</text>
-  <text x="680" y="492" class="mono">CARv1 (car_bundle.rs)</text>
-  <text x="680" y="512" class="s">one streaming durable PUT</text>
-  <text x="680" y="528" class="mono">commit CID = blake3(cbor)</text>
+  <path d="M980 124 L980 150" stroke="#7c3aed" stroke-width="2" fill="none" marker-end="url(#ap)"/>
+  <path d="M300 124 L210 188" stroke="#15803d" stroke-width="2" fill="none" marker-end="url(#ag)"/>
 
-  <rect x="954" y="386" width="262" height="158" rx="8" fill="#ffffff" stroke="#a78bfa"/>
-  <text x="968" y="406" class="h">CommitDag + checkpoint</text>
-  <text x="968" y="424" class="mono">CommitDag{commits,heads}</text>
-  <text x="968" y="444" class="s">Merkle chain via prev →</text>
-  <text x="968" y="458" class="s">full lineage / commits_since</text>
-  <text x="968" y="478" class="mono">committed_seq → journal</text>
-  <text x="968" y="492" class="s">checkpoint (survives restart:</text>
-  <text x="968" y="506" class="mono">replay delta only)</text>
-  <text x="968" y="528" class="s">head = per-graph root commit</text>
+  <!-- ===== ③ STORAGE: kotoba's own block store + async export ===== -->
+  <rect x="40" y="468" width="1190" height="180" rx="12" fill="#fff7ed" stroke="#ea580c"/>
+  <text x="60" y="492" class="lane" fill="#c2410c">③ BLOCK STORE — kotoba is its own IPFS block store + pinner (ADR-2606041151 A)</text>
 
-  <!-- ===================== STORAGE TIERS ===================== -->
-  <rect x="70" y="600" width="1160" height="170" rx="12" fill="#fff7ed" stroke="#ea580c"/>
-  <text x="90" y="622" class="lane" fill="#c2410c">④ BLOCK STORE  ·  TieredBlockStore&lt;BudgetedMemory, KuboIpfs&gt;  ·  kotoba-store/src/tiered_store.rs</text>
+  <rect x="60" y="506" width="430" height="124" rx="8" fill="#eff6ff" stroke="#2563eb" stroke-width="2"/>
+  <text x="74" y="526" class="h" fill="#1d4ed8">Embedded local block store + pinner</text>
+  <text x="74" y="544" class="mono">in-process flatfs/sled/redb (direct disk, µs–ms)</text>
+  <text x="74" y="560" class="s">durable hot tier — NOT Kubo-over-HTTP</text>
+  <text x="74" y="576" class="s">pin = a flag in kotoba's own store (no pin/add RPC)</text>
+  <text x="74" y="596" class="s">removes the HTTP hop: ~35× ingest (142→5222 ent/s)</text>
+  <text x="74" y="610" class="s">+ ~30 s WAL replay. BudgetedBlockStore LRU over it.</text>
+  <text x="74" y="624" class="badge" fill="#2563eb">re-introduce embedded store (sled removed 2026-05-26)</text>
 
-  <rect x="90" y="636" width="300" height="120" rx="8" fill="#ffffff" stroke="#fdba74"/>
-  <text x="104" y="656" class="h">HOT tier</text>
-  <text x="104" y="674" class="mono">BudgetedBlockStore&lt;Memory&gt;</text>
-  <text x="104" y="690" class="s">LRU, byte-budget, µs latency</text>
-  <text x="104" y="710" class="s">serves query hits; misses</text>
-  <text x="104" y="724" class="s">promoted from cold on read</text>
-  <text x="104" y="744" class="mono">put_many_durable (batch)</text>
+  <rect x="510" y="506" width="350" height="124" rx="8" fill="#ffffff" stroke="#64748b"/>
+  <text x="524" y="526" class="h">Async export — sealed commits only</text>
+  <text x="524" y="544" class="mono">Kubo IPFS (network: bitswap + DHT)</text>
+  <text x="524" y="560" class="s">off the hot write path</text>
+  <text x="524" y="580" class="s">→ kotoba as a networked pin SERVICE for peers</text>
+  <text x="524" y="594" class="s">  = live multi-copy via the donated mesh</text>
+  <text x="524" y="608" class="badge" fill="#0e7490">situational, mesh-gated (ADR-2606041151 C / 2606012100)</text>
 
-  <rect x="410" y="636" width="360" height="120" rx="8" fill="#ffffff" stroke="#fdba74"/>
-  <text x="424" y="656" class="h">COLD tier — IPFS (Kubo)</text>
-  <text x="424" y="674" class="mono">KuboBlockStore · kubo_store.rs</text>
-  <text x="424" y="690" class="mono">/api/v0/block/{put,get} · pin/add</text>
-  <text x="424" y="706" class="s">CIDv1 sha2-256 · dag-cbor/raw</text>
-  <text x="424" y="722" class="s">flatfs repo on external volume</text>
-  <text x="424" y="742" class="mono">IPFS network · multihash-keyed</text>
+  <rect x="880" y="506" width="350" height="124" rx="8" fill="#ecfeff" stroke="#06b6d4"/>
+  <text x="894" y="526" class="h" fill="#0e7490">Backblaze B2 — off-host cold pin</text>
+  <text x="894" y="544" class="mono">50-infra/kotoba-b2-pin (DataLad + git-annex S3)</text>
+  <text x="894" y="562" class="s">mirrors every block, drop-after-copy (no 3rd copy)</text>
+  <text x="894" y="578" class="mono">restore: annex get → ipfs block put</text>
+  <text x="894" y="594" class="s">creds from 1Password at runtime (embedcreds=no)</text>
+  <text x="894" y="610" class="badge" fill="#0e7490">ADR-2606041130 · one of several replication targets</text>
 
-  <rect x="790" y="636" width="426" height="120" rx="8" fill="#ecfeff" stroke="#06b6d4"/>
-  <text x="804" y="656" class="h" fill="#0e7490">OFF-HOST cold pin — Backblaze B2  <tspan fill="#06b6d4" font-size="10">NEW</tspan></text>
-  <text x="804" y="674" class="mono">50-infra/kotoba-b2-pin (DataLad + git-annex S3)</text>
-  <text x="804" y="690" class="s">mirrors every local block (ipfs refs local)</text>
-  <text x="804" y="706" class="s">incremental · drop-after-copy (no 3rd local copy)</text>
-  <text x="804" y="722" class="mono">restore: annex get → ipfs block put</text>
-  <text x="804" y="742" class="s">creds from 1Password at runtime (embedcreds=no)</text>
+  <path d="M385 434 C385 470 275 470 275 506" stroke="#16a34a" stroke-width="2" fill="none" marker-end="url(#a)"/>
+  <text x="300" y="462" class="s" fill="#15803d">commit blocks persisted</text>
+  <path d="M490 568 L510 568" stroke="#64748b" stroke-width="2" fill="none" marker-end="url(#a)" stroke-dasharray="4 3"/>
+  <path d="M490 590 C620 660 760 660 880 600" stroke="#06b6d4" stroke-width="2" fill="none" marker-end="url(#ac)" stroke-dasharray="5 4"/>
 
-  <!-- ===================== ANCHORS ===================== -->
-  <rect x="70" y="810" width="1160" height="120" rx="12" fill="#f8fafc" stroke="#64748b"/>
-  <text x="90" y="832" class="lane" fill="#334155">⑤ CANONICAL STATE &amp; TRUST ANCHORS</text>
+  <!-- ===== ④ ANCHORS ===== -->
+  <rect x="40" y="666" width="1190" height="106" rx="12" fill="#f8fafc" stroke="#64748b"/>
+  <text x="60" y="690" class="lane" fill="#334155">④ CANONICAL STATE &amp; TRUST ANCHORS</text>
 
-  <rect x="90" y="846" width="270" height="68" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
-  <text x="104" y="866" class="t">Datom log = canonical</text>
-  <text x="104" y="882" class="mono">(E,A,V,T,Added) first-class</text>
-  <text x="104" y="898" class="s">ADR-2605312345 · 非終末論 as-of</text>
+  <rect x="60" y="702" width="270" height="56" rx="8" fill="#ffffff" stroke="#16a34a"/>
+  <text x="74" y="722" class="t" fill="#15803d">Datom log = canonical</text>
+  <text x="74" y="740" class="s">(E,A,V,T,Added) · ADR-2605312345</text>
 
-  <rect x="378" y="846" width="270" height="68" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
-  <text x="392" y="866" class="t">IPNS signed heads</text>
-  <text x="392" y="882" class="mono">graph root ← ed25519 / DID</text>
-  <text x="392" y="898" class="s">disk-persistent, durable restart</text>
+  <rect x="350" y="702" width="270" height="56" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="364" y="722" class="t">IPNS signed heads</text>
+  <text x="364" y="740" class="s">per-graph root, durable across restart</text>
 
-  <rect x="666" y="846" width="270" height="68" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
-  <text x="680" y="866" class="t">Base L2 trust anchor</text>
-  <text x="680" y="882" class="s">commit-DAG root anchored on-chain</text>
-  <text x="680" y="898" class="s">tamper-evident lineage</text>
+  <rect x="640" y="702" width="270" height="56" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="654" y="722" class="t">Base L2 trust anchor</text>
+  <text x="654" y="740" class="s">commit-DAG root, tamper-evident</text>
 
-  <rect x="954" y="846" width="262" height="68" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
-  <text x="968" y="866" class="t">AT-Proto MST</text>
-  <text x="968" y="882" class="s">ingress / interop wire</text>
-  <text x="968" y="898" class="s">materializes the Datom log</text>
+  <rect x="930" y="702" width="300" height="56" rx="8" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="944" y="722" class="t">AT-Proto MST</text>
+  <text x="944" y="740" class="s">ingress / interop wire (materializes the log)</text>
 
-  <!-- ===================== ARROWS ===================== -->
-  <!-- clients to paths -->
-  <path d="M320 128 L320 160" class="ew" stroke-width="2" fill="none" marker-end="url(#arrW)"/>
-  <path d="M980 128 L980 160" class="er" stroke-width="2" fill="none" marker-end="url(#arrR)"/>
-
-  <!-- insert internal -->
-  <path d="M320 226 L201 232" class="ew" stroke-width="1.5" fill="none" marker-end="url(#arrW)"/>
-  <path d="M320 226 L439 232" class="ew" stroke-width="1.5" fill="none" marker-end="url(#arrW)"/>
-
-  <!-- query internal -->
-  <path d="M980 226 L861 232" class="er" stroke-width="1.5" fill="none" marker-end="url(#arrR)"/>
-  <path d="M980 226 L1099 232" class="er" stroke-width="1.5" fill="none" marker-end="url(#arrR)"/>
-
-  <!-- insert path -> commit engine -->
-  <path d="M320 310 L320 350" class="ew" stroke-width="2" fill="none" marker-end="url(#arrW)"/>
-  <text x="328" y="338" class="s" fill="#1d4ed8">commit()</text>
-
-  <!-- query hot -> arrangement (read uses hot directly; dashed up) -->
-  <path d="M861 300 C861 325 320 300 320 268" class="er" stroke-width="1.3" fill="none" stroke-dasharray="4 3" marker-end="url(#arrR)"/>
-  <text x="560" y="312" class="s" fill="#15803d">read hot Arrangement</text>
-
-  <!-- query cold -> commit engine/prolly -->
-  <path d="M1099 300 L1099 350" class="er" stroke-width="2" fill="none" marker-end="url(#arrR)"/>
-  <text x="1107" y="338" class="s" fill="#15803d">cold scan</text>
-
-  <!-- commit engine internal L->R -->
-  <path d="M360 465 L378 465" class="e" stroke-width="1.5" fill="none" marker-end="url(#arr)"/>
-  <path d="M648 465 L666 465" class="e" stroke-width="1.5" fill="none" marker-end="url(#arr)"/>
-  <path d="M936 465 L954 465" class="e" stroke-width="1.5" fill="none" marker-end="url(#arr)"/>
-
-  <!-- commit engine -> storage -->
-  <path d="M650 560 L650 600" class="e" stroke-width="2" fill="none" marker-end="url(#arr)"/>
-  <text x="658" y="588" class="s">put_many_durable (hot sync + cold async)</text>
-
-  <!-- storage hot<->cold, cold->b2 -->
-  <path d="M390 696 L410 696" class="e" stroke-width="1.5" fill="none" marker-end="url(#arr)"/>
-  <path d="M770 696 L790 696" stroke="#06b6d4" stroke-width="2" fill="none" marker-end="url(#arr)"/>
-  <text x="700" y="620" class="s" fill="#0e7490">refs local → mirror</text>
-
-  <!-- commit dag -> anchors -->
-  <path d="M1085 544 C1085 770 225 770 225 846" class="e" stroke-width="1.3" fill="none" stroke-dasharray="4 3" marker-end="url(#arr)"/>
-  <path d="M1085 544 L513 846" class="e" stroke-width="1.1" fill="none" stroke-dasharray="4 3" marker-end="url(#arr)"/>
-  <path d="M1085 544 L801 846" class="e" stroke-width="1.1" fill="none" stroke-dasharray="4 3" marker-end="url(#arr)"/>
+  <path d="M275 354 L195 666" stroke="#16a34a" stroke-width="1.2" fill="none" stroke-dasharray="4 3"/>
 </svg>


### PR DESCRIPTION
Updates the architecture diagram + README to the latest canonical design and prunes the layers the structural analysis found redundant.

## What
- **`docs/kotoba-datomic-architecture.svg`** redrawn to the latest architecture: canonical spine **Datom log → ProllyTree (EAVT/AEVT/AVET/VAET) → CommitDag (= the WAL) → kotoba's own embedded block store + pinner → async export (Kubo IPFS / B2 cold pin)**; query tier-1 = **Datomic index scan + incremental MaterializedView**.
- **Pruned** (diagram + README): the per-assert **Journal WAL** (4-topic double-write) and **Kubo-as-durable-tier** — the CommitDag already is a write-ahead log; the Journal was a redundant double-write and the ~30 s startup-replay bottleneck.
- **README `## Architecture`** rewritten to match (① canonical write path / ② Datomic first-tier query + MV / ③ kotoba-as-own-blockstore+pinner + async export / ④ anchors).

## Why
Source-grounded analysis: the in-memory Arrangement + Journal WAL are not structurally necessary (the authors' own note: *"in-memory Arrangement is only an optimisation"*); the Datomic Datalog query engine re-evaluates from scratch (`MaterializedView` IVM exists in `kotoba-kqe/src/mv.rs` but is unwired). Design rationale tracked in the etzhayyim/root ADRs:
- **ADR-2606041151** — CommitDag-as-WAL (Journal demotion) + incremental MaterializedView query tier + kotoba-as-networked-pin-service.
- **ADR-2606041130** — off-host cold pin to Backblaze B2 (DataLad + git-annex).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)