### PR TITLE
feat: prune the datomic journal write — CommitDag is the single durable log (0 datomic journal blocks)

### DIFF
--- a/crates/kotoba-kse/src/journal.rs
+++ b/crates/kotoba-kse/src/journal.rs
@@ -108,6 +108,23 @@ impl Journal {
     }
 
     pub async fn publish(&self, topic: Topic, payload: Bytes) -> JournalEntry {
+        self.publish_inner(topic, payload, true).await
+    }
+
+    /// Broadcast + ring-buffer an entry **without** persisting a block.
+    ///
+    /// Used for the datomic firehose: every committed datom is already durable in
+    /// the CommitDag (ProllyTree + IPNS head), so persisting a second copy in the
+    /// Journal's Merkle chain is pure redundancy. The ephemeral publish keeps the
+    /// unified live-tail (broadcast) and short backlog (ring) — durable replay of
+    /// datomic comes from the CommitDag (`sync.eventsFromCommits` /
+    /// `eventsAllGraphs`) — so the per-datom Journal blocks drop to zero
+    /// regardless of `KOTOBA_JOURNAL_WAL`.
+    pub async fn publish_ephemeral(&self, topic: Topic, payload: Bytes) -> JournalEntry {
+        self.publish_inner(topic, payload, false).await
+    }
+
+    async fn publish_inner(&self, topic: Topic, payload: Bytes, persist: bool) -> JournalEntry {
         let mut seq_guard = self.seq.write().await;
         *seq_guard += 1;
         let seq = *seq_guard;
@@ -140,8 +157,8 @@ impl Journal {
             }
         }
 
