### PR TITLE
ops(deploy): kotoba-trusted in-cluster proxy (S1 shim for in-cluster writers)

### DIFF
--- a/deploy/kotoba-trusted-proxy.yaml
+++ b/deploy/kotoba-trusted-proxy.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kotoba-trusted-proxy
+  namespace: kotoba
+data:
+  # nginx image envsubst's ${KOTOBA_INTERNAL_SECRET} (in env); $host etc. are NOT
+  # in env so they're preserved. In-cluster only (ClusterIP) — this restores
+  # write access for trusted in-cluster callers without exposing the bypass
+  # externally; the external write boundary stays kotobase.net (S1).
+  default.conf.template: |
+    server {
+      listen 8080;
+      location / {
+        proxy_pass http://kotoba.kotoba.svc.cluster.local:8080;
+        proxy_set_header x-internal-trust "${KOTOBA_INTERNAL_SECRET}";
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_http_version 1.1;
+        proxy_read_timeout 120s;
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kotoba-trusted-proxy
+  namespace: kotoba
+  labels: { app: kotoba-trusted-proxy }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: kotoba-trusted-proxy } }
+  template:
+    metadata:
+      labels: { app: kotoba-trusted-proxy }
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.27-alpine
+          ports: [{ containerPort: 8080 }]
+          env:
+            - name: KOTOBA_INTERNAL_SECRET
+              valueFrom:
+                secretKeyRef: { name: kotoba-internal-trust, key: secret }
+          volumeMounts:
+            - { name: tpl, mountPath: /etc/nginx/templates }
+          readinessProbe:
+            httpGet: { path: /health, port: 8080 }
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          resources:
+            requests: { memory: "16Mi", cpu: "10m" }
+            limits: { memory: "64Mi" }
+      volumes:
+        - name: tpl
+          configMap: { name: kotoba-trusted-proxy }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kotoba-trusted
+  namespace: kotoba
+spec:
+  type: ClusterIP
+  selector: { app: kotoba-trusted-proxy }
+  ports: [{ name: http, port: 8080, targetPort: 8080 }]


### PR DESCRIPTION
Restores write access for **in-cluster** direct writers after the S1 lock, without weakening the external boundary.

After `KOTOBA_INTERNAL_SECRET` made kotobase.net the only external write surface, in-cluster writers (`mitama-udf`: `lg-shinshi` / `lg-yatabase` / `lg-yukkuri`) that hit `kotoba.kotoba.svc` directly get 401 — they don't forward `x-internal-trust`.

This adds a tiny **nginx ClusterIP** proxy `kotoba-trusted.kotoba.svc:8080` that injects `x-internal-trust` (from the `kotoba-internal-trust` Secret) and forwards to the pod. Writers repoint `KOTOBA_URL`/`KOTOBA_XRPC_URL` at it — **env-only, no image rebuild, no code change**. Being ClusterIP it does **not** expose the bypass externally, so S1's real goal (block external forged-JWT writes) is preserved while in-cluster writes work again.

**Rolled out live + verified:** write via proxy → 200, same write direct → 401; the 3 writers repointed + rolled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)