### PR TITLE
fix(car-on-b2): hook the distributed commit path (prod pin/kg)

### DIFF
--- a/Dockerfile.bak
+++ b/Dockerfile.bak
@@ -1,5 +1,5 @@
 # ── Build stage ──────────────────────────────────────────────────────────────
-FROM rust:1-slim-bookworm AS builder
+FROM rust:1.88-slim-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         pkg-config libssl-dev libclang-dev clang cmake \

--- a/crates/kotoba-datomic/Cargo.toml
+++ b/crates/kotoba-datomic/Cargo.toml
@@ -7,6 +7,7 @@ authors.workspace = true
 
 [dependencies]
 kotoba-core = { path = "../kotoba-core" }
+kotoba-store = { path = "../kotoba-store" }
 kotoba-edn = { path = "../kotoba-edn" }
 kotoba-kqe = { path = "../kotoba-kqe" }
 anyhow.workspace = true

--- a/crates/kotoba-datomic/src/distributed.rs
+++ b/crates/kotoba-datomic/src/distributed.rs
@@ -2424,6 +2424,23 @@ where
         self.store.pin(&commit.cid);
         let pin_ms = t_pin.elapsed().as_millis();
 
+        // CAR-on-B2 cold export (durability-first: after the local durable flush
+        // + pin). `captured` already holds every block of this commit including
+        // the commit block (`commit.persist(&cap)`), so the CAR is
+        // self-restorable. Pack into one CAR keyed by the commit CID (idempotent,
+        // content-addressed) and enqueue for the global B2 exporter — a no-op
+        // unless KOTOBA_B2_* is configured. Off the hot path.
+        if let Some(q) = kotoba_store::b2_export::global() {
+            if !captured.is_empty() {
+                let mut car = kotoba_store::CarBundleWriter::new(commit.cid.clone());
+                for (bcid, data) in &captured {
+                    car.append(bcid, data);
+                }
+                let (car_bytes, _idx) = car.finish();
+                q.enqueue(&commit.cid.to_multibase(), &car_bytes);
+            }
+        }
+
         let commit_ipfs_cid = kotoba_ipfs::parse_cid(&commit.cid.to_multibase())
             .map_err(|e| DistributedCommitError::InvalidCommitCid(e.to_string()))?;
         let mut ipns_record = IpnsRecord::new(

--- a/crates/kotoba-graph/src/quad_store.rs
+++ b/crates/kotoba-graph/src/quad_store.rs
@@ -39,7 +39,7 @@ use kotoba_kqe::quad::LegacyQuad as Quad;
 use kotoba_kqe::quad::LegacyQuadObject;
 use kotoba_kse::journal::Journal;
 use kotoba_kse::topic::Topic;
-use kotoba_store::{CapturingBlockStore, CarBundleWriter, CarExportQueue};
+use kotoba_store::{CapturingBlockStore, CarBundleWriter};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -75,10 +75,6 @@ pub struct QuadStore {
     /// keeps retract tombstones so the next commit can persist full Datomic
     /// `(E,A,V,T,Added)` history into the Datom-native ProllyTree indexes.
     pending_datoms: Arc<DashMap<String, Vec<Datom>>>,
-    /// Optional CAR-on-B2 cold-export queue.  When set, every commit's CAR
-    /// bundle is staged + uploaded to B2 off the hot path (ADR: kotobase B2
-    /// cold pin).  `None` (default) keeps behaviour unchanged.
-    car_export: Option<Arc<CarExportQueue>>,
 }
 
 /// Datom-native graph store facade.
@@ -95,12 +91,6 @@ impl DatomGraphStore {
         Self {
             inner: QuadStore::new(journal, block_store),
         }
-    }
-
-    /// Attach a CAR-on-B2 cold-export queue (forwards to the inner QuadStore).
-    pub fn with_car_export(mut self, queue: Arc<CarExportQueue>) -> Self {
-        self.inner = self.inner.with_car_export(queue);
-        self
     }
 
     pub fn legacy_quad_store(&self) -> &QuadStore {
@@ -210,15 +200,7 @@ impl QuadStore {
             committed_seq: Arc::new(RwLock::new(0)),
             hot_covers_all: Arc::new(DashMap::new()),
             pending_datoms: Arc::new(DashMap::new()),
-            car_export: None,
         }
-    }
-
-    /// Attach a CAR-on-B2 cold-export queue. Builder form so existing
-    /// `QuadStore::new` call sites stay source-compatible.
-    pub fn with_car_export(mut self, queue: Arc<CarExportQueue>) -> Self {
-        self.car_export = Some(queue);
-        self
     }
 
     fn record_pending_datom(&self, graph_key: &str, quad: Quad, op: bool) {
@@ -3556,9 +3538,10 @@ impl QuadStore {
             }
             // CAR-on-B2 cold export (off the hot path). car_key = commit CID
             // multibase → idempotent, content-addressed overwrite. Staged on
-            // disk + enqueued; the exporter task uploads to B2.
-            if let Some(q) = &self.car_export {
-                if car_block_count > 0 {
+            // disk + enqueued; the exporter task uploads to B2. Uses the global
+            // queue installed at startup (None unless KOTOBA_B2_* configured).
+            if car_block_count > 0 {
+                if let Some(q) = kotoba_store::b2_export::global() {
                     q.enqueue(&cid.to_multibase(), &car_bytes);
                 }
             }

--- a/crates/kotoba-server/src/server.rs
+++ b/crates/kotoba-server/src/server.rs
@@ -689,16 +689,17 @@ impl KotobaState {
         let ipfs_pin = IpfsPinClient::from_env();
         tracing::info!("IPFS pin client ready (KOTOBA_IPFS_ENDPOINT)");
 
+        // CAR-on-B2 cold export — install the process-global export queue when
+        // KOTOBA_B2_* + KOTOBA_STORE_PATH are set. All commit paths
+        // (QuadStore::commit + the distributed DistributedCommitWriter) consult
+        // `kotoba_store::b2_export::global()`; no per-store threading needed.
+        let _car_export = kotoba_store::CarExportQueue::start(store_path.as_deref());
+
         // QuadStore — wraps Journal + BlockStore; provides ProllyTree commit path.
-        // When KOTOBA_B2_* is configured, attach the CAR-on-B2 cold-export queue
-        // so each commit's CAR bundle is archived off-site in B2 (one PUT/commit).
-        let quad_store = {
-            let qs = QuadStore::new(Arc::clone(&journal), Arc::clone(&block_store));
-            match kotoba_store::CarExportQueue::start(store_path.as_deref()) {
-                Some(q) => Arc::new(qs.with_car_export(q)),
-                None => Arc::new(qs),
-            }
-        };
+        let quad_store = Arc::new(QuadStore::new(
+            Arc::clone(&journal),
+            Arc::clone(&block_store),
+        ));
 
         // Vault — content-addressed private blob store; backed by block_store.
         let vault = Arc::new(if store_path.is_some() {

--- a/crates/kotoba-store/src/b2_export.rs
+++ b/crates/kotoba-store/src/b2_export.rs
@@ -18,8 +18,20 @@
 
 use crate::b2_client::{b2_spawn, B2Client, B2Config};
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use tokio::sync::mpsc;
+
+/// Process-global CAR export queue. Set once at startup by [`CarExportQueue::start`]
+/// so every commit path (`QuadStore::commit`, the distributed
+/// `DistributedCommitWriter::commit_datoms`, …) can reach it without threading
+/// it through each call site. `None` (default) keeps export disabled.
+static GLOBAL: OnceLock<Arc<CarExportQueue>> = OnceLock::new();
+
+/// The installed global export queue, if any. Commit paths call this and
+/// enqueue their CAR when it returns `Some`.
+pub fn global() -> Option<&'static CarExportQueue> {
+    GLOBAL.get().map(|a| a.as_ref())
+}
 
 /// Sender half held by `QuadStore`. Staging dir + bounded channel.
 #[derive(Clone)]
@@ -61,8 +73,10 @@ impl CarExportQueue {
         let bucket = client.bucket().to_string();
         reconcile(&dir, &queue.tx);
         b2_spawn(run_exporter(rx, client, dir));
+        let arc = Arc::new(queue);
+        let _ = GLOBAL.set(Arc::clone(&arc)); // first install wins (one per process)
         tracing::info!(bucket, "CAR-on-B2 cold export enabled");
-        Some(Arc::new(queue))
+        Some(arc)
     }
 
     fn staged_path(&self, car_key: &str) -> PathBuf {


### PR DESCRIPTION
v0.3.0 hooked CAR-on-B2 export into `QuadStore::commit()`, but production pin/kg writes go through `DistributedCommitWriter::commit_datoms` (kotoba-datomic) — so **no CAR was exported in prod** (verified: staging dir stayed empty; commit CID 404 in bucket).

Refactor to a **process-global** export queue (`b2_export::global()`, installed once at startup) consulted by **both** commit paths — avoids threading through the ~10 `DistributedCommitWriter` call sites. The distributed hook builds the CAR from `captured` (already includes the commit block via `commit.persist(&cap)`) after the durable flush + pin. Off by default.

Tests: store 107 + graph 231 + datomic 132 pass; live B2 round-trip green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)