-        // Persist to block store as a Merkle chain entry
-        if let Some(store) = &self.store {
+        // Persist to block store as a Merkle chain entry (skipped for ephemeral).
+        if let (true, Some(store)) = (persist, &self.store) {
             let mut cbor = Vec::new();
             if ciborium::into_writer(&entry, &mut cbor).is_ok() {
                 let block_cid = KotobaCid::from_bytes(&cbor);

--- a/crates/kotoba-server/src/server.rs
+++ b/crates/kotoba-server/src/server.rs
@@ -1343,7 +1343,9 @@ impl KotobaState {
             if let Some(tx_cid) = &tx_cid {
                 datom.tx = tx_cid.clone();
             }
-            self.journal_assert_datom(&graph_cid, &datom).await;
+            // Already committed to the CommitDag above (commit_datoms) — announce
+            // to the live-tail without a redundant Journal block.
+            self.journal_assert_datom_ephemeral(&graph_cid, &datom).await;
             self.quad_store
                 .apply_journaled_datom(graph_cid.clone(), datom)
                 .await;
@@ -1398,6 +1400,17 @@ impl KotobaState {
     ///
     /// Returns the JournalEntry CID string.
     pub async fn journal_assert(&self, quad: &Quad) -> String {
+        self.journal_assert_with(quad, true).await
+    }
+
+    /// Ephemeral assert: broadcast + ring (live-tail) but **no** block persist.
+    /// Used by the datomic commit path — the datom is already durable in the
+    /// CommitDag, so the Journal must not keep a redundant second copy.
+    pub async fn journal_assert_ephemeral(&self, quad: &Quad) -> String {
+        self.journal_assert_with(quad, false).await
+    }
+
+    async fn journal_assert_with(&self, quad: &Quad, persist: bool) -> String {
         let object_str = format!("{:?}", quad.object);
         let topic = Topic::quad_spo(
             &quad.graph.to_multibase(),
@@ -1417,7 +1430,11 @@ impl KotobaState {
                 .ok();
         }
 
-        let entry = self.journal.publish(topic, Bytes::from(payload)).await;
+        let entry = if persist {
+            self.journal.publish(topic, Bytes::from(payload)).await
+        } else {
+            self.journal.publish_ephemeral(topic, Bytes::from(payload)).await
+        };
         entry.cid.to_multibase()
     }
 
@@ -1428,6 +1445,18 @@ impl KotobaState {
     /// back to Quad at the call site.
     pub async fn journal_assert_datom(&self, graph_cid: &KotobaCid, datom: &KqeDatom) -> String {
         self.journal_assert(&datom_journal_quad(graph_cid, datom))
+            .await
+    }
+
+    /// Ephemeral datom assert — live-tail broadcast only, no Journal block.
+    /// For callers whose datoms are already durable in the CommitDag (e.g. node
+    /// self-registration commits then announces), so the Journal copy is redundant.
+    pub async fn journal_assert_datom_ephemeral(
+        &self,
+        graph_cid: &KotobaCid,
+        datom: &KqeDatom,
+    ) -> String {
+        self.journal_assert_ephemeral(&datom_journal_quad(graph_cid, datom))
             .await
     }
 
@@ -1471,6 +1500,15 @@ impl KotobaState {
 
     /// Publish a Quad retract to the KSE Journal.
     pub async fn journal_retract(&self, quad: &Quad) -> String {
+        self.journal_retract_with(quad, true).await
+    }
+
+    /// Ephemeral retract: broadcast + ring (live-tail) but **no** block persist.
+    pub async fn journal_retract_ephemeral(&self, quad: &Quad) -> String {
+        self.journal_retract_with(quad, false).await
+    }
+
+    async fn journal_retract_with(&self, quad: &Quad, persist: bool) -> String {
         let topic = Topic(format!(
             "kotoba/retract/{}/{}/{}",
             quad.graph, quad.subject, quad.predicate
@@ -1485,7 +1523,11 @@ impl KotobaState {
                 .ok();
         }
 
-        let entry = self.journal.publish(topic, Bytes::from(payload)).await;
+        let entry = if persist {
+            self.journal.publish(topic, Bytes::from(payload)).await
+        } else {
+            self.journal.publish_ephemeral(topic, Bytes::from(payload)).await
+        };
         entry.cid.to_multibase()
     }
 

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -2679,17 +2679,17 @@ pub(crate) async fn commit_protocol_datoms(
     // journal replay); opt out with KOTOBA_JOURNAL_WAL=off to drop the double
     // write. The hot-arrangement update (`apply_journaled_datom`) ALWAYS runs —
     // it serves hot reads and is independent of the WAL block-write.
+    // Datomic firehose: ephemeral live-tail broadcast, no Journal block persist
+    // (the CommitDag is the durable record; sync.eventsFromCommits replays it).
     let mut journal_cids = Vec::with_capacity(datoms.len());
     for datom in &datoms {
-        if state.journal_wal_enabled {
-            let quad = datom_to_projection_quad(datom, &graph_cid);
-            let cid = if datom.added {
-                state.journal_assert(&quad).await
-            } else {
-                state.journal_retract(&quad).await
-            };
-            journal_cids.push(cid);
-        }
+        let quad = datom_to_projection_quad(datom, &graph_cid);
+        let cid = if datom.added {
+            state.journal_assert_ephemeral(&quad).await
+        } else {
+            state.journal_retract_ephemeral(&quad).await
+        };
+        journal_cids.push(cid);
         state
             .quad_store
             .apply_journaled_datom(graph_cid.clone(), datom_to_projection_kqe(datom))
@@ -4896,25 +4896,24 @@ pub async fn datomic_transact(
     let distributed_commit = distributed.commit;
     let tx_datoms = distributed.datoms;
 
+    // Datomic firehose: broadcast each datom to the live-tail (ephemeral — NO
+    // Journal block persist), since the commit is already durable in the CommitDag
+    // and replayable via sync.eventsFromCommits / eventsAllGraphs. This removes the
+    // redundant per-datom Journal copy entirely (the Journal now persists only
+    // non-datomic topics: signal / realtime / kse pub-sub).
     let mut journal_cids = Vec::with_capacity(tx_datoms.len());
     for datom in &tx_datoms {
         let quad = datom_to_projection_quad(datom, &graph_cid);
-        let journal_cid = if datom.added {
-            let cid = state.journal_assert(&quad).await;
-            state
-                .quad_store
-                .apply_journaled_datom(graph_cid.clone(), datom_to_projection_kqe(datom))
-                .await;
-            cid
+        let cid = if datom.added {
+            state.journal_assert_ephemeral(&quad).await
         } else {
-            let cid = state.journal_retract(&quad).await;
-            state
-                .quad_store
-                .apply_journaled_datom(graph_cid.clone(), datom_to_projection_kqe(datom))
-                .await;
-            cid
+            state.journal_retract_ephemeral(&quad).await
         };
-        journal_cids.push(journal_cid);
+        state
+            .quad_store
+            .apply_journaled_datom(graph_cid.clone(), datom_to_projection_kqe(datom))
+            .await;
+        journal_cids.push(cid);
     }
 
     // Refresh the resident db_before cache from the actual committed datoms


### PR DESCRIPTION
## Summary

Removes the redundant per-datom **Journal block-write** from every datomic write path. The CommitDag (ProllyTree + IPNS head) is already the durable record, replayable via `sync.eventsFromCommits` / `sync.eventsAllGraphs` (#53/#54), so the Journal's second copy was pure write-amplification.

Investigation finding that makes this safe: the Journal is a **notification/firehose bus**, not the durable store for non-datomic topics either — `signal` ciphertext lives in the **Shelf**, `realtime` snapshots are **content-addressed in the block store**; their `journal.publish` calls are announcements. So the journal's only *durable* job was the redundant datomic copy.

### Changes
- `Journal::publish_ephemeral` — broadcast + ring (live-tail), **no** block persist.
- `journal_assert_ephemeral` / `journal_retract_ephemeral` (+ datom variants).
- `datomic.transact` and `atproto_repo_write_datoms` announce each datom via the ephemeral path; the hot arrangement (`apply_journaled_datom`) is unchanged.
- Node self-registration (already commits to the CommitDag) announces ephemerally.
- `register_external_node` (**not** CommitDag-backed) keeps its durable journal write.

## Result
- **Datomic durability = CommitDag, exclusively.** Live-tail stays unified via the in-memory journal broadcast; durable replay via CommitDag.
- The Journal now carries only **non-datomic** topics (signal / realtime / kse pub-sub) + the live-tail.

## Benchmark (local, 2,000-triple graph, **`KOTOBA_JOURNAL_WAL=on`**)

| | |
|---|---|
| datomic journal blocks on disk | **0** (was 2,472) |
| datomic live-tail (`sync.events` ring) | 977 person events |
| datomic backfill (`sync.eventsAllGraphs`) | 977 person events |
| `datomic.q` (ProllyTree) | works (20 Tokyo rows) |

Blocks drop to 0 **regardless of the WAL flag** now (it previously only gated one path and never the datomic write). Non-datomic publishers untouched. `kotoba-kse` (150) + server journal tests green.

## On full "one CommitDag" unification
Routing the remaining **non-datomic** announcements (signal/realtime/kse) into the CommitDag too would make it a single mechanism, but each event would become a CommitDag commit — and a commit rebuilds the covering ProllyTree, which is far more expensive than a cheap append. The journal is the right tool for high-frequency pub-sub notification; only the datomic redundancy needed removing. Left as a deliberate boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)