### PR TITLE
ops(deploy): durable-v14 + KOTOBA_INTERNAL_SECRET + kotoba-api ClusterIP (kotobase.net unification)

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -31,7 +31,10 @@ spec:
 
       containers:
         - name: kotoba
-          image: ghcr.io/gftdcojp/kotoba:latest
+          # Pinned: durable-v14 = security (JWT direct-access gate / SSRF / alloc
+          # caps / query body limits) + CID-emitting query provenance + perf v0.6.0
+          # (async pin, O(datoms+pins) pin.list) + self-sovereign CACAO pin auth.
+          image: ghcr.io/gftdcojp/kotoba:durable-v14-amd64
           imagePullPolicy: Always
 
           env:
@@ -104,6 +107,20 @@ spec:
                   name: kotoba-agent-identity
                   key: KOTOBA_AGENT_DID
                   optional: true
+            # S1 direct-access gate: when set, every JWT `sub`-trusting write
+            # path (operator auth + kotobase pin/account) requires the trusted
+            # edge Worker's `x-internal-trust: <secret>` header. This makes
+            # kotobase.net the only write surface — a directly-reachable pod can
+            # no longer be impersonated with a forged JWT. Reads stay ungated.
+            # Same value is set as the net-kotobase Worker secret
+            # (wrangler secret KOTOBA_INTERNAL_SECRET). Created out-of-band:
+            #   kubectl create secret generic kotoba-internal-trust \
+            #     -n kotoba --from-literal=secret=<hex>
+            - name: KOTOBA_INTERNAL_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: kotoba-internal-trust
+                  key: secret
 
           ports:
             - name: http

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -13,8 +13,12 @@ spec:
       targetPort: 8080
       protocol: TCP
 ---
-# Public XRPC endpoint for kotobase CF Worker (ADR-2605260001)
-# KOTOBA_BACKEND_URL=http://<LB-IP>:8080
+# In-cluster XRPC endpoint. NOT a public LoadBalancer anymore: the kotobase CF
+# Worker reaches the pod through the cloudflared tunnel (kotoba-origin.gftd.ai →
+# kotoba.kotoba.svc:8080), and S1 (KOTOBA_INTERNAL_SECRET) makes kotobase.net the
+# only write surface. Demoted from LoadBalancer to ClusterIP to remove the raw
+# public pod IP that bypassed the Worker (was 149.28.207.62). In-cluster callers
+# resolve it by DNS; direct external writers must migrate to kotobase.net.
 apiVersion: v1
 kind: Service
 metadata:
@@ -23,7 +27,7 @@ metadata:
 spec:
   selector:
     app.kubernetes.io/name: kotoba
-  type: LoadBalancer
+  type: ClusterIP
   ports:
     - name: xrpc
       port: 8080


### PR DESCRIPTION
Reconciles `deploy/` with the live cluster after unifying external traffic on **kotobase.net**.

- **deployment.yaml** — pin image `:latest` → `durable-v14-amd64`; add `KOTOBA_INTERNAL_SECRET` env (`valueFrom kotoba-internal-trust/secret`). Activates the S1 direct-access gate: kotobase.net (the Worker, which forwards `x-internal-trust`) becomes the **only write surface**; a directly-reachable pod can't be impersonated with a forged JWT. Reads stay ungated.
- **service.yaml** — `kotoba-api` LoadBalancer → ClusterIP, removing the raw public pod IP (`149.28.207.62`) that bypassed the Worker.

Live cluster already reflects this (applied imperatively + verified: direct forged-JWT write → 401, kotobase.net → 200). This PR stops a manual `kubectl apply -f deploy/` from reverting the posture. The `kotoba-internal-trust` Secret is created out-of-band (not committed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)