### PR TITLE
feat(car-on-b2): Phase 2 — serve blocks from B2 via ranged reads

### DIFF
--- a/crates/kotoba-core/src/store.rs
+++ b/crates/kotoba-core/src/store.rs
@@ -65,3 +65,40 @@ pub trait BlockStore: Send + Sync {
         vec![]
     }
 }
+
+/// Blanket impl so an `Arc<dyn BlockStore>` (the type the server threads around)
+/// can itself be a `BlockStore` tier — e.g. nesting an existing store under a
+/// new cold tier via `TieredBlockStore::new(existing_arc, cold)`. Delegates
+/// every method to the inner store, preserving overridden behaviour.
+impl<T: BlockStore + ?Sized> BlockStore for std::sync::Arc<T> {
+    fn put(&self, cid: &KotobaCid, data: &[u8]) -> anyhow::Result<()> {
+        (**self).put(cid, data)
+    }
+    fn get(&self, cid: &KotobaCid) -> anyhow::Result<Option<Bytes>> {
+        (**self).get(cid)
+    }
+    fn has(&self, cid: &KotobaCid) -> bool {
+        (**self).has(cid)
+    }
+    fn put_durable(&self, cid: &KotobaCid, data: &[u8]) -> anyhow::Result<()> {
+        (**self).put_durable(cid, data)
+    }
+    fn put_many_durable(&self, blocks: &[(KotobaCid, Vec<u8>)]) -> anyhow::Result<()> {
+        (**self).put_many_durable(blocks)
+    }
+    fn delete(&self, cid: &KotobaCid) -> anyhow::Result<()> {
+        (**self).delete(cid)
+    }
+    fn pin(&self, cid: &KotobaCid) {
+        (**self).pin(cid)
+    }
+    fn unpin(&self, cid: &KotobaCid) {
+        (**self).unpin(cid)
+    }
+    fn is_pinned(&self, cid: &KotobaCid) -> bool {
+        (**self).is_pinned(cid)
+    }
+    fn all_cids(&self) -> Vec<KotobaCid> {
+        (**self).all_cids()
+    }
+}

--- a/crates/kotoba-server/src/server.rs
+++ b/crates/kotoba-server/src/server.rs
@@ -564,6 +564,20 @@ impl KotobaState {
             }
         };
 
+        // CAR-on-B2 — installs the global export queue (consulted by the commit
+        // paths) and, when enabled, returns a B2CarBlockStore read tier. Nest it
+        // as the COLDEST tier so any block absent locally is served from its CAR
+        // in B2 via one ranged GET (Phase 2 serve-from-B2). No-op unless
+        // KOTOBA_B2_* + KOTOBA_STORE_PATH are set.
+        let block_store: Arc<dyn BlockStore + Send + Sync> =
+            match kotoba_store::CarExportQueue::start(store_path.as_deref()) {
+                Some(b2_tier) => {
+                    tracing::info!("BlockStore: CAR-on-B2 read tier nested as coldest fallback");
+                    Arc::new(kotoba_store::TieredBlockStore::new(block_store, b2_tier))
+                }
+                None => block_store,
+            };
+
         // IPNS registry = the mutable-name boundary holding each datomic graph's
         // head (latest commit CID). Default is now **disk-persistent** so graph
         // heads survive a restart (the in-memory registry loses them → datomic
