### PR TITLE
fix(kotoba-datomic): make kotoba-store native-only so kotoba-wasm links for wasm32 (drops mio)

### DIFF
--- a/crates/kotoba-datomic/Cargo.toml
+++ b/crates/kotoba-datomic/Cargo.toml
@@ -7,7 +7,6 @@ authors.workspace = true
 
 [dependencies]
 kotoba-core = { path = "../kotoba-core" }
-kotoba-store = { path = "../kotoba-store" }
 kotoba-edn = { path = "../kotoba-edn" }
 kotoba-kqe = { path = "../kotoba-kqe" }
 anyhow.workspace = true
@@ -20,8 +19,13 @@ hex.workspace = true
 regex.workspace = true
 tracing.workspace = true
 
+# kotoba-store is native-only: its sole user (the `distributed` module) is
+# `#[cfg(not(target_arch = "wasm32"))]` (lib.rs), and store pulls reqwest → tokio
+# `net` → mio, which does NOT build for wasm32. Keeping it here (not in plain
+# [dependencies]) lets kotoba-wasm link for wasm32. (ADR-2606066000 follow-up.)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 kotoba-ipfs = { path = "../kotoba-ipfs" }
+kotoba-store = { path = "../kotoba-store" }
 
 [dev-dependencies]
 kotoba-store = { path = "../kotoba-store" }


### PR DESCRIPTION
## Problem

`kotoba-wasm` could not link for `wasm32-unknown-unknown` — `error: could not compile mio`. Root cause: `kotoba-datomic` declared `kotoba-store` in its **plain `[dependencies]`** (all targets), so store compiled for wasm32 even though its only user (the `distributed` module) is already `#[cfg(not(target_arch = "wasm32"))]` in lib.rs. `kotoba-store` pulls `reqwest` → tokio `net` → **mio** (no wasm32 support), and feature unification poisoned the whole wasm build.

## Fix

Move `kotoba-store` to the existing `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` section (beside `kotoba-ipfs`). **One line; no source change** — `distributed` is already gated.

## Verification

- `cargo tree -p kotoba-wasm --target wasm32-unknown-unknown -i mio` → **nothing** (mio gone).
- `cargo build --target wasm32-unknown-unknown -p kotoba-wasm` → **Finished** — the first clean wasm32 link, and it **includes the `commitHeadSigned` IPNS-head binding** from #47.
- native `cargo build -p kotoba-datomic -p kotoba-store` → Finished (unchanged).

Unblocks rebuilding the browser `kotoba_wasm_bg.wasm` bundle with the IPNS head-record binding (etzhayyim/root ADR-2606066000). Follow-up to #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)