### PR TITLE
feat(server): KOTOBA_JOURNAL_WAL opt-out — drop the redundant WAL double-write (ADR-2606041151 A)

### DIFF
--- a/crates/kotoba-server/src/server.rs
+++ b/crates/kotoba-server/src/server.rs
@@ -281,6 +281,14 @@ pub struct KotobaState {
     /// Maintained on every kg commit (`commit_kg_datoms`); registered + read via
     /// `kg.mv.register` / `kg.mv.result`.
     pub mv_registry: Arc<tokio::sync::RwLock<kotoba_kqe::mv::MvRegistry>>,
+    // ── Journal WAL (ADR-2606041151 A) ───────────────────────────────────────
+    /// When `false` (`KOTOBA_JOURNAL_WAL=off`), the per-datom Journal WAL
+    /// block-write is skipped on the commit path. The synchronous
+    /// DistributedCommitWriter commit is already durable (ProllyTree + IPNS
+    /// head), so the WAL is a redundant double-write; the hot-arrangement update
+    /// (`apply_journaled_datom`) always runs regardless. Default `true`
+    /// (unchanged behaviour: fast restart via journal replay).
+    pub journal_wal_enabled: bool,
     // ── kotobase Pinning ─────────────────────────────────────────────────────────
     /// Optional kotobase.gftd.ai XRPC pin client (KOTOBA_PIN_TOKEN).
     pub ipfs_pin: Arc<IpfsPinClient>,
@@ -381,6 +389,22 @@ impl KotobaState {
         // Persistence: KuboBlockStore cold tier (Kubo/IPFS HTTP, SHA2-256 dual-CID) if KOTOBA_STORE_PATH is set.
         // All KSE components (Journal, Vault, SecureVault) share the same store.
         let store_path: Option<String> = std::env::var("KOTOBA_STORE_PATH").ok();
+
+        // ADR-2606041151 A — Journal WAL opt-out. Default on (unchanged). When
+        // off, the per-datom WAL double-write is skipped on the commit path; the
+        // synchronous CommitDag commit is already durable.
+        let journal_wal_enabled = !std::env::var("KOTOBA_JOURNAL_WAL")
+            .map(|v| v.eq_ignore_ascii_case("off") || v == "0" || v.eq_ignore_ascii_case("false"))
+            .unwrap_or(false);
+        if !journal_wal_enabled {
+            tracing::warn!(
+                "Journal WAL DISABLED (KOTOBA_JOURNAL_WAL=off) — per-datom WAL \
+                 double-write skipped; durability = synchronous CommitDag commit + \
+                 cold ProllyTree. Restart no longer replays the WAL; rely on \
+                 KOTOBA_DATOMIC_WARM_GRAPHS / cold-path for hot-arrangement warmup \
+                 (ADR-2606041151 A, experimental)"
+            );
+        }
 
         const DEFAULT_HOT_BYTES: usize = 256 * 1024 * 1024; // 256 MiB
         let hot_cache_bytes: usize = std::env::var("KOTOBA_HOT_CACHE_BYTES")
@@ -808,6 +832,7 @@ impl KotobaState {
             mv_registry: Arc::new(tokio::sync::RwLock::new(
                 kotoba_kqe::mv::MvRegistry::new(),
             )),
+            journal_wal_enabled,
             operator_did,
             node_roles,
             identity,

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -2653,25 +2653,27 @@ pub(crate) async fn commit_protocol_datoms(
             ),
         })?;
 
+    // ADR-2606041151 A — the synchronous DistributedCommitWriter commit above is
+    // already durable (ProllyTree + IPNS head), so the per-datom Journal WAL
+    // block-write is a redundant double-write. Kept by default (fast restart via
+    // journal replay); opt out with KOTOBA_JOURNAL_WAL=off to drop the double
+    // write. The hot-arrangement update (`apply_journaled_datom`) ALWAYS runs —
+    // it serves hot reads and is independent of the WAL block-write.
     let mut journal_cids = Vec::with_capacity(datoms.len());
     for datom in &datoms {
-        let quad = datom_to_projection_quad(datom, &graph_cid);
-        let journal_cid = if datom.added {
-            let cid = state.journal_assert(&quad).await;
-            state
-                .quad_store
-                .apply_journaled_datom(graph_cid.clone(), datom_to_projection_kqe(datom))
-                .await;
-            cid
-        } else {
-            let cid = state.journal_retract(&quad).await;
-            state
-                .quad_store
-                .apply_journaled_datom(graph_cid.clone(), datom_to_projection_kqe(datom))
-                .await;
-            cid
-        };
-        journal_cids.push(journal_cid);
+        if state.journal_wal_enabled {
+            let quad = datom_to_projection_quad(datom, &graph_cid);
+            let cid = if datom.added {
+                state.journal_assert(&quad).await
+            } else {
+                state.journal_retract(&quad).await
+            };
+            journal_cids.push(cid);
+        }
+        state
+            .quad_store
+            .apply_journaled_datom(graph_cid.clone(), datom_to_projection_kqe(datom))
+            .await;
     }
 
     let assert_count = datoms.iter().filter(|datom| datom.added).count();


### PR DESCRIPTION
First, **safe** increment of **Decision A** (CommitDag-as-WAL), with the durability rewrite explicitly *not* rushed.

## Key finding
kg ingest is **already a synchronous commit**: `commit_protocol_datoms` seals a `DistributedCommitWriter` commit (ProllyTree + IPNS head) on every call. The per-datom **Journal WAL block-write that follows is a redundant double-write** of data the commit already persisted. So Decision A reduces to *demoting/removing the Journal WAL* — the CommitDag already **is** the write-ahead log.

## What
Makes the WAL block-write **opt-out**, additively:
- `KotobaState.journal_wal_enabled` from `KOTOBA_JOURNAL_WAL` (**default ON = unchanged behaviour**).
- Commit path: when off, skip `journal_assert`/`journal_retract`; the **hot-arrangement update (`apply_journaled_datom`) ALWAYS runs** — it serves hot reads and is independent of the WAL block-write.
- Startup WARN when disabled.

Default is unchanged; the running server is unaffected. `kotoba-server` builds clean.

## Why it's safe (when off)
Durability is provided by the synchronous CommitDag commit (already happening) + cold ProllyTree fallback (`get_entity_quads_cold`) + startup cache-warm (`KOTOBA_DATOMIC_WARM_GRAPHS`). No data is lost — the committed ProllyTree is the durable record.

## HONEST — not in this PR (the careful remainder)
- Does **not** flip the default or remove the Journal. Today restart rebuilds the hot arrangement via `replay_from_journal`; with WAL off that path is empty, so restart must rebuild from the committed CommitDag / cold path.
- Next increment: **crash-recovery tests** proving restart-from-CommitDag with WAL off → then flip default → then remove the Journal entirely. A durability-core change deserves that gate.

Builds on the merged FsBlockStore tier (local durability, no Kubo-HTTP hop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)