### PR TITLE
perf: async pin (opt-in), O(datoms+pins) pin.list, fewer CarIndex syscalls

### DIFF
--- a/crates/kotoba-server/src/kotobase_xrpc.rs
+++ b/crates/kotoba-server/src/kotobase_xrpc.rs
@@ -934,21 +934,37 @@ pub async fn handle_pin_list(
         .collect::<Vec<_>>();
     pin_subjects.sort_by_key(|cid| cid.to_multibase());
     pin_subjects.dedup();
+    // Group datoms by subject once (O(datoms)) so per-pin attribute lookups are
+    // O(attrs-per-pin) instead of a full O(datoms) linear scan each — turning the
+    // overall cost from O(pins × datoms) into O(datoms + pins).
+    let mut by_subject: std::collections::HashMap<[u8; 36], Vec<&kotoba_datomic::Datom>> =
+        std::collections::HashMap::with_capacity(pin_subjects.len());
+    for d in &datoms {
+        by_subject.entry(d.e.0).or_default().push(d);
+    }
+    let empty: Vec<&kotoba_datomic::Datom> = Vec::new();
+    let text = |rows: &[&kotoba_datomic::Datom], pred: &str| -> Option<String> {
+        rows.iter().find(|d| d.a == pred).and_then(|d| datom_text(&d.v))
+    };
+    let int = |rows: &[&kotoba_datomic::Datom], pred: &str| -> i64 {
+        rows.iter()
+            .find(|d| d.a == pred)
+            .and_then(|d| datom_int(&d.v))
+            .unwrap_or(0)
+    };
     let records: Vec<PinRecord> = pin_subjects
         .iter()
         .filter_map(|subj_cid| {
+            let rows = by_subject.get(&subj_cid.0).unwrap_or(&empty);
             // Return the stored nanoid (== what create returns / delete consumes);
             // fall back to the subject CID for pins written before this field.
-            let pin_id = text_for_subject(&datoms, subj_cid, "kotobase/pin/id")
-                .unwrap_or_else(|| subj_cid.to_multibase());
-            let cid_val = text_for_subject(&datoms, subj_cid, "kotobase/pin/cid")?;
-            let name = text_for_subject(&datoms, subj_cid, "kotobase/pin/name").unwrap_or_default();
-            let status = text_for_subject(&datoms, subj_cid, "kotobase/pin/status")
-                .unwrap_or_else(|| "pinning".into());
-            let ipfs_status = text_for_subject(&datoms, subj_cid, "kotobase/pin/ipfs_status");
-            let size_bytes = int_for_subject(&datoms, subj_cid, "kotobase/pin/size_bytes");
-            let created_at =
-                text_for_subject(&datoms, subj_cid, "kotobase/pin/created_at").unwrap_or_default();
+            let pin_id = text(rows, "kotobase/pin/id").unwrap_or_else(|| subj_cid.to_multibase());
+            let cid_val = text(rows, "kotobase/pin/cid")?;
+            let name = text(rows, "kotobase/pin/name").unwrap_or_default();
+            let status = text(rows, "kotobase/pin/status").unwrap_or_else(|| "pinning".into());
+            let ipfs_status = text(rows, "kotobase/pin/ipfs_status");
+            let size_bytes = int(rows, "kotobase/pin/size_bytes");
+            let created_at = text(rows, "kotobase/pin/created_at").unwrap_or_default();
 
             if let Some(sf) = req.status.as_deref() {
                 if status != sf {

--- a/crates/kotoba-store/src/car_index.rs
+++ b/crates/kotoba-store/src/car_index.rs
@@ -45,14 +45,24 @@ impl CarIndex {
     /// Atomic (temp + rename); idempotent (content-addressed).
     pub fn put(&self, cid: &KotobaCid, car_key: &str, offset: u64, len: u32) -> std::io::Result<()> {
         let path = self.path(cid);
-        if let Some(dir) = path.parent() {
-            std::fs::create_dir_all(dir)?;
-        }
         let tmp = path.with_extension("tmp");
-        {
-            let mut f = std::fs::File::create(&tmp)?;
+        let write = |p: &std::path::Path| -> std::io::Result<()> {
+            let mut f = std::fs::File::create(p)?;
             write!(f, "{car_key}\n{offset}\n{len}")?;
-            f.flush()?;
+            f.flush()
+        };
+        // Hot path assumes the shard dir exists — `create_dir_all` only runs on
+        // the first write into a shard (NotFound), not on every put. With 1024
+        // shards that is ~1024 dir-creates total instead of one per block.
+        if let Err(e) = write(&tmp) {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                if let Some(dir) = path.parent() {
+                    std::fs::create_dir_all(dir)?;
+                }
+                write(&tmp)?;
+            } else {
+                return Err(e);
+            }
         }
         std::fs::rename(&tmp, &path)
     }

--- a/crates/kotoba-store/src/kubo_store.rs
+++ b/crates/kotoba-store/src/kubo_store.rs
@@ -519,42 +519,70 @@ impl BlockStore for KuboBlockStore {
         let token = self.token.clone();
         let inflight = Arc::clone(&self.inflight);
         let cid_mb = cid.to_multibase();
-        // Skip the HTTP round-trip when called outside a Tokio runtime (e.g.
-        // sync unit tests) — the in-memory pin set above is already updated.
-        let pin_result = match tokio::runtime::Handle::try_current() {
-            Err(_) => Ok::<(), anyhow::Error>(()),
-            Ok(_) => kubo_block_on(async move {
-                    let _permit = inflight.acquire_owned().await.map_err(|e| anyhow!(e))?;
-                    let rb = client.post(&url);
-                    let rb = match &token {
-                        Some(t) => rb.bearer_auth(t),
-                        None => rb,
-                    };
-                    let resp = rb.send().await.map_err(|e| anyhow!("kubo pin/add: {e}"))?;
-                    if !resp.status().is_success() {
-                        let st = resp.status();
-                        let tx = resp.text().await.unwrap_or_default();
-                        return Err(anyhow!("kubo pin/add {st}: {tx}"));
-                    }
-                    Ok::<(), anyhow::Error>(())
-            }),
-        };
-        if let Err(e) = pin_result {
-            tracing::warn!(cid = %cid_mb, err = %e, "kubo pin/add failed");
-            if e.to_string().contains("connect") {
-                self.mark_unavailable();
+
+        // The pin/add HTTP call as a Send + 'static future.
+        let pin_future = {
+            let cid_mb = cid_mb.clone();
+            async move {
+                let _permit = inflight.acquire_owned().await.map_err(|e| anyhow!(e))?;
+                let rb = client.post(&url);
+                let rb = match &token {
+                    Some(t) => rb.bearer_auth(t),
+                    None => rb,
+                };
+                let resp = rb.send().await.map_err(|e| anyhow!("kubo pin/add: {e}"))?;
+                if !resp.status().is_success() {
+                    let st = resp.status();
+                    let tx = resp.text().await.unwrap_or_default();
+                    return Err(anyhow!("kubo pin/add {st}: {tx}"));
+                }
+                tracing::debug!(cid = %cid_mb, "kubo cid pinned");
+                Ok::<(), anyhow::Error>(())
             }
-        } else {
-            tracing::debug!(cid = %cid_mb, "kubo cid pinned recursively");
-            // F-3: fan the pin out to kotobase (or any KOTOBA_IPFS_PIN_ENDPOINT)
-            // — fire-and-forget; failures are logged but never block kotoba.
-            if let Some(remote) = &self.remote_pin {
-                let remote = Arc::clone(remote);
-                let cid_for_remote = cid_mb.clone();
-                if let Ok(handle) = tokio::runtime::Handle::try_current() {
-                    handle.spawn(async move { remote.pin(&cid_for_remote).await });
+        };
+
+        // Result handler (mark-unavailable on connect failure; fan out the
+        // pin to the remote pin service on success). Pulled out so both the
+        // sync and the opt-in async path share it.
+        let remote_pin = self.remote_pin.clone();
+        let failed_at = Arc::clone(&self.failed_at_unix);
+        let handle_result = move |res: Result<(), anyhow::Error>| match res {
+            Err(e) => {
+                tracing::warn!(cid = %cid_mb, err = %e, "kubo pin/add failed");
+                if e.to_string().contains("connect") {
+                    let now = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .map(|d| d.as_secs())
+                        .unwrap_or(0);
+                    failed_at.store(now, Ordering::Relaxed);
                 }
             }
+            Ok(()) => {
+                if let Some(remote) = &remote_pin {
+                    let remote = Arc::clone(remote);
+                    let cid_for_remote = cid_mb.clone();
+                    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                        handle.spawn(async move { remote.pin(&cid_for_remote).await });
+                    }
+                }
+            }
+        };
+
+        // Opt-in async pin (KOTOBA_ASYNC_PIN): keep the commit hot path off the
+        // pin/add round-trip (prod pin_ms ~4–10s). Blocks are already durable via
+        // put_many_durable before pin is called; pin only protects from kubo GC,
+        // so deferring it is safe when kubo GC is not aggressive. Default keeps
+        // the synchronous behaviour. Outside any runtime (sync tests) the
+        // in-memory pin set above is already updated and the HTTP call is skipped.
+        let async_pin = std::env::var("KOTOBA_ASYNC_PIN")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true") || v.eq_ignore_ascii_case("on"))
+            .unwrap_or(false);
+        match tokio::runtime::Handle::try_current() {
+            Err(_) => {}
+            Ok(_) if async_pin => {
+                kubo_runtime().spawn(async move { handle_result(pin_future.await) });
+            }
+            Ok(_) => handle_result(kubo_block_on(pin_future)),
         }
     }
 


### PR DESCRIPTION
P1 KOTOBA_ASYNC_PIN (default sync), P3 pin.list O(pins*datoms) to O(datoms+pins), P2 CarIndex create_dir_all once/shard. store 108 + server 397 tests pass. Generated with Claude Code