### PR TITLE
feat: Decision A/B wiring — FsBlockStore durable tier + MvRegistry

### DIFF
--- a/crates/kotoba-kqe/src/mv.rs
+++ b/crates/kotoba-kqe/src/mv.rs
@@ -26,6 +26,75 @@ impl MaterializedView {
     }
 }
 
+/// `MvRegistry` — named, incrementally-maintained MaterializedViews.
+///
+/// The foundation for serving Datalog queries first-tier (ADR-2606041151 B):
+/// register a program once, feed every commit's Δ through [`maintain`], and read
+/// the accumulated derived facts from [`result`] instead of re-evaluating the
+/// program from scratch on each request (which is what `kg.query` does today).
+///
+/// [`maintain`]: MvRegistry::maintain
+/// [`result`]: MvRegistry::result
+#[derive(Default)]
+pub struct MvRegistry {
+    views: std::collections::HashMap<String, MaterializedView>,
+    /// Accumulated derived (IDB) facts per view, advanced by every `maintain`.
+    results: std::collections::HashMap<String, Arrangement>,
+}
+
+impl MvRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register (or replace) a view by name. Returns `true` when newly added,
+    /// `false` when it replaced an existing view of the same name.
+    pub fn register(&mut self, name: impl Into<String>, program: DatalogProgram) -> bool {
+        let name = name.into();
+        let is_new = !self.views.contains_key(&name);
+        self.views
+            .insert(name.clone(), MaterializedView::new(name.clone(), program));
+        self.results.entry(name).or_insert_with(Arrangement::new);
+        is_new
+    }
+
+    pub fn contains(&self, name: &str) -> bool {
+        self.views.contains_key(name)
+    }
+
+    pub fn names(&self) -> Vec<String> {
+        self.views.keys().cloned().collect()
+    }
+
+    /// Incrementally maintain every registered view with a commit's deltas,
+    /// accumulating each view's derived output into its result arrangement.
+    /// Call once per committed transaction with that transaction's `Delta`s.
+    pub fn maintain(&mut self, deltas: &[Delta]) {
+        let names: Vec<String> = self.views.keys().cloned().collect();
+        for name in names {
+            let derived = self
+                .views
+                .get_mut(&name)
+                .expect("view present")
+                .apply(deltas);
+            self.results
+                .entry(name)
+                .or_insert_with(Arrangement::new)
+                .apply(&derived);
+        }
+    }
+
+    /// The accumulated derived facts of a registered view (the maintained query
+    /// result), or `None` if the view is not registered.
+    pub fn result(&self, name: &str) -> Option<&Arrangement> {
+        self.results.get(name)
+    }
+
+    pub fn view(&self, name: &str) -> Option<&MaterializedView> {
+        self.views.get(name)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -286,5 +355,49 @@ mod tests {
             mv.apply(&[edge_assert(&format!("from{i}"), &format!("to{i}"))]);
             assert_eq!(mv.state.len(), (i as usize) + 1);
         }
+    }
+
+    // ── MvRegistry (ADR-2606041151 B) ─────────────────────────────────────
+
+    fn reachable_prog() -> DatalogProgram {
+        let mut prog = DatalogProgram::new();
+        prog.add_rule(make_rule("reachable", "edge"));
+        prog
+    }
+
+    #[test]
+    fn registry_register_and_query() {
+        let mut reg = MvRegistry::new();
+        assert!(reg.register("reachable", reachable_prog()), "newly added");
+        assert!(reg.contains("reachable"));
+        assert_eq!(reg.names(), vec!["reachable".to_string()]);
+        // re-register same name = replace → false
+        assert!(!reg.register("reachable", reachable_prog()));
+    }
+
+    #[test]
+    fn registry_maintains_incrementally_across_commits() {
+        let mut reg = MvRegistry::new();
+        reg.register("reachable", reachable_prog());
+
+        // commit 1: two edges → two derived reachable facts
+        reg.maintain(&[edge_assert("a", "b"), edge_assert("b", "c")]);
+        assert_eq!(reg.result("reachable").unwrap().len(), 2);
+
+        // commit 2: one more edge → accumulates, no full re-eval
+        reg.maintain(&[edge_assert("c", "d")]);
+        assert_eq!(
+            reg.result("reachable").unwrap().len(),
+            3,
+            "derived facts accumulate across commits (incremental maintenance)"
+        );
+    }
+
+    #[test]
+    fn registry_unknown_view_is_none() {
+        let reg = MvRegistry::new();
+        assert!(reg.result("nope").is_none());
+        assert!(reg.view("nope").is_none());
+        assert!(!reg.contains("nope"));
     }
 }

--- a/crates/kotoba-server/src/server.rs
+++ b/crates/kotoba-server/src/server.rs
@@ -397,7 +397,36 @@ impl KotobaState {
                     v.eq_ignore_ascii_case("off") || v == "0" || v.eq_ignore_ascii_case("false")
                 })
                 .unwrap_or(false);
