### PR TITLE
feat(kotoba-wasm): verifyIpnsRecord reader-side check + JSON round-trip interop test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3807,6 +3807,7 @@ dependencies = [
  "ipld-core",
  "multibase",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
 ]
 

--- a/crates/kotoba-ipns-record/Cargo.toml
+++ b/crates/kotoba-ipns-record/Cargo.toml
@@ -17,3 +17,8 @@ ed25519-dalek = { workspace = true }
 multibase = { workspace = true }
 ipld-core = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+# JSON is the wire form of a head record (commitHeadSigned emits it, the apex
+# relays it, verifyIpnsRecord parses it); the round-trip test exercises that path.
+serde_json = { workspace = true }

--- a/crates/kotoba-ipns-record/src/lib.rs
+++ b/crates/kotoba-ipns-record/src/lib.rs
@@ -278,6 +278,28 @@ mod tests {
         assert_eq!(rec.value, HEAD_CID);
     }
 
+    // The exact path the kotoba-wasm `verifyIpnsRecord` binding takes: sign →
+    // serde_json to_string → from_str → verify. Proves the signature survives the
+    // JSON round-trip the browser/apex use as the wire form (ADR-2606066000 — the
+    // TS↔Rust interop vector: a Rust-signed record verifies after JSON transport).
+    #[test]
+    fn json_roundtrip_verifies() {
+        let mut rec =
+            IpnsRecord::with_value_string("did:key:zfeed", HEAD_CID, 9, "2030-01-01T00:00:00Z");
+        rec.controller_did = Some("did:key:zfeed".into());
+        rec.sign_ed25519(&key()).unwrap();
+        let json = serde_json::to_string(&rec).unwrap();
+        let parsed: IpnsRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, rec); // lossless wire round-trip
+        parsed
+            .require_verified_signature()
+            .expect("Rust-signed record verifies after JSON round-trip (wasm verifyIpnsRecord path)");
+        // A flipped field in the transported JSON must fail verification.
+        let tampered = json.replace("\"sequence\":9", "\"sequence\":10");
+        let bad: IpnsRecord = serde_json::from_str(&tampered).unwrap();
+        assert!(bad.require_verified_signature().is_err());
+    }
+
     // Tiny local hex (test-only) to avoid a dev-dep just for the did string.
     mod hex {
         pub fn encode_upper(bytes: impl AsRef<[u8]>) -> String {

--- a/crates/kotoba-wasm/src/lib.rs
+++ b/crates/kotoba-wasm/src/lib.rs
@@ -937,6 +937,21 @@ mod wasm {
             serde_json::to_string(&rec).map_err(|e| JsValue::from_str(&e.to_string()))
         }
 
+        /// Reader-side verification of a canonical kotoba IPNS head record's
+        /// Ed25519 signature (ADR-2606066000): the consumer checks the record
+        /// itself, so the apex / any gateway serving it is NOT trusted (no-server-
+        /// key). `json` is the record as emitted by `commitHeadSigned`. Returns
+        /// true iff a signature + public key are present and verify over the
+        /// canonical ciborium-CBOR payload. A static method:
+        /// `KotobaNode.verifyIpnsRecord(json)`.
+        #[wasm_bindgen(js_name = verifyIpnsRecord)]
+        pub fn verify_ipns_record(json: String) -> bool {
+            match serde_json::from_str::<IpnsRecord>(&json) {
+                Ok(rec) => rec.require_verified_signature().is_ok(),
+                Err(_) => false,
+            }
+        }
+
         /// Write one fact (entity, attr, value). In-memory read engine + the
         /// write-set behind `commit`. (was the read-only PoC `assert`.)
         pub fn assert(&mut self, entity: &str, attr: &str, value: &str) {


### PR DESCRIPTION
Adds the **reader half** of the content-addressed feed head (etzhayyim/root ADR-2606066000): the consumer verifies the IPNS head record itself, so the apex / any gateway serving it is **not trusted** (no-server-key).

- **kotoba-wasm**: `KotobaNode.verifyIpnsRecord(json)` static binding — parses a record (the wire form `commitHeadSigned` emits) and returns true iff its Ed25519 signature verifies over the canonical ciborium-CBOR payload.
- **kotoba-ipns-record**: `json_roundtrip_verifies` test — sign → `serde_json` to_string → from_str → verify (+ tampered-JSON negative). The **TS↔Rust interop vector**: a Rust-signed record verifies after JSON transport (the exact browser/apex path).

Verified: record crate **6/6**; kotoba-wasm **wasm32 build clean** (verifyIpnsRecord compiles + links). Follow-up to #47/#48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)