### PR TITLE
docs(deploy): reflect CAR-on-B2 in deps.toml + configmap

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -27,12 +27,17 @@ data:
   # KOTOBA_EMBED_DIM: "768"
   # KOTOBA_EMBED_BATCH: "64"
 
-  # Storage design (ADR-2605260001):
-  #   kotoba  = Sled PVC (primary, durable) — this pod
-  #   kotobase = B2 cold-storage pinning service (CF Worker, separate)
-  #
-  # B2 vars have been removed from kotoba. kotoba is now Sled-only.
+  # Storage design (ADR-2605260001, updated by ADR-2606042100):
+  #   Local durable tier — kubo (IPFS) blockstore on the PVC (KOTOBA_IPNS=kubo);
+  #     blocks + IPNS heads persist at $KOTOBA_STORE_PATH on kotoba-sled.
+  #   Off-site durable tier — CAR-on-B2 (v0.4.0): each commit's CAR bundle is
+  #     archived to B2 as ONE object (bucket ai-gftd-nats, root key = commit CID;
+  #     count ∝ commits, not blocks). Cold reads are served from B2 via a single
+  #     ranged GET, located by a local index ($KOTOBA_STORE_PATH/carindex).
+  #     Enabled by the kotoba-b2 Secret (KOTOBA_B2_ENDPOINT/BUCKET/KEY_ID/APP_KEY);
+  #     off when absent. Supersedes the earlier "Sled-only / B2 removed" note.
   # IPFS secondary pin (optional): set kotoba-ipfs-pin Secret to enable.
   # Secrets (kubectl create secret generic):
+  #   kotoba-b2        — KOTOBA_B2_ENDPOINT, KOTOBA_B2_BUCKET, KOTOBA_B2_KEY_ID, KOTOBA_B2_APP_KEY
   #   kotoba-ipfs-pin  — KOTOBA_IPFS_PIN_ENDPOINT, KOTOBA_IPFS_PIN_JWT
   #   kotoba-vault     — KOTOBA_VAULT_KEY (32-byte hex, email E2E)

--- a/deps.toml
+++ b/deps.toml
@@ -25,19 +25,24 @@ depends_on = [
   "90-docs/adr/2605270000-kotoba-integer-cast-security-hardening.md",
   "90-docs/adr/2605301800-kotoba-evm-read-verify-surface.md",
   "90-docs/adr/2605302200-kotoba-multimodal-cross-modal-search.md",
+  "90-docs/adr/2606042100-kotoba-car-on-b2-cold-store.md",
 ]
 
 [deployment]
 cluster        = "vultr-vke-sjc-31d5f7dc"
 namespace      = "kotoba"
-image          = "ghcr.io/gftdcojp/kotoba:latest"
+image          = "ghcr.io/gftdcojp/kotoba:durable-v11-amd64"   # kotoba v0.4.0 (CAR-on-B2 Phase 2)
 build_script   = "60-apps/ai-gftd-project-kotoba/scripts/build-push.sh"
 deploy_script  = "60-apps/ai-gftd-project-kotoba/scripts/deploy.sh"
 k8s_manifest   = "60-apps/ai-gftd-project-kotoba/deploy/deployment.yaml"
 external_http  = "149.28.207.62:8080"
 external_p2p   = "45.32.131.41:4001/UDP"
 b2_bucket      = "ai-gftd-nats"
-b2_stores      = ["kotoba/journal/", "kotoba/blocks/", "kotoba/vault/", "kotoba/email-vault/"]
+# CAR-on-B2 (v0.3.1 Phase 1 + v0.4.0 Phase 2, ADR-2606042100): every commit's
+# CAR bundle is one B2 object at a ROOT key = the commit CID (no per-block
+# objects → scales O(commits)). Read index is local under
+# $KOTOBA_STORE_PATH/carindex. Enabled by the kotoba-b2 Secret (KOTOBA_B2_*).
+b2_stores      = ["<commit-cid>  # CAR-on-B2: one CAR object per commit, root-keyed"]
 first_deployed = "2026-05-25"
 live_verified  = "2026-05-26"
 mcp_tools      = 17


### PR DESCRIPTION
Doc/config catch-up after CAR-on-B2 (#33/#34/#35, v0.3.0→v0.4.0). deps.toml image→durable-v11, b2_stores→CAR layout, +ADR ref. configmap: replace stale 'Sled-only / B2 removed' with the current kubo-on-PVC + CAR-on-B2 two-tier design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)