-            if !ipfs_off {
+            // ADR-2606041151 A — embedded durable local tier. When
+            // KOTOBA_FS_BLOCKS_DIR (or KOTOBA_FS_BLOCKS=1 + KOTOBA_STORE_PATH) is
+            // set, kotoba is its own durable block store + pinner: blocks are
+            // written to local disk directly (no Kubo-over-HTTP round-trip),
+            // the enabler for cheap micro-batch synchronous commit. Kubo / B2
+            // then become async export of sealed commits, off the hot write path.
+            let fs_blocks_dir = std::env::var("KOTOBA_FS_BLOCKS_DIR").ok().or_else(|| {
+                let on = std::env::var("KOTOBA_FS_BLOCKS")
+                    .map(|v| {
+                        v == "1" || v.eq_ignore_ascii_case("on") || v.eq_ignore_ascii_case("true")
+                    })
+                    .unwrap_or(false);
+                if on {
+                    std::env::var("KOTOBA_STORE_PATH")
+                        .ok()
+                        .map(|p| format!("{p}/fsblocks"))
+                } else {
+                    None
+                }
+            });
+            if let Some(dir) = fs_blocks_dir {
+                let fs = kotoba_store::FsBlockStore::open(&dir)?;
+                let tiered = kotoba_store::TieredBlockStore::new(hot, fs);
+                tracing::info!(
+                    hot_cache_mib = hot_cache_bytes / (1024 * 1024),
+                    dir = %dir,
+                    "BlockStore: TieredBlockStore<BudgetedMemory, FsBlockStore> — embedded durable local tier (ADR-2606041151 A); Kubo/B2 = async export"
+                );
+                Arc::new(tiered) as Arc<dyn BlockStore + Send + Sync>
+            } else if !ipfs_off {
                 let cold = kotoba_store::KuboBlockStore::from_env();
                 // F-3: attach the kotobase remote-pin client if configured so
                 // every local recursive pin/add also lands on kotobase.gftd.ai.

--- a/crates/kotoba-store/src/fs_store.rs
+++ b/crates/kotoba-store/src/fs_store.rs
@@ -261,4 +261,26 @@ mod tests {
         assert_eq!(s.all_cids().len(), 1);
         let _ = fs::remove_dir_all(&root);
     }
+
+    #[test]
+    fn tiered_over_fs_is_durable() {
+        use crate::{BudgetedBlockStore, MemoryBlockStore, TieredBlockStore};
+        let root = tmp_root("tiered");
+        let data = b"tiered durable block";
+        let c = KotobaCid::from_bytes(data);
+        {
+            // hot = in-memory cache, durable tier = FsBlockStore (ADR-2606041151 A shape)
+            let hot = BudgetedBlockStore::new(MemoryBlockStore::new(), 1 << 20);
+            let fs = FsBlockStore::open(&root).unwrap();
+            let tiered = TieredBlockStore::new(hot, fs);
+            tiered.put_durable(&c, data).unwrap();
+            assert_eq!(tiered.get(&c).unwrap().unwrap().as_ref(), data);
+        }
+        // a fresh FsBlockStore on the same root sees the block — durability is on
+        // disk, independent of the in-memory cache (no Kubo / no HTTP involved).
+        let fs2 = FsBlockStore::open(&root).unwrap();
+        assert!(fs2.has(&c), "put_durable must land the block on the FS tier");
+        assert_eq!(fs2.get(&c).unwrap().unwrap().as_ref(), data);
+        let _ = fs::remove_dir_all(&root);
+    }
 }


### PR DESCRIPTION
Two reviewable increments toward etzhayyim/root **ADR-2606041151** (canonical-tier hardening). Each is a separate commit.

## A — `feat(server)`: wire FsBlockStore as the durable hot tier
When `KOTOBA_FS_BLOCKS_DIR` (or `KOTOBA_FS_BLOCKS=1` + `KOTOBA_STORE_PATH`) is set, `kotoba serve` builds `TieredBlockStore<BudgetedMemory, FsBlockStore>` — **kotoba is its own durable block store + pinner**, writing blocks to local disk directly with no Kubo-over-HTTP round-trip (the enabler for cheap micro-batch sync commit; Kubo + B2 become async export of sealed commits). Additive and env-gated — the Kubo default is unchanged.
- test `tiered_over_fs_is_durable`: `put_durable` through the tiered store lands on the FS tier and survives a fresh open (durable on disk, no cache / no HTTP).

## B — `feat(kqe)`: MvRegistry — registered, incrementally-maintained MaterializedViews
Foundation for serving Datalog queries **first-tier** instead of from-scratch per request (`kg.query` rebuilds the fact base every call today — 2.1× slower than the auxiliary SPARQL path). `MvRegistry` holds named programs; `maintain(deltas)` advances every view incrementally per committed transaction, accumulating derived facts read via `result(name)`. Wraps the existing `MaterializedView::apply` IVM primitive.
- 3 tests (register/replace/query, incremental accumulation across commits, unknown-view → None).

## Status
`kotoba-store` + `kotoba-kqe` green (incl. 4 new tests); `kotoba-server` builds clean.

## Follow-on (not in this PR)
- A remainder: micro-batch **synchronous commit** + **Journal-WAL demotion/removal** (CommitDag-as-WAL).
- B remainder: register programs from the server + feed each commit's Δ + route `kg.query` to read the maintained MV (hot-path wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)