### PR TITLE
feat(kotoba-server): journal-free firehose — derive change feed from the CommitDag (journal blocks → 0)

### DIFF
--- a/crates/kotoba-server/src/firehose.rs
+++ b/crates/kotoba-server/src/firehose.rs
@@ -39,7 +39,9 @@ use futures::stream::{self, Stream};
 use serde::{Deserialize, Serialize};
 
 use kotoba_core::cid::KotobaCid;
-use kotoba_kse::{Cursor, Journal, JournalEntry};
+use kotoba_datomic::distributed::DistributedDatomReader;
+use kotoba_ipfs::{IpnsName, IpnsRegistryError};
+use kotoba_kse::{Cursor, Journal, JournalEntry, Topic};
 
 use crate::graph_auth::{check_read_access, AccessDenied};
 use crate::server::KotobaState;
@@ -48,6 +50,10 @@ use crate::server::KotobaState;
 pub const NSID_SYNC_SUBSCRIBE: &str = "com.etzhayyim.apps.kotoba.sync.subscribe";
 /// JSON cursor paging / long-poll firehose.
 pub const NSID_SYNC_EVENTS: &str = "com.etzhayyim.apps.kotoba.sync.events";
+/// CommitDag-derived firehose: reconstruct one graph's change feed from the
+/// Datomic commit chain (no Journal) — journal-independent durable replay.
+pub const NSID_SYNC_EVENTS_FROM_COMMITS: &str =
+    "com.etzhayyim.apps.kotoba.sync.eventsFromCommits";
 
 /// Hard cap on a single paging response so a huge cold backfill can't OOM the node.
 const MAX_PAGE_LIMIT: usize = 1000;