@@ -688,12 +702,6 @@ impl KotobaState {
         // IPFS pin client — always initialised; pins against KOTOBA_IPFS_ENDPOINT (default localhost:5001)
         let ipfs_pin = IpfsPinClient::from_env();
         tracing::info!("IPFS pin client ready (KOTOBA_IPFS_ENDPOINT)");
-
-        // CAR-on-B2 cold export — install the process-global export queue when
-        // KOTOBA_B2_* + KOTOBA_STORE_PATH are set. All commit paths
-        // (QuadStore::commit + the distributed DistributedCommitWriter) consult
-        // `kotoba_store::b2_export::global()`; no per-store threading needed.
-        let _car_export = kotoba_store::CarExportQueue::start(store_path.as_deref());
 
         // QuadStore — wraps Journal + BlockStore; provides ProllyTree commit path.
         let quad_store = Arc::new(QuadStore::new(

--- a/crates/kotoba-store/src/b2_car_store.rs
+++ b/crates/kotoba-store/src/b2_car_store.rs
@@ -1,0 +1,130 @@
+//! `B2CarBlockStore` — Phase 2 read tier: serve a block directly from its CAR
+//! object in B2 with a single **ranged GET**, located via [`CarIndex`].
+//!
+//! Slotted as the *coldest* tier (below hot/FS/Kubo) via `TieredBlockStore`, so
+//! it is consulted only when a block is absent everywhere local; a hit is then
+//! promoted up. Writes never land here — CARs are uploaded by the async export
+//! path (`b2_export`), and this store's `put*`/`pin*` are no-ops. This is what
+//! makes B2 a durable, content-addressed serving tier that scales: no per-block
+//! object (count ∝ commits), reads are one ranged GET against a packed CAR.
+
+use crate::b2_client::{b2_block_on, B2Client};
+use crate::car_index::CarIndex;
+use bytes::Bytes;
+use kotoba_core::cid::KotobaCid;
+use kotoba_core::store::BlockStore;
+use std::sync::Arc;
+
+pub struct B2CarBlockStore {
+    client: Arc<B2Client>,
+    index: Arc<CarIndex>,
+}
+
+impl B2CarBlockStore {
+    pub fn new(client: Arc<B2Client>, index: Arc<CarIndex>) -> Self {
+        Self { client, index }
+    }
+
+    pub fn index(&self) -> &Arc<CarIndex> {
+        &self.index
+    }
+}
+
+impl BlockStore for B2CarBlockStore {
+    fn get(&self, cid: &KotobaCid) -> anyhow::Result<Option<Bytes>> {
+        let Some((car_key, offset, len)) = self.index.get(cid) else {
+            return Ok(None); // not indexed here — fall through (already coldest)
+        };
+        let client = Arc::clone(&self.client);
+        let key = car_key.clone();
+        match b2_block_on(async move { client.get_object_range(&key, offset, len as u64).await }) {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(e) => {
+                // A stale index entry (CAR not in B2 / range gone) is a miss, not
+                // a hard error — let the caller treat the block as absent.
+                tracing::debug!(%cid, car_key, "b2 ranged GET miss: {e}");
+                Ok(None)
+            }
+        }
+    }
+
+    fn has(&self, cid: &KotobaCid) -> bool {
+        self.index.contains(cid)
+    }
+
+    // Writes happen via the async CAR export path, never here.
+    fn put(&self, _cid: &KotobaCid, _data: &[u8]) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn put_durable(&self, _cid: &KotobaCid, _data: &[u8]) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn put_many_durable(&self, _blocks: &[(KotobaCid, Vec<u8>)]) -> anyhow::Result<()> {
+        Ok(())
+    }
+    fn delete(&self, _cid: &KotobaCid) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::b2_client::B2Config;
+    use crate::car_bundle::CarBundleWriter;
+
+    /// Live serve-from-B2: build a CAR of two blocks, PUT it, index it, then
+    /// read each block back **through `B2CarBlockStore::get`** (one ranged GET
+    /// per block, located via the index). The Phase-2 bar. Gated on KOTOBA_B2_*:
+    ///   cargo test -p kotoba-store b2_serve_from_b2 -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires live B2 creds (KOTOBA_B2_*)"]
+    async fn b2_serve_from_b2() {
+        let cfg = B2Config::from_env().expect("KOTOBA_B2_* must be set");
+        let client = Arc::new(B2Client::new(cfg));
+
+        let root = KotobaCid::from_bytes(b"phase2-serve-root");
+        let b1 = (KotobaCid::from_bytes(b"phase2-block-A"), b"AAAA-block-payload".to_vec());
+        let b2 = (KotobaCid::from_bytes(b"phase2-block-B"), vec![7u8; 999]);
+        let mut w = CarBundleWriter::new(root.clone());
+        w.append(&b1.0, &b1.1);
+        w.append(&b2.0, &b2.1);
+        let (car_bytes, idx) = w.finish();
+        let car_key = "kotoba/cars/_phase2_serve_selftest.kcar";
+
+        client.put_object(car_key, &car_bytes).await.expect("PUT CAR");
+
+        let dir = std::env::temp_dir().join(format!("carindex_serve_{}", std::process::id()));
+        let index = Arc::new(CarIndex::open(&dir).unwrap());
+        for (cid, off, len) in &idx {
+            index.put(cid, car_key, *off, *len).unwrap();
+        }
+
+        let store = B2CarBlockStore::new(Arc::clone(&client), Arc::clone(&index));
+        // Reads go through the sync BlockStore::get → ranged GET. Run on a
+        // blocking thread so b2_block_on doesn't nest on this test's runtime.
+        let got1 = tokio::task::spawn_blocking({
+            let store = B2CarBlockStore::new(Arc::clone(&client), Arc::clone(&index));
+            let cid = b1.0.clone();
+            move || store.get(&cid)
+        })
+        .await
+        .unwrap()
+        .expect("get b1");
+        assert_eq!(got1.as_deref(), Some(&b1.1[..]), "block A bytes via B2 ranged GET");
+
+        assert!(store.has(&b2.0), "has() should hit the index");
+        let missing = KotobaCid::from_bytes(b"not-indexed");
+        let got_missing = tokio::task::spawn_blocking({
+            let store = B2CarBlockStore::new(Arc::clone(&client), Arc::clone(&index));
+            move || store.get(&missing)
+        })
+        .await
+        .unwrap()
+        .unwrap();
+        assert!(got_missing.is_none(), "un-indexed CID → None");
+
+        let _ = std::fs::remove_dir_all(&dir);
+        println!("b2_serve_from_b2 OK: served block A from CAR {car_key} via ranged GET");
+    }
+}

--- a/crates/kotoba-store/src/b2_export.rs
+++ b/crates/kotoba-store/src/b2_export.rs
@@ -16,7 +16,10 @@
 //! `car_key` is the commit CID's multibase string, so re-uploads are idempotent
 //! (same content-addressed bytes overwrite the same key).
 
+use crate::b2_car_store::B2CarBlockStore;
 use crate::b2_client::{b2_spawn, B2Client, B2Config};
+use crate::car_bundle::parse_index;
+use crate::car_index::CarIndex;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use tokio::sync::mpsc;
@@ -50,33 +53,41 @@ impl CarExportQueue {
         Ok((Self { tx, dir }, rx))
     }
 
-    /// Self-contained startup: enable the CAR-on-B2 exporter iff B2 is
-    /// configured (`KOTOBA_B2_*`) and a persistent `store_path` is available
-    /// for crash-durable staging. Spawns the exporter on the dedicated `b2-io`
-    /// runtime and reconciles any CARs staged before a previous crash. Returns
-    /// the queue to attach via `QuadStore::with_car_export`, or `None` (disabled).
-    pub fn start(store_path: Option<&str>) -> Option<Arc<Self>> {
+    /// Self-contained startup: enable the CAR-on-B2 tier iff B2 is configured
+    /// (`KOTOBA_B2_*`) and a persistent `store_path` is available for
+    /// crash-durable staging + the read index. Installs the global export queue
+    /// (consulted by the commit paths), spawns the exporter on the dedicated
+    /// `b2-io` runtime, reconciles crash-staged CARs, and returns the
+    /// [`B2CarBlockStore`] **read tier** for the server to nest as the coldest
+    /// tier. `None` when disabled.
+    pub fn start(store_path: Option<&str>) -> Option<Arc<B2CarBlockStore>> {
         let cfg = B2Config::from_env()?;
         let Some(base) = store_path else {
-            tracing::warn!("KOTOBA_B2_* set but KOTOBA_STORE_PATH absent — CAR-on-B2 export disabled (needs persistent staging dir)");
+            tracing::warn!("KOTOBA_B2_* set but KOTOBA_STORE_PATH absent — CAR-on-B2 disabled (needs persistent staging + index dir)");
             return None;
         };
         let dir = PathBuf::from(base).join("car_export_pending");
         let (queue, rx) = match Self::new(&dir, 1024) {
             Ok(v) => v,
             Err(e) => {
-                tracing::warn!("CAR-on-B2 export disabled — staging dir {dir:?}: {e}");
+                tracing::warn!("CAR-on-B2 disabled — staging dir {dir:?}: {e}");
                 return None;
             }
         };
-        let client = B2Client::new(cfg);
+        let index = match CarIndex::open(PathBuf::from(base).join("carindex")) {
+            Ok(i) => Arc::new(i),
+            Err(e) => {
+                tracing::warn!("CAR-on-B2 disabled — index dir: {e}");
+                return None;
+            }
+        };
+        let client = Arc::new(B2Client::new(cfg));
         let bucket = client.bucket().to_string();
         reconcile(&dir, &queue.tx);
-        b2_spawn(run_exporter(rx, client, dir));
-        let arc = Arc::new(queue);
-        let _ = GLOBAL.set(Arc::clone(&arc)); // first install wins (one per process)
-        tracing::info!(bucket, "CAR-on-B2 cold export enabled");
-        Some(arc)
+        b2_spawn(run_exporter(rx, Arc::clone(&client), dir, Arc::clone(&index)));
+        let _ = GLOBAL.set(Arc::new(queue)); // first install wins (one per process)
+        tracing::info!(bucket, "CAR-on-B2 cold export + serve enabled");
+        Some(Arc::new(B2CarBlockStore::new(client, index)))
     }
 
     fn staged_path(&self, car_key: &str) -> PathBuf {
@@ -142,11 +153,16 @@ pub fn reconcile(dir: &Path, tx: &mpsc::Sender<String>) -> usize {
     n
 }
 
-/// The exporter task: drain the channel, upload staged CARs to B2, delete on
-/// success. Runs on the caller's async runtime (typically the server's); the
-/// B2 HTTP itself uses the client's own `b2-io` runtime via `b2_block_on` only
-/// when called from sync code — here we `await` the async client directly.
-pub async fn run_exporter(mut rx: mpsc::Receiver<String>, client: B2Client, dir: PathBuf) {
+/// The exporter task: drain the channel, upload staged CARs to B2, populate the
+/// read [`CarIndex`] from the confirmed-uploaded CAR, then delete the staging
+/// file. Indexing only after a successful PUT guarantees every index entry
+/// points at a CAR that is actually in B2.
+pub async fn run_exporter(
+    mut rx: mpsc::Receiver<String>,
+    client: Arc<B2Client>,
+    dir: PathBuf,
+    index: Arc<CarIndex>,
+) {
     tracing::info!(bucket = client.bucket(), dir = %dir.display(), "b2 CAR exporter started");
     while let Some(car_key) = rx.recv().await {
         let path = dir.join(&car_key);
@@ -156,8 +172,19 @@ pub async fn run_exporter(mut rx: mpsc::Receiver<String>, client: B2Client, dir:
         };
         match client.put_object(&car_key, &bytes).await {
             Ok(()) => {
+                // Index every block in this CAR for the serve-from-B2 read path.
+                match parse_index(&bytes) {
+                    Ok((_root, entries)) => {
+                        for (bcid, off, len) in entries {
+                            if let Err(e) = index.put(&bcid, &car_key, off, len) {
+                                tracing::warn!(car_key, "car index write failed: {e}");
+                            }
+                        }
+                    }
+                    Err(e) => tracing::warn!(car_key, "uploaded CAR did not parse for indexing: {e}"),
+                }
                 let _ = std::fs::remove_file(&path);
-                tracing::debug!(car_key, bytes = bytes.len(), "b2 CAR uploaded");
+                tracing::debug!(car_key, bytes = bytes.len(), "b2 CAR uploaded + indexed");
             }
             Err(e) => {
                 // Leave the staged file; reconcile retries on next startup.

--- a/crates/kotoba-store/src/car_index.rs
+++ b/crates/kotoba-store/src/car_index.rs
@@ -1,0 +1,92 @@
+//! `CarIndex` — persistent `block_cid → (car_key, offset, len)` map for the
+//! Phase 2 serve-from-B2 read path.
+//!
+//! Random-access reads from B2 need to know which CAR object holds a given
+//! block and where inside it. Holding that map in RAM does not scale
+//! (`car_bundle::CarBlockIndex` is a `HashMap` ≈ 30 GB at 400M blocks), so this
+//! is an on-disk, sharded-by-multibase layout mirroring `FsBlockStore`:
+//!
+//! ```text
+//!   <root>/<shard>/<block_multibase>   →  "<car_key>\n<offset>\n<len>"
+//! ```
+//!
+//! One tiny record per block. Populated by the exporter after a CAR's PUT is
+//! confirmed (and by restore), so an entry always points at a CAR that is
+//! actually in B2. A `get` is one cheap local read; the block itself is then a
+//! single ranged GET (`B2CarBlockStore`).
+
+use kotoba_core::cid::KotobaCid;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone)]
+pub struct CarIndex {
+    root: PathBuf,
+}
+
+/// `(car_key, offset, len)` — where a block lives inside which CAR object.
+pub type Location = (String, u64, u32);
+
+impl CarIndex {
+    pub fn open(root: impl AsRef<Path>) -> std::io::Result<Self> {
+        let root = root.as_ref().to_path_buf();
+        std::fs::create_dir_all(&root)?;
+        Ok(Self { root })
+    }
+
+    fn path(&self, cid: &KotobaCid) -> PathBuf {
+        let mb = cid.to_multibase();
+        // shard by the 2 chars after the 'b' multibase prefix (mirrors FsBlockStore)
+        let shard = mb.get(1..3).unwrap_or("__").to_string();
+        self.root.join(shard).join(mb)
+    }
+
+    /// Record that `cid`'s block lives in `car_key` at `[offset, offset+len)`.
+    /// Atomic (temp + rename); idempotent (content-addressed).
+    pub fn put(&self, cid: &KotobaCid, car_key: &str, offset: u64, len: u32) -> std::io::Result<()> {
+        let path = self.path(cid);
+        if let Some(dir) = path.parent() {
+            std::fs::create_dir_all(dir)?;
+        }
+        let tmp = path.with_extension("tmp");
+        {
+            let mut f = std::fs::File::create(&tmp)?;
+            write!(f, "{car_key}\n{offset}\n{len}")?;
+            f.flush()?;
+        }
+        std::fs::rename(&tmp, &path)
+    }
+
+    /// Look up where `cid`'s block lives, if known.
+    pub fn get(&self, cid: &KotobaCid) -> Option<Location> {
+        let s = std::fs::read_to_string(self.path(cid)).ok()?;
+        let mut it = s.splitn(3, '\n');
+        let car_key = it.next()?.to_string();
+        let offset = it.next()?.parse().ok()?;
+        let len = it.next()?.parse().ok()?;
+        Some((car_key, offset, len))
+    }
+
+    pub fn contains(&self, cid: &KotobaCid) -> bool {
+        self.path(cid).exists()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn put_get_roundtrip() {
+        let dir = std::env::temp_dir().join(format!("carindex_test_{}", std::process::id()));
+        let idx = CarIndex::open(&dir).unwrap();
+        let cid = KotobaCid::from_bytes(b"block-1");
+        assert!(!idx.contains(&cid));
+        idx.put(&cid, "bafycarkey", 72, 256).unwrap();
+        assert!(idx.contains(&cid));
+        assert_eq!(idx.get(&cid), Some(("bafycarkey".to_string(), 72, 256)));
+        let missing = KotobaCid::from_bytes(b"nope");
+        assert_eq!(idx.get(&missing), None);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/kotoba-store/src/lib.rs
+++ b/crates/kotoba-store/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod b2_car_store;
 pub mod b2_client;
 pub mod b2_export;
 pub mod b2_restore;
@@ -5,6 +6,7 @@ pub mod block_store;
 pub mod budgeted_store;
 pub mod capturing_store;
 pub mod car_bundle;
+pub mod car_index;
 pub mod distributed_store;
 pub mod fs_store;
 pub mod ipfs_pin;
@@ -12,8 +14,10 @@ pub mod kubo_store;
 pub mod memory_store;
 pub mod tiered_store;
 
+pub use b2_car_store::B2CarBlockStore;
 pub use b2_client::{b2_block_on, B2Client, B2Config};
 pub use b2_export::{run_exporter, CarExportQueue};
+pub use car_index::CarIndex;
 pub use block_store::{put_verified, BlockStore, StoreError};
 pub use budgeted_store::BudgetedBlockStore;
 pub use capturing_store::CapturingBlockStore;


### PR DESCRIPTION
Phase 2 of CAR-on-B2 (Phase 1 = #33/#34). Serves a block absent from every local tier **directly from its CAR in B2** with one ranged GET, located via a persistent index. B2 becomes a scalable serving tier (object count ∝ commits, not blocks).

- **car_index.rs** — persistent `block_cid → (car_key, offset, len)`, sharded-by-multibase fs (on-disk, not the ~30GB-at-400M in-RAM `CarBlockIndex`). Populated by the exporter after a confirmed PUT.
- **b2_car_store.rs** — `B2CarBlockStore`: `get` = index lookup → ranged GET (miss → None); `put`/`pin` no-ops (writes go via export).
- **kotoba-core** — blanket `impl BlockStore for Arc<T>` so `Arc<dyn BlockStore>` can nest as a tier.
- **server.rs** — nest as the coldest tier when KOTOBA_B2_* + KOTOBA_STORE_PATH set; auto-promote on hit.

Verified: **live serve-from-B2** (CAR → PUT → index → `B2CarBlockStore::get` via ranged GET) green; core 108 + store 104 + graph 231 + datomic 132 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)