### PR TITLE
docs(deps): image → durable-v12 (v0.4.1)

### DIFF
--- a/deps.toml
+++ b/deps.toml
@@ -31,7 +31,7 @@ depends_on = [
 [deployment]
 cluster        = "vultr-vke-sjc-31d5f7dc"
 namespace      = "kotoba"
-image          = "ghcr.io/gftdcojp/kotoba:durable-v11-amd64"   # kotoba v0.4.0 (CAR-on-B2 Phase 2)
+image          = "ghcr.io/gftdcojp/kotoba:durable-v12-amd64"   # kotoba v0.4.1 (CAR-on-B2 + consistent pin_id for the PSA /pins API)
 build_script   = "60-apps/ai-gftd-project-kotoba/scripts/build-push.sh"
 deploy_script  = "60-apps/ai-gftd-project-kotoba/scripts/deploy.sh"
 k8s_manifest   = "60-apps/ai-gftd-project-kotoba/deploy/deployment.yaml"


### PR DESCRIPTION
Catch deps.toml up to the deployed image (kotoba v0.4.1, durable-v12 — consistent pin_id for the PSA /pins API).