### PR TITLE
feat(kotoba-wasm): browser-signed IPNS head record (commitHeadSigned) + wasm-safe kotoba-ipns-record crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3785,6 +3785,7 @@ dependencies = [
  "ciborium",
  "ed25519-dalek",
  "ipld-core",
+ "kotoba-ipns-record",
  "multibase",
  "multihash-codetable",
  "reqwest 0.12.28",
@@ -3795,6 +3796,18 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "kotoba-ipns-record"
+version = "0.1.0"
+dependencies = [
+ "ciborium",
+ "ed25519-dalek",
+ "ipld-core",
+ "multibase",
+ "serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3880,6 +3893,7 @@ dependencies = [
  "hex",
  "kotoba-core",
  "kotoba-kse",
+ "kotoba-rt",
  "libp2p",
  "serde",
  "serde_bytes",
@@ -4092,6 +4106,7 @@ dependencies = [
  "kotoba-core",
  "kotoba-datomic",
  "kotoba-edn",
+ "kotoba-ipns-record",
  "kotoba-kqe",
  "kotoba-store-web",
  "rand_core 0.6.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/kotoba-signal",
     "crates/kotoba-ingest",
     "crates/kotoba-ipfs",
+    "crates/kotoba-ipns-record",
     "crates/kotoba-cli",
     "crates/kotoba-edn",
     "crates/kotoba-datomic",

--- a/crates/kotoba-ipfs/Cargo.toml
+++ b/crates/kotoba-ipfs/Cargo.toml
@@ -18,6 +18,9 @@ tracing.workspace   = true
 ed25519-dalek.workspace = true
 multibase.workspace = true
 
+# Wasm-safe IPNS record type (shared with kotoba-wasm; ADR-2606066000).
+kotoba-ipns-record = { path = "../kotoba-ipns-record" }
+
 # IPFS-compatible CID substrate plus a lightweight self-owned block exchange.
 ipld-core = { workspace = true }
 multihash-codetable = { version = "0.2", features = ["sha2"] }

--- a/crates/kotoba-ipfs/src/ipns.rs
+++ b/crates/kotoba-ipfs/src/ipns.rs
@@ -7,10 +7,8 @@
 //! preserving the same record semantics.
 
 use crate::cid::{dag_cbor_block, parse_cid};
-use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
 use ipld_core::cid::Cid as IpldCid;
-use multibase::Base;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
@@ -21,174 +19,10 @@ const KUBO_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const KUBO_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
 const KUBO_POOL_MAX_IDLE_PER_HOST: usize = 8;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct IpnsName(pub String);
-
-impl IpnsName {
-    pub fn new(name: impl Into<String>) -> Self {
-        Self(name.into())
-    }
-
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-/// A Kotoba IPNS record.
-///
-/// `value` is the CID string of the latest DAG-CBOR commit block.  `sequence`
-/// is monotonically increasing per name; stale records are rejected by
-/// [`InMemoryIpnsRegistry`].  `valid_until` uses strict UTC text so the record
-/// is stable in DAG-CBOR and JSON.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct IpnsRecord {
-    pub name: IpnsName,
-    pub value: String,
-    pub sequence: u64,
-    pub valid_until: String,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub ttl_secs: Option<u64>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub controller_did: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub public_key_multibase: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub signature_multibase: Option<String>,
-}
-
-impl IpnsRecord {
-    pub fn new(
-        name: impl Into<String>,
-        value: &IpldCid,
-        sequence: u64,
-        valid_until: impl Into<String>,
-    ) -> Self {
-        Self {
-            name: IpnsName::new(name),
-            value: value.to_string(),
-            sequence,
-            valid_until: valid_until.into(),
-            ttl_secs: None,
-            controller_did: None,
-            public_key_multibase: None,
-            signature_multibase: None,
-        }
-    }
-
-    pub fn value_cid(&self) -> Result<IpldCid, IpnsRegistryError> {
-        parse_cid(&self.value).map_err(|e| IpnsRegistryError::InvalidCid(e.to_string()))
-    }
-
-    pub fn signing_payload(&self) -> Result<Vec<u8>, IpnsRegistryError> {
-        #[derive(Serialize)]
-        struct Payload<'a> {
-            name: &'a IpnsName,
-            value: &'a str,
-            sequence: u64,
-            valid_until: &'a str,
-            ttl_secs: Option<u64>,
-            controller_did: Option<&'a str>,
-            public_key_multibase: Option<&'a str>,
-        }
-
-        let payload = Payload {
-            name: &self.name,
-            value: &self.value,
-            sequence: self.sequence,
-            valid_until: &self.valid_until,
-            ttl_secs: self.ttl_secs,
-            controller_did: self.controller_did.as_deref(),
-            public_key_multibase: self.public_key_multibase.as_deref(),
-        };
-        let mut bytes = Vec::new();
-        ciborium::into_writer(&payload, &mut bytes)
-            .map_err(|e| IpnsRegistryError::Signature(e.to_string()))?;
-        Ok(bytes)
-    }
-
-    pub fn sign_ed25519(&mut self, signing_key: &SigningKey) -> Result<(), IpnsRegistryError> {
-        self.public_key_multibase = Some(multibase::encode(
-            Base::Base58Btc,
-            signing_key.verifying_key().as_bytes(),
-        ));
-        let payload = self.signing_payload()?;
-        let signature = signing_key.sign(&payload);
-        self.signature_multibase = Some(multibase::encode(Base::Base58Btc, signature.to_bytes()));
-        Ok(())
-    }
-
-    pub fn verify_ed25519_signature(&self) -> Result<(), IpnsRegistryError> {
-        let public_key_multibase = self
-            .public_key_multibase
-            .as_deref()
-            .ok_or(IpnsRegistryError::MissingPublicKey)?;
-        let signature_multibase = self
-            .signature_multibase
-            .as_deref()
-            .ok_or(IpnsRegistryError::MissingSignature)?;
-        let (_, public_key_bytes) = multibase::decode(public_key_multibase)
-            .map_err(|e| IpnsRegistryError::InvalidSignature(e.to_string()))?;
-        let verifying_key = VerifyingKey::from_bytes(
-            public_key_bytes
-                .as_slice()
-                .try_into()
-                .map_err(|_| IpnsRegistryError::InvalidPublicKey(public_key_bytes.len()))?,
-        )
-        .map_err(|e| IpnsRegistryError::InvalidSignature(e.to_string()))?;
-        let (_, signature_bytes) = multibase::decode(signature_multibase)
-            .map_err(|e| IpnsRegistryError::InvalidSignature(e.to_string()))?;
-        let signature = Signature::from_slice(&signature_bytes)
-            .map_err(|e| IpnsRegistryError::InvalidSignature(e.to_string()))?;
-        verifying_key
-            .verify_strict(&self.signing_payload()?, &signature)
-            .map_err(|e| IpnsRegistryError::InvalidSignature(e.to_string()))
-    }
-
-    pub fn signature_verified(&self) -> bool {
-        self.verify_ed25519_signature().is_ok()
-    }
-
-    pub fn verify_signature_if_present(&self) -> Result<(), IpnsRegistryError> {
-        match (&self.public_key_multibase, &self.signature_multibase) {
-            (None, None) => Ok(()),
-            _ => self.verify_ed25519_signature(),
-        }
-    }
-
-    pub fn require_verified_signature(&self) -> Result<(), IpnsRegistryError> {
-        self.verify_ed25519_signature()
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-pub enum IpnsRegistryError {
-    #[error("IPNS name not found: {0}")]
-    NotFound(String),
-    #[error("stale IPNS record for {name}: current sequence {current}, incoming {incoming}")]
-    StaleRecord {
-        name: String,
-        current: u64,
-        incoming: u64,
-    },
-    #[error("invalid CID in IPNS value: {0}")]
-    InvalidCid(String),
-    #[error("missing IPNS public key")]
-    MissingPublicKey,
-    #[error("invalid IPNS public key length: {0}")]
-    InvalidPublicKey(usize),
-    #[error("missing IPNS signature")]
-    MissingSignature,
-    #[error("invalid IPNS signature: {0}")]
-    InvalidSignature(String),
-    #[error("IPNS signature payload: {0}")]
-    Signature(String),
-    #[error("kubo IPNS HTTP: {0}")]
-    Kubo(String),
-    #[error("registry lock poisoned")]
-    LockPoisoned,
-    #[error("persistent IPNS store io: {0}")]
-    Io(String),
-}
+// IpnsName / IpnsRecord / IpnsRegistryError moved to the wasm-safe kotoba-ipns-record
+// crate (ADR-2606066000) and re-exported here so the native registries below + every
+// downstream `kotoba_ipfs::Ipns*` user are unchanged.
+pub use kotoba_ipns_record::{IpnsName, IpnsRecord, IpnsRegistryError};
 
 pub trait IpnsRegistry: Send + Sync {
     fn publish(&self, record: IpnsRecord) -> Result<(), IpnsRegistryError>;
@@ -959,6 +793,8 @@ impl IpnsRegistry for KuboIpnsRegistry {
 mod tests {
     use super::*;
     use crate::raw_cid;
+    use ed25519_dalek::SigningKey;
+    use multibase::Base;
 
     #[test]
     fn publish_and_resolve_roundtrip() {

--- a/crates/kotoba-ipns-record/Cargo.toml
+++ b/crates/kotoba-ipns-record/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "kotoba-ipns-record"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Wasm-safe kotoba IPNS head record (member-signed, content-addressed-head pointer) — shared by kotoba-ipfs (native registries) and kotoba-wasm (browser publish). ADR-2606066000."
+
+# Pure-Rust, wasm32-clean: NO tokio/reqwest. The native IPNS registries
+# (InMemory/Persistent/Kubo) stay in kotoba-ipfs; only the record TYPE + its
+# Ed25519 sign/verify live here so the browser node can emit a canonical,
+# self-verifying head record (no parallel format — ADR-2605262130).
+[dependencies]
+serde = { workspace = true }
+ciborium = { workspace = true }
+ed25519-dalek = { workspace = true }
+multibase = { workspace = true }
+ipld-core = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/kotoba-ipns-record/src/lib.rs
+++ b/crates/kotoba-ipns-record/src/lib.rs
@@ -1,0 +1,291 @@
+//! Wasm-safe kotoba IPNS head record (ADR-2606066000 / ADR-2606013600).
+//!
+//! An IPNS name resolves to the latest commit CID for a graph/database — the
+//! mutable-name boundary of the distributed Datomic target. This crate holds the
+//! **record type and its Ed25519 sign/verify ONLY**, with no native I/O, so the
+//! exact same self-verifying record can be produced by:
+//!
+//!   - the native registries in `kotoba-ipfs` (which re-exports these types), and
+//!   - the **browser node** (`kotoba-wasm`) when a member publishes a head.
+//!
+//! Keeping one record type (rather than a parallel browser format) is required by
+//! ADR-2605262130 (no parallel substrate): a `kotoba-wasm`-signed record verifies
+//! byte-identically under this crate's verifier, which `kotoba-ipfs` re-exports.
+//!
+//! The signing payload is the deterministic CBOR (ciborium) of the record fields
+//! **excluding the signature**; the signature and public key are base58btc
+//! multibase. `sequence` is the monotonic stale-guard / CAS ordering.
+
+use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+use ipld_core::cid::Cid as IpldCid;
+use multibase::Base;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct IpnsName(pub String);
+
+impl IpnsName {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A Kotoba IPNS record.
+///
+/// `value` is the CID string of the latest DAG-CBOR commit block. `sequence`
+/// is monotonically increasing per name; stale records are rejected by the
+/// registries in `kotoba-ipfs`. `valid_until` uses strict UTC text so the record
+/// is stable in DAG-CBOR and JSON.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IpnsRecord {
+    pub name: IpnsName,
+    pub value: String,
+    pub sequence: u64,
+    pub valid_until: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttl_secs: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub controller_did: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub public_key_multibase: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature_multibase: Option<String>,
+}
+
+impl IpnsRecord {
+    pub fn new(
+        name: impl Into<String>,
+        value: &IpldCid,
+        sequence: u64,
+        valid_until: impl Into<String>,
+    ) -> Self {
+        Self::with_value_string(name, value.to_string(), sequence, valid_until)
+    }
+
+    /// Construct from a CID *string* (multibase) directly — the form the browser
+    /// node has on hand (`KotobaCid::to_multibase`), so `kotoba-wasm` does not need
+    /// to depend on the CID crate just to build a head record.
+    pub fn with_value_string(
+        name: impl Into<String>,
+        value: impl Into<String>,
+        sequence: u64,
+        valid_until: impl Into<String>,
+    ) -> Self {
+        Self {
+            name: IpnsName::new(name),
+            value: value.into(),
+            sequence,
+            valid_until: valid_until.into(),
+            ttl_secs: None,
+            controller_did: None,
+            public_key_multibase: None,
+            signature_multibase: None,
+        }
+    }
+
+    pub fn value_cid(&self) -> Result<IpldCid, IpnsRegistryError> {
+        self.value
+            .parse::<IpldCid>()
+            .map_err(|e| IpnsRegistryError::InvalidCid(e.to_string()))
+    }
+
+    pub fn signing_payload(&self) -> Result<Vec<u8>, IpnsRegistryError> {
+        #[derive(Serialize)]
+        struct Payload<'a> {
+            name: &'a IpnsName,
+            value: &'a str,
+            sequence: u64,
+            valid_until: &'a str,
+            ttl_secs: Option<u64>,
+            controller_did: Option<&'a str>,
+            public_key_multibase: Option<&'a str>,
+        }
+
+        let payload = Payload {
+            name: &self.name,
+            value: &self.value,
+            sequence: self.sequence,
+            valid_until: &self.valid_until,
+            ttl_secs: self.ttl_secs,
+            controller_did: self.controller_did.as_deref(),
+            public_key_multibase: self.public_key_multibase.as_deref(),
+        };
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&payload, &mut bytes)
+            .map_err(|e| IpnsRegistryError::Signature(e.to_string()))?;
+        Ok(bytes)
+    }
+
+    pub fn sign_ed25519(&mut self, signing_key: &SigningKey) -> Result<(), IpnsRegistryError> {
+        self.public_key_multibase = Some(multibase::encode(
+            Base::Base58Btc,
+            signing_key.verifying_key().as_bytes(),
+        ));
+        let payload = self.signing_payload()?;
+        let signature = signing_key.sign(&payload);
+        self.signature_multibase = Some(multibase::encode(Base::Base58Btc, signature.to_bytes()));
+        Ok(())
+    }
+
+    pub fn verify_ed25519_signature(&self) -> Result<(), IpnsRegistryError> {
+        let public_key_multibase = self
+            .public_key_multibase
+            .as_deref()
+            .ok_or(IpnsRegistryError::MissingPublicKey)?;
+        let signature_multibase = self
+            .signature_multibase
+            .as_deref()
+            .ok_or(IpnsRegistryError::MissingSignature)?;
+        let (_, public_key_bytes) = multibase::decode(public_key_multibase)
+            .map_err(|e| IpnsRegistryError::InvalidSignature(e.to_string()))?;
+        let verifying_key = VerifyingKey::from_bytes(
+            public_key_bytes
+                .as_slice()
+                .try_into()
+                .map_err(|_| IpnsRegistryError::InvalidPublicKey(public_key_bytes.len()))?,
+        )
+        .map_err(|e| IpnsRegistryError::InvalidSignature(e.to_string()))?;
+        let (_, signature_bytes) = multibase::decode(signature_multibase)
+            .map_err(|e| IpnsRegistryError::InvalidSignature(e.to_string()))?;
+        let signature = Signature::from_slice(&signature_bytes)
+            .map_err(|e| IpnsRegistryError::InvalidSignature(e.to_string()))?;
+        verifying_key
+            .verify_strict(&self.signing_payload()?, &signature)
+            .map_err(|e| IpnsRegistryError::InvalidSignature(e.to_string()))
+    }
+
+    pub fn signature_verified(&self) -> bool {
+        self.verify_ed25519_signature().is_ok()
+    }
+
+    pub fn verify_signature_if_present(&self) -> Result<(), IpnsRegistryError> {
+        match (&self.public_key_multibase, &self.signature_multibase) {
+            (None, None) => Ok(()),
+            _ => self.verify_ed25519_signature(),
+        }
+    }
+
+    pub fn require_verified_signature(&self) -> Result<(), IpnsRegistryError> {
+        self.verify_ed25519_signature()
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum IpnsRegistryError {
+    #[error("IPNS name not found: {0}")]
+    NotFound(String),
+    #[error("stale IPNS record for {name}: current sequence {current}, incoming {incoming}")]
+    StaleRecord {
+        name: String,
+        current: u64,
+        incoming: u64,
+    },
+    #[error("invalid CID in IPNS value: {0}")]
+    InvalidCid(String),
+    #[error("missing IPNS public key")]
+    MissingPublicKey,
+    #[error("invalid IPNS public key length: {0}")]
+    InvalidPublicKey(usize),
+    #[error("missing IPNS signature")]
+    MissingSignature,
+    #[error("invalid IPNS signature: {0}")]
+    InvalidSignature(String),
+    #[error("IPNS signature payload: {0}")]
+    Signature(String),
+    #[error("kubo IPNS HTTP: {0}")]
+    Kubo(String),
+    #[error("registry lock poisoned")]
+    LockPoisoned,
+    #[error("persistent IPNS store io: {0}")]
+    Io(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn key() -> SigningKey {
+        SigningKey::from_bytes(&[7u8; 32])
+    }
+
+    // The CID the head points at (a real CIDv1 dag-cbor sha2-256 multibase string).
+    const HEAD_CID: &str = "bafyreibidp6u4y5rssjx25vjppru6xrerrrdglk4yyd4qvqc4d43daxmce";
+
+    #[test]
+    fn sign_then_verify_roundtrips() {
+        let mut rec = IpnsRecord::with_value_string(
+            "did:key:zfeed",
+            HEAD_CID,
+            1,
+            "2030-01-01T00:00:00Z",
+        );
+        rec.sign_ed25519(&key()).unwrap();
+        assert!(rec.public_key_multibase.is_some());
+        assert!(rec.signature_multibase.is_some());
+        rec.verify_ed25519_signature().expect("valid signature verifies");
+        assert!(rec.signature_verified());
+    }
+
+    #[test]
+    fn tamper_with_value_fails_verify() {
+        let mut rec =
+            IpnsRecord::with_value_string("did:key:zfeed", HEAD_CID, 1, "2030-01-01T00:00:00Z");
+        rec.sign_ed25519(&key()).unwrap();
+        rec.value = "bafyreih4tampered000000000000000000000000000000000000000000".into();
+        assert!(rec.verify_ed25519_signature().is_err());
+    }
+
+    #[test]
+    fn tamper_with_sequence_fails_verify() {
+        let mut rec =
+            IpnsRecord::with_value_string("did:key:zfeed", HEAD_CID, 1, "2030-01-01T00:00:00Z");
+        rec.sign_ed25519(&key()).unwrap();
+        rec.sequence = 2; // a different head ordering than was signed
+        assert!(rec.verify_ed25519_signature().is_err());
+    }
+
+    #[test]
+    fn unsigned_record_verify_if_present_is_ok_but_require_fails() {
+        let rec =
+            IpnsRecord::with_value_string("did:key:zfeed", HEAD_CID, 1, "2030-01-01T00:00:00Z");
+        assert!(rec.verify_signature_if_present().is_ok());
+        assert!(rec.require_verified_signature().is_err());
+    }
+
+    // Mirrors the kotoba-wasm browser publish path: controller_did set to the
+    // member did:key, signed with the same key — the record a browser emits must
+    // verify under this canonical verifier (the ADR-2606066000 interop guarantee).
+    #[test]
+    fn browser_shaped_record_verifies() {
+        let sk = key();
+        let did = format!(
+            "did:key:z{}",
+            hex::encode_upper(sk.verifying_key().to_bytes())
+        )
+        .to_lowercase();
+        let mut rec =
+            IpnsRecord::with_value_string(did.clone(), HEAD_CID, 42, "2030-06-06T00:00:00Z");
+        rec.controller_did = Some(did);
+        rec.sign_ed25519(&sk).unwrap();
+        rec.require_verified_signature()
+            .expect("browser-shaped record verifies under canonical verifier");
+        assert_eq!(rec.sequence, 42);
+        assert_eq!(rec.value, HEAD_CID);
+    }
+
+    // Tiny local hex (test-only) to avoid a dev-dep just for the did string.
+    mod hex {
+        pub fn encode_upper(bytes: impl AsRef<[u8]>) -> String {
+            bytes
+                .as_ref()
+                .iter()
+                .map(|b| format!("{b:02X}"))
+                .collect()
+        }
+    }
+}

--- a/crates/kotoba-wasm/Cargo.toml
+++ b/crates/kotoba-wasm/Cargo.toml
@@ -16,6 +16,9 @@ kotoba-core = { path = "../kotoba-core" }
 kotoba-datomic = { path = "../kotoba-datomic" }
 kotoba-edn = { path = "../kotoba-edn" }
 kotoba-kqe = { path = "../kotoba-kqe" }
+# Wasm-safe canonical IPNS head record (ADR-2606066000) — the browser emits the
+# SAME member-signed record kotoba-ipfs verifies (no parallel format).
+kotoba-ipns-record = { path = "../kotoba-ipns-record" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 ciborium = { workspace = true }

--- a/crates/kotoba-wasm/src/lib.rs
+++ b/crates/kotoba-wasm/src/lib.rs
@@ -51,6 +51,7 @@
 
 use bytes::Bytes;
 use kotoba_core::cid::KotobaCid;
+use kotoba_ipns_record::IpnsRecord;
 use kotoba_core::prolly::ProllyTree;
 use kotoba_core::store::BlockStore;
 use kotoba_kqe::{Arrangement, Datom, Value};
@@ -659,6 +660,26 @@ impl WriteCrypto {
         hex::encode(self.signing_key.sign(msg).to_bytes())
     }
 
+    /// Build + Ed25519-sign a canonical kotoba IPNS **head record** (ADR-2606066000):
+    /// the member-signed, self-verifying mutable head pointer whose `value` is the
+    /// committed root CID (multibase). `name` is the DID-derived IPNS name and
+    /// `sequence` is the monotonic CAS / stale-guard. The record is built with the
+    /// shared `kotoba-ipns-record` type and signed with the member key, so it
+    /// verifies **byte-identically** under `kotoba-ipfs`'s verifier — no parallel
+    /// head format (ADR-2605262130).
+    pub fn sign_ipns_head(
+        &self,
+        name: String,
+        value_multibase: String,
+        sequence: u64,
+        valid_until: String,
+    ) -> Result<IpnsRecord, String> {
+        let mut rec = IpnsRecord::with_value_string(name, value_multibase, sequence, valid_until);
+        rec.controller_did = Some(self.did());
+        rec.sign_ed25519(&self.signing_key).map_err(|e| e.to_string())?;
+        Ok(rec)
+    }
+
     /// Encrypt plaintext under the vault key → `signal:v1:<hex(nonce||ct)>`.
     /// The server/IndexedDB only ever sees this ciphertext.
     pub fn encrypt(&self, plaintext: &str) -> Result<String, String> {
@@ -890,6 +911,30 @@ mod wasm {
                 "root": root.to_multibase(), "did": did, "sig": sig,
             }))
             .map_err(|e| JsValue::from_str(&e.to_string()))
+        }
+
+        /// `commit()` + emit a member-signed **kotoba IPNS head record**
+        /// (ADR-2606066000) — the content-addressed, self-verifying head pointer
+        /// that supersedes the apex `{root,did,sig}` shim + the trusted KV `kroot:`
+        /// value. `value` = the committed root CID; the IPNS name is DID-derived;
+        /// `sequence` is the monotonic CAS guard the publisher passes (the head it
+        /// rebased on + 1). The returned JSON is a canonical `IpnsRecord` that the
+        /// apex relays untrusted and any reader verifies (no-server-key).
+        #[wasm_bindgen(js_name = commitHeadSigned)]
+        pub fn commit_head_signed(
+            &mut self,
+            sequence: u64,
+            valid_until: String,
+        ) -> Result<String, JsValue> {
+            let root = self.inner.commit();
+            let c = self
+                .crypto
+                .as_ref()
+                .ok_or_else(|| JsValue::from_str("no identity — call useIdentity first"))?;
+            let rec = c
+                .sign_ipns_head(c.did(), root.to_multibase(), sequence, valid_until)
+                .map_err(|e| JsValue::from_str(&e))?;
+            serde_json::to_string(&rec).map_err(|e| JsValue::from_str(&e.to_string()))
         }
 
         /// Write one fact (entity, attr, value). In-memory read engine + the


### PR DESCRIPTION
## What

Implements the **browser side of the content-addressed feed head** (etzhayyim/root **ADR-2606066000**): the browser node emits the **same canonical, member-signed `IpnsRecord`** that `kotoba-ipfs` verifies — no parallel head format. This supersedes the apex `{root,did,sig}` shim + the trusted KV `kroot:` value with a self-verifying head record (no-server-key: the apex relays it untrusted, any reader verifies).

## Changes

**New crate `kotoba-ipns-record`** — the `IpnsRecord` / `IpnsName` / `IpnsRegistryError` types + Ed25519 sign/verify, factored out of `kotoba-ipfs` so they are **wasm32-clean** (deps: serde, ciborium, ed25519-dalek, multibase, ipld-core, thiserror — **no tokio/reqwest**). Adds `IpnsRecord::with_value_string` so a caller holding the head CID as a multibase string (the browser) needn't pull the CID crate.

**`kotoba-ipfs`** — re-exports the moved types (`pub use kotoba_ipns_record::…`); the native registries (InMemory/Persistent/Kubo/Signed) are **unchanged**.

**`kotoba-wasm`** — `WriteCrypto::sign_ipns_head(name, value_multibase, sequence, valid_until)` builds + signs a canonical `IpnsRecord` with the member key; new `#[wasm_bindgen] commitHeadSigned(sequence, valid_until)` commits + returns the signed record JSON.

## Verification

| crate | host build | wasm32 build | tests |
|---|---|---|---|
| `kotoba-ipns-record` | ✅ | ✅ | 5/5 (sign→verify, tamper-value, tamper-seq, unsigned, browser-shaped-record-verifies) |
| `kotoba-ipfs` | ✅ | — | **12/12 ipns** (registries sign/verify through the re-exported type = byte-identical) |
| `kotoba-wasm` | ✅ | ⚠️ see below | — |

⚠️ The full `kotoba-wasm` **wasm32 link** is blocked by a **pre-existing** tokio/mio transitive dependency via `kotoba-kqe` / `kotoba-datomic` (`cargo tree -i mio` confirms it does **not** pass through `kotoba-ipns-record`). This is unrelated to this change — the crate added here is verified **wasm32-clean in isolation**, and the `commitSigned`-style binding mirrors the existing wasm surface. The `wasm-pack` bundle path the operator uses handles the tokio creep; a follow-up should trim tokio from the `kotoba-kqe`/`kotoba-datomic` wasm path.

## Follow-on (separate)

monorepo: bump the `40-engine/kotoba` submodule to this commit, then wire the apex `block.put`/`root` to store/serve the `IpnsRecord` (`kroot:` JSON → stored record), with TS↔Rust cross-verification before authority switches (per ADR-2606066000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