@@ -247,6 +253,114 @@ pub async fn events(
         .unwrap_or(0);
 
     let events = entries.iter().map(FirehoseEvent::from_entry).collect();
+
+    Ok(Json(EventsResponse {
+        events,
+        cursor,
+        current_seq,
+        has_more,
+    }))
+}
+
+// ── CommitDag-derived firehose (journal-free) ────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+pub struct CommitEventsParams {
+    /// Graph CID (multibase) to reconstruct the change feed for.
+    pub graph: String,
+    pub cursor: Option<u64>,
+    pub limit: Option<usize>,
+    pub topic_prefix: Option<String>,
+    pub cacao_b64: Option<String>,
+}
+
+/// Build the ordered firehose events for one graph straight from its Datomic
+/// commit chain — the same `{topic,payload}` a Journal entry would carry, but
+/// derived from `tx_range_from_head` instead of a persisted per-datom log. The
+/// `seq` is a stable 1-based index in commit order (older commits keep their seq
+/// as new ones append), so it works as a resumable cursor.
+fn firehose_events_from_commitdag(
+    state: &KotobaState,
+    graph_mb: &str,
+) -> Result<Vec<FirehoseEvent>, (StatusCode, String)> {
+    let graph_cid = KotobaCid::from_multibase(graph_mb)
+        .ok_or((StatusCode::BAD_REQUEST, "invalid graph CID".to_string()))?;
+    let ipns_name = crate::xrpc::distributed_graph_ipns_name(&graph_cid);
+    let head = match state.ipns_registry.resolve(&IpnsName::new(ipns_name)) {
+        Ok(record) => KotobaCid::from_multibase(&record.value),
+        Err(IpnsRegistryError::NotFound(_)) => None,
+        Err(e) => return Err((StatusCode::INTERNAL_SERVER_ERROR, format!("ipns: {e}"))),
+    };
+    let Some(head) = head else {
+        return Ok(Vec::new());
+    };
+
+    let reader = DistributedDatomReader::new(&*state.block_store, &*state.ipns_registry);
+    let range = reader
+        .tx_range_from_head(&head, None, None)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("tx_range: {e}")))?;
+
+    let mut events = Vec::new();
+    let mut seq = 0u64;
+    for entry in &range {
+        for datom in &entry.datoms {
+            seq += 1;
+            let quad = crate::xrpc::datom_to_projection_quad(datom, &graph_cid);
+            // Topic byte-for-byte matching the Journal projection (journal_assert
+            // → Topic::quad_spo; journal_retract → kotoba/retract/{g}/{s}/{p}).
+            let topic = if datom.added {
+                Topic::quad_spo(
+                    &quad.graph.to_multibase(),
+                    &quad.subject.to_multibase(),
+                    &quad.predicate,
+                    &format!("{:?}", quad.object),
+                )
+                .0
+            } else {
+                format!(
+                    "kotoba/retract/{}/{}/{}",
+                    quad.graph, quad.subject, quad.predicate
+                )
+            };
+            let payload =
+                serde_json::to_value(&quad).unwrap_or(serde_json::Value::Null);
+            events.push(FirehoseEvent {
+                seq,
+                ts: entry.commit.ts,
+                topic,
+                cid: entry.commit.tx_cid.to_multibase(),
+                payload,
+            });
+        }
+    }
+    Ok(events)
+}
+
+/// `GET /xrpc/com.etzhayyim.apps.kotoba.sync.eventsFromCommits?graph=&cursor=N&limit=K&topic_prefix=...`
+///
+/// Journal-free firehose backfill: reconstructs one graph's change feed from the
+/// CommitDag. Identical `{topic,payload}` to the Journal-backed `sync.events`,
+/// so a consumer can replay durable history even when `KOTOBA_JOURNAL_WAL=off`
+/// has dropped the per-datom journal blocks.
+pub async fn events_from_commits(
+    State(state): State<Arc<KotobaState>>,
+    headers: HeaderMap,
+    Query(params): Query<CommitEventsParams>,
+) -> Result<Json<EventsResponse>, (StatusCode, String)> {
+    gate(&state, &headers, params.cacao_b64.as_deref()).await?;
+
+    let all = firehose_events_from_commitdag(&state, &params.graph)?;
+    let current_seq = all.last().map(|e| e.seq).unwrap_or(0);
+
+    let from = params.cursor.unwrap_or(0);
+    let limit = params.limit.unwrap_or(DEFAULT_PAGE_LIMIT).min(MAX_PAGE_LIMIT);
+    let mut events: Vec<FirehoseEvent> = all.into_iter().filter(|e| e.seq > from).collect();
+    if let Some(prefix) = &params.topic_prefix {
+        events.retain(|e| e.topic.starts_with(prefix.as_str()));
+    }
+    let has_more = events.len() > limit;
+    events.truncate(limit);
+    let cursor = events.last().map(|e| e.seq).or(params.cursor).unwrap_or(0);
 
     Ok(Json(EventsResponse {
         events,

--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -1314,6 +1314,10 @@ pub fn build_router(state: Arc<KotobaState>) -> Router {
             &format!("/xrpc/{}", firehose::NSID_SYNC_EVENTS),
             get(firehose::events),
         )
+        .route(
+            &format!("/xrpc/{}", firehose::NSID_SYNC_EVENTS_FROM_COMMITS),
+            get(firehose::events_from_commits),
+        )
         // ── Realtime ingress (ADR-2606060001): bidirectional WebSocket (T1) ──
         // The bus is per-room and isolated from the firehose/gossip above.
         .route(

--- a/crates/kotoba-server/src/server.rs
+++ b/crates/kotoba-server/src/server.rs
@@ -641,15 +641,22 @@ impl KotobaState {
         };
 
         // Journal — Merkle WAL backed by block_store; head pointer in a sibling JSON file.
-        let journal = Arc::new(match &store_path {
-            Some(path) => {
+        //
+        // With `KOTOBA_JOURNAL_WAL=off` the per-entry block persistence is dropped:
+        // the Journal stays an in-memory broadcast + ring (firehose live-tail and the
+        // gossip relay keep working), while durable firehose replay is served from the
+        // CommitDag (`sync.eventsFromCommits` → tx_range_from_head). The CommitDag is
+        // already the durable WAL (ADR-2606041151), so the per-datom journal blocks
+        // were a redundant second copy of every change.
+        let journal = Arc::new(match (&store_path, journal_wal_enabled) {
+            (Some(path), true) => {
                 let head_path = format!("{path}.journal-head.json");
                 tracing::info!("KSE Journal: block-store persistence enabled");
                 Journal::with_block_store(Arc::clone(&block_store), head_path)
             }
-            None => {
+            _ => {
                 tracing::info!(
-                    "KSE Journal: in-memory only (set KOTOBA_STORE_PATH for persistence)"
+                    "KSE Journal: in-memory only (live-tail via broadcast; durable replay via CommitDag)"
                 );
                 Journal::new()
             }

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -2273,7 +2273,7 @@ fn did_document_ipns_name(did: &str) -> String {
     crate::server::did_document_ipns_name(did)
 }
 
-fn datom_to_projection_quad(
+pub(crate) fn datom_to_projection_quad(
     datom: &kotoba_datomic::Datom,
     graph_cid: &kotoba_core::cid::KotobaCid,
 ) -> kotoba_kqe::quad::LegacyQuad {


### PR DESCRIPTION
## Summary

The per-datom **KSE Journal** block-write is a second persisted copy of every change — ~40% of a freshly-loaded graph's on-disk bytes — and it exists **only** to back the firehose. Datomic queries (`q`/`pull`/`datoms`/`as-of`/`since`/`history`) read the **ProllyTree CommitDag**, never the journal. This PR makes the firehose reproducible from the CommitDag so the journal can stop persisting.

### 1. `sync.eventsFromCommits?graph=&cursor=&limit=`
Reconstructs one graph's ordered change feed straight from the Datomic commit chain via `tx_range_from_head` (per-commit delta datoms). It emits the **same `{topic,payload}`** a Journal entry carries:
- assert → `Topic::quad_spo(...)`
- retract → `kotoba/retract/{graph}/{subject}/{predicate}`

`seq` is a stable 1-based index in commit order (older commits keep their seq as new ones append), so it's a resumable cursor. The `eavt/aevt/avet/tea` index roots are already **delta-only per commit**, so the change feed is intrinsic to the CommitDag — no separate log needed.

### 2. `KOTOBA_JOURNAL_WAL=off` now actually drops the journal blocks
The Journal is built **without a block store** in that mode: it stays an in-memory broadcast + ring (firehose live-tail and the libp2p gossip relay keep working), while durable replay comes from the CommitDag. Previously the flag only gated the `atproto_repo_write_datoms` path, so `datomic.transact` still persisted a journal block per datom regardless.

## Benchmark (local, identical 2,000-triple graph, 4 commits)

| | journal blocks | change-feed events |
|---|---|---|
| journal ON  | 2,472 | `sync.events` → 2,398 user events |
| **journal OFF** | **0** | `sync.eventsFromCommits` → **2,398 user events** |

**Set-equality of the two change feeds: IDENTICAL** (2,396 unique, 0 in only one side). With the journal off:
- `sync.events` (in-memory ring) still serves live-tail ✓
- `datomic.q` still works (ProllyTree intact) ✓
- per-datom journal blocks = 0 ✓

## Notes / follow-ups
- `eventsFromCommits` is **per-graph**. A cross-graph (whole-node) firehose needs a small `(ts, graph, tx_cid)` pointer index merged across commit chains — far smaller than a per-datom journal. Left as a follow-up.
- Backfill depth now equals **retained commit history** (the journal gave history-independent backfill). Composes with the history-GC PR (#52): GC sets the firehose backfill horizon.
- Precedent: `kotoba-rt` already does journal-free change streaming (ephemeral gossip deltas + content-addressed snapshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)