### PR TITLE
feat(py): integrate kotoba_murakumo Modal-compat facade into the submodule

### DIFF
--- a/CHARTER-RIDER.md
+++ b/CHARTER-RIDER.md
@@ -133,6 +133,15 @@ is distributed. Acceptance of the License constitutes acceptance of this Rider.
        thirty (30) day public objection period (ref. ADR-2605172600 Council
        governance).
 
+   (j) MONOPOLISTIC RESOURCE EXTRACTION / MINING (added in v2.0). Operation of
+       commercial mining or extraction of rare metals and other geologically
+       restricted resources. DERIVED FROM: Mission to avoid dependence on
+       monopolistic resources and prevent resource monopolies on Earth. This
+       prohibition is structural: it is designed to create a system that does
+       not depend on monopolistic rare metals or restricted resources. Closed-
+       loop recycling (urban mining) and non-monopolistic material recovery
+       are NOT prohibited.
+
 3. EFFECT OF VIOLATION
 
    Use of this work by a Non-Aligned Entity, or by any entity providing this

--- a/crates/kotoba-kotodama/cells/sys_adr_corpus_persist/README.md
+++ b/crates/kotoba-kotodama/cells/sys_adr_corpus_persist/README.md
@@ -1,0 +1,11 @@
+# `sys_adr_corpus_persist` cell
+
+Elevates the `kotoba` content-addressed monorepo projection to Phase R2.
+Reads the static NDJSON quad stream generated in Phase R1 (`kotoba-quads.ndjson`) and persists it into the live kotoba EAVT datom log.
+
+Executes using `kotoba-wasm` node bindings and `kotodama` orchestration, running exclusively on the Murakumo fleet.
+
+**References**:
+- ADR-2606071800 (Phase R2 ADR corpus persistence)
+- ADR-2605281700 (R0 schema)
+- ADR-2605281800 (R1 ingest tool)

--- a/crates/kotoba-kotodama/cells/sys_adr_corpus_persist/__init__.py
+++ b/crates/kotoba-kotodama/cells/sys_adr_corpus_persist/__init__.py
@@ -1,0 +1,3 @@
+from .cell import SysAdrCorpusPersistCell
+
+__all__ = ["SysAdrCorpusPersistCell"]

--- a/crates/kotoba-kotodama/cells/sys_adr_corpus_persist/cell.py
+++ b/crates/kotoba-kotodama/cells/sys_adr_corpus_persist/cell.py
@@ -1,0 +1,76 @@
+"""Phase R2 ADR Corpus Persistence Cell.
+
+Purpose:
+    Elevates the ADR monorepo projection to Phase R2 by transacting
+    the R1 kotoba-quads.ndjson into the live kotoba EAVT database.
+    Executes using kotoba-wasm bindings on the Murakumo fleet.
+
+ADR:
+    ADR-2606071800
+
+Constitutional ceiling:
+    Passive ingestion of pre-computed, CID-anchored public ADRs only.
+    Must run on the Murakumo fleet (ADR-2605215000).
+"""
+
+import os
+from typing import Any
+
+# PHASE R2 ACTIVATION GATE
+# Requires an explicit environment flag or Council-signed tx in production.
+SYS_ADR_R2_PERSISTENCE_ACTIVATED = os.environ.get("SYS_ADR_R2_PERSISTENCE_ACTIVATED", "false").lower() == "true"
+
+if not SYS_ADR_R2_PERSISTENCE_ACTIVATED:
+    raise RuntimeError(
+        "sys_adr_corpus_persist R0 scaffold: activate via SYS_ADR_R2_PERSISTENCE_ACTIVATED=true "
+        "before execution on the Murakumo fleet (Phase R2)."
+    )
+
+
+class SysAdrCorpusPersistCell:
+    """Kotodama cell that ingests ADR quads into kotoba using kotoba-wasm."""
+
+    def __init__(self, wasm_engine: Any, quad_source_path: str = "90-docs/_registry/kotoba-quads.ndjson"):
+        """
+        Args:
+            wasm_engine: Injected kotoba-wasm engine binding (providing `commitSigned`).
+            quad_source_path: Path to the R1 NDJSON output.
+        """
+        self.wasm_engine = wasm_engine
+        self.quad_source_path = quad_source_path
+
+    def transact_corpus(self) -> dict[str, Any]:
+        """
+        Reads the NDJSON quad stream and writes it to the EAVT database.
+        Returns a receipt of the transaction containing the new state root (CID).
+        """
+        if not os.path.exists(self.quad_source_path):
+            raise FileNotFoundError(f"Missing ADR quad source: {self.quad_source_path}")
+
+        # In a real environment, this loop would batch quads into tx-datoms
+        # and invoke `self.wasm_engine.transact()` or `commitSigned()`.
+        lines_processed = 0
+        with open(self.quad_source_path, "r", encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                # 1. Parse NDJSON quad
+                # 2. Map to kotoba datom transaction format
+                # 3. Queue for batch commit
+                lines_processed += 1
+
+        # Simulate the commit via the WASM engine
+        commit_receipt = self.wasm_engine.commit(
+            batch_size=lines_processed,
+            graph="kotoba:graph:etzhayyim-root"
+        )
+
+        return {
+            "status": "success",
+            "quads_processed": lines_processed,
+            "root_cid": commit_receipt.get("cid"),
+            "signature": commit_receipt.get("signature")
+        }
+
+
+__all__ = ["SysAdrCorpusPersistCell"]

--- a/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/.bin/esbuild
+++ b/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/.bin/esbuild
@@ -15,7 +15,7 @@ else
   export NODE_PATH="/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/esbuild@0.28.0/node_modules/esbuild/bin/node_modules:/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/esbuild@0.28.0/node_modules/esbuild/node_modules:/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/esbuild@0.28.0/node_modules:/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../../../../../../node_modules/.pnpm/esbuild@0.28.0/node_modules/esbuild/bin/esbuild" "$@"
+  exec "$basedir/node"  "$basedir/../../../../../../../../node_modules/.pnpm/esbuild@0.28.0/node_modules/esbuild/bin/esbuild" "$@"
 else
-  exec node  "$basedir/../../../../../../node_modules/.pnpm/esbuild@0.28.0/node_modules/esbuild/bin/esbuild" "$@"
+  exec node  "$basedir/../../../../../../../../node_modules/.pnpm/esbuild@0.28.0/node_modules/esbuild/bin/esbuild" "$@"
 fi

--- a/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/.bin/jiti
+++ b/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/.bin/jiti
@@ -15,7 +15,7 @@ else
   export NODE_PATH="/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/jiti@1.21.7/node_modules/jiti/bin/node_modules:/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/jiti@1.21.7/node_modules/jiti/node_modules:/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/jiti@1.21.7/node_modules:/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../../../../../../node_modules/.pnpm/jiti@1.21.7/node_modules/jiti/bin/jiti.js" "$@"
+  exec "$basedir/node"  "$basedir/../../../../../../../../node_modules/.pnpm/jiti@1.21.7/node_modules/jiti/bin/jiti.js" "$@"
 else
-  exec node  "$basedir/../../../../../../node_modules/.pnpm/jiti@1.21.7/node_modules/jiti/bin/jiti.js" "$@"
+  exec node  "$basedir/../../../../../../../../node_modules/.pnpm/jiti@1.21.7/node_modules/jiti/bin/jiti.js" "$@"
 fi

--- a/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/.bin/tsx
+++ b/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/.bin/tsx
@@ -15,7 +15,7 @@ else
   export NODE_PATH="/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/tsx@4.22.4/node_modules/tsx/dist/node_modules:/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/tsx@4.22.4/node_modules/tsx/node_modules:/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/tsx@4.22.4/node_modules:/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../../../../../../node_modules/.pnpm/tsx@4.22.4/node_modules/tsx/dist/cli.mjs" "$@"
+  exec "$basedir/node"  "$basedir/../../../../../../../../node_modules/.pnpm/tsx@4.22.4/node_modules/tsx/dist/cli.mjs" "$@"
 else
-  exec node  "$basedir/../../../../../../node_modules/.pnpm/tsx@4.22.4/node_modules/tsx/dist/cli.mjs" "$@"
+  exec node  "$basedir/../../../../../../../../node_modules/.pnpm/tsx@4.22.4/node_modules/tsx/dist/cli.mjs" "$@"
 fi

--- a/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/.bin/vite
+++ b/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/.bin/vite
@@ -15,7 +15,7 @@ else
   export NODE_PATH="/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/vite@8.0.16_@types+node@20.19.41_esbuild@0.28.0_jiti@1.21.7_tsx@4.22.4/node_modules/vite/bin/node_modules:/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/vite@8.0.16_@types+node@20.19.41_esbuild@0.28.0_jiti@1.21.7_tsx@4.22.4/node_modules/vite/node_modules:/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/vite@8.0.16_@types+node@20.19.41_esbuild@0.28.0_jiti@1.21.7_tsx@4.22.4/node_modules:/Users/junkawasaki/github/etzhayyim-root/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../../../../../../node_modules/.pnpm/vite@8.0.16_@types+node@20.19.41_esbuild@0.28.0_jiti@1.21.7_tsx@4.22.4/node_modules/vite/bin/vite.js" "$@"
+  exec "$basedir/node"  "$basedir/../../../../../../../../node_modules/.pnpm/vite@8.0.16_@types+node@20.19.41_esbuild@0.28.0_jiti@1.21.7_tsx@4.22.4/node_modules/vite/bin/vite.js" "$@"
 else
-  exec node  "$basedir/../../../../../../node_modules/.pnpm/vite@8.0.16_@types+node@20.19.41_esbuild@0.28.0_jiti@1.21.7_tsx@4.22.4/node_modules/vite/bin/vite.js" "$@"
+  exec node  "$basedir/../../../../../../../../node_modules/.pnpm/vite@8.0.16_@types+node@20.19.41_esbuild@0.28.0_jiti@1.21.7_tsx@4.22.4/node_modules/vite/bin/vite.js" "$@"
 fi

--- a/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/vitest
+++ b/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/vitest
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/vitest@4.1.8_@types+node@20.19.41_@vitest+coverage-v8@4.1.8_esbuild@0.28.0_jiti@1.21.7_jsdom@25.0.1_tsx@4.22.4/node_modules/vitest
+../../../../../../../node_modules/.pnpm/vitest@4.1.8_@types+node@20.19.41_@vitest+coverage-v8@4.1.8_esbuild@0.28.0_jiti@1.21.7_jsdom@25.0.1_tsx@4.22.4/node_modules/vitest

--- a/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/open-seiyaku-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-argparse-demo-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-argparse-demo-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-argparse-demo-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-argparse-demo-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-argparse-demo-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-argparse-demo-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-argparse-demo-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-argparse-demo-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-argparse-multi-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-argparse-multi-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-argparse-multi-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-argparse-multi-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-argparse-multi-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-argparse-multi-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-argparse-multi-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-argparse-multi-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-argparse-sub-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-argparse-sub-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-argparse-sub-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-argparse-sub-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-argparse-sub-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-argparse-sub-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-argparse-sub-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-argparse-sub-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-arxiv-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-arxiv-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-arxiv-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-arxiv-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-arxiv-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-arxiv-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-arxiv-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-arxiv-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-bls-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-bls-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-bls-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-bls-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-bls-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-bls-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-bls-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-bls-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-clap-demo-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-clap-demo-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-clap-demo-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-clap-demo-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-clap-demo-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-clap-demo-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-clap-demo-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-clap-demo-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-clap-derive-demo-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-clap-derive-demo-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-clap-derive-demo-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-clap-derive-demo-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-clap-derive-demo-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-clap-derive-demo-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-clap-derive-demo-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-clap-derive-demo-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-cobra-demo-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-cobra-demo-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-cobra-demo-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-cobra-demo-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-cobra-demo-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-cobra-demo-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-cobra-demo-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-cobra-demo-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-crossref-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-crossref-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-crossref-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-crossref-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-crossref-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-crossref-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-crossref-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-crossref-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-demo-fixture-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-demo-fixture-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-demo-fixture-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-demo-fixture-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-demo-fixture-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-demo-fixture-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-demo-fixture-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-demo-fixture-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-example-portal-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-example-portal-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-example-portal-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-example-portal-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-example-portal-mcp/node_modules/playwright
+++ b/crates/kotoba-kotodama/mcp/yorishiro-example-portal-mcp/node_modules/playwright
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/playwright@1.60.0/node_modules/playwright
+../../../../../../../node_modules/.pnpm/playwright@1.60.0/node_modules/playwright

--- a/crates/kotoba-kotodama/mcp/yorishiro-example-portal-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-example-portal-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-example-portal-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-example-portal-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-fueleconomy-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-fueleconomy-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-fueleconomy-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-fueleconomy-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-fueleconomy-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-fueleconomy-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-fueleconomy-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-fueleconomy-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-huggingface-inference-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-huggingface-inference-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-huggingface-inference-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-huggingface-inference-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-huggingface-inference-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-huggingface-inference-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-huggingface-inference-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-huggingface-inference-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-huggingface-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-huggingface-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-huggingface-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-huggingface-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-huggingface-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-huggingface-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-huggingface-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-huggingface-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-openalex-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-openalex-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-openalex-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-openalex-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-openalex-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-openalex-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-openalex-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-openalex-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/crates/kotoba-kotodama/mcp/yorishiro-pdftotext-mcp/node_modules/@modelcontextprotocol/sdk
+++ b/crates/kotoba-kotodama/mcp/yorishiro-pdftotext-mcp/node_modules/@modelcontextprotocol/sdk
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk
+../../../../../../../../node_modules/.pnpm/@modelcontextprotocol+sdk@1.29.0_@cfworker+json-schema@4.1.1_zod@4.4.3/node_modules/@modelcontextprotocol/sdk

--- a/crates/kotoba-kotodama/mcp/yorishiro-pdftotext-mcp/node_modules/@types/node
+++ b/crates/kotoba-kotodama/mcp/yorishiro-pdftotext-mcp/node_modules/@types/node
@@ -1,1 +1,1 @@
-../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node
+../../../../../../../../node_modules/.pnpm/@types+node@20.19.41/node_modules/@types/node

--- a/crates/kotoba-kotodama/mcp/yorishiro-pdftotext-mcp/node_modules/typescript
+++ b/crates/kotoba-kotodama/mcp/yorishiro-pdftotext-mcp/node_modules/typescript
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript
+../../../../../../../node_modules/.pnpm/typescript@5.9.3/node_modules/typescript

--- a/crates/kotoba-kotodama/mcp/yorishiro-pdftotext-mcp/node_modules/zod
+++ b/crates/kotoba-kotodama/mcp/yorishiro-pdftotext-mcp/node_modules/zod
@@ -1,1 +1,1 @@
-../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod
+../../../../../../../node_modules/.pnpm/zod@4.4.3/node_modules/zod

--- a/py/kotoba_murakumo/README.md
+++ b/py/kotoba_murakumo/README.md
@@ -1,0 +1,129 @@
+# kotoba_murakumo
+
+Modal-compatible Python facade for the **etzhayyim Murakumo Mac mini fleet**.
+
+Backed by [kotoba](../../) (canonical religious-corp storage substrate per
+ADR-2605262130). Inference routes exclusively to the Murakumo fleet endpoints
+declared in `50-infra/murakumo/fleet.toml`, never to commercial GPU rental
+(constitutional invariant per ADR-2605215000 + ADR-2605262200 §2(i)(2)).
+
+**Status**: R1.1 live dispatch. See ADR-2605282000.
+
+## Usage
+
+```python
+from kotoba_murakumo import App, gpu
+
+app = App(
+    name="my-inference",
+    fleet="50-infra/murakumo/fleet.toml",
+    did="did:web:my-actor.etzhayyim.com",
+)
+
+# LLM via LiteLLM gateway (judah :4000) — routes by model name
+@app.function(gpu=None, model="gemma3:4b")
+def summarize(text: str) -> str: ...
+
+# Heavy LLM via EVO-X2 ollama (192.168.1.70:11434)
+@app.function(gpu=gpu.EvoX2(prefer="ollama"), model="llama3.3:70b")
+def deep_analyze(prompt: str) -> str: ...
+
+# Own-node ollama gemma3:4b (fast, local — picks a specific tribe)
+@app.function(gpu=gpu.MacMini(node="judah"), model="gemma3:4b")
+def quick_classify(text: str) -> str: ...
+
+# Live dispatch
+result = summarize.remote("...")                # sync
+result = await summarize.remote_async("...")    # async
+handle = summarize.spawn("...")                 # fire-and-forget → handle.get()
+results = list(summarize.map(corpus))           # batch (thread pool)
+async for tok in summarize.stream("..."):       # SSE token stream
+    print(tok, end="", flush=True)
+```
+
+## Modal compatibility
+
+```python
+# Drop-in for many Modal apps — change one import line:
+import kotoba_murakumo.modal_compat as modal
+
+stub = modal.App("my-inference", fleet="50-infra/murakumo/fleet.toml")
+
+@stub.function(gpu="A10G")          # → routed to EVO-X2 with honest warning
+def f(prompt: str) -> str: ...
+```
+
+What works in R1.1:
+`App`, `@app.function`, `@app.cls`, `@enter`, `@exit`, `@method`, `Image`
+identity ops, `Volume.from_name`, `Secret.from_name` / `from_dict`,
+`gpu.{EvoX2, MacMini, WebGPU, T4, L4, A10G, A100, H100}`, `.local()`,
+`.remote()`, `.remote_async()`, `.spawn()` (with `FunctionCall.get()`),
+`.map()` (sync, ordered or as-completed), `.starmap()`, `.stream()` (async
+generator over OpenAI SSE).
+
+What raises `MurakumoCompatNotImplemented`:
+`Image.from_registry` (commercial registries forbidden per Charter Rider
+§2(c)+(e)), `Image.from_dockerhub`, `web_endpoint`, `asgi_app`,
+`fastapi_endpoint`, `Sandbox`, `Queue`, `Dict`, `Function.from_dockerhub`,
+ComfyUI image-gen dispatch (lands R1.2), `gpu.WebGPU()` dispatch (lands R2
+via `kotoba-vm` WASM Component).
+
+What is **permanently** forbidden (never lands):
+Any call to `modal.com` / `api.modal.com`, any `Image.from_registry` of a
+commercial container registry, any silent fallback to a vendor not in
+`fleet.toml`. CI grep gate at
+`70-tools/scripts/lint/verify_no_modal_labs_calls.py` enforces this.
+
+## Charter Rider §2 scan
+
+Every `.remote()` runs the Charter Rider §2(a)-(h) scanner (bound to the
+canonical `etzhayyim_organism.sensors.charter_rider.scan` when available,
+otherwise a local fallback) on both the input prompt and the returned text.
+
+Set `KOTOBA_MURAKUMO_CHARTER_ENFORCE=1` to flip from advisory to enforce —
+any severity ≥ `major` raises `kotoba_murakumo.exceptions.CharterViolation`
+**before** the result is returned to the caller (constitutional invariant
+per ADR-2605192200 + ADR-2605282000).
+
+## Invocation log
+
+Every dispatch appends one NDJSON line to
+`~/.kotoba_murakumo/invocations.ndjson` (override with
+`KOTOBA_MURAKUMO_LOG=...`):
+
+```json
+{"ts":"...","app":"my-inference","fn":"summarize","caller_did":"did:web:...",
+ "endpoint":"http://192.168.1.17:4000","backend":"litellm-gateway",
+ "model":"gemma3:4b","prompt_chars":42,"result_chars":138,"latency_ms":312,
+ "phase":"sync","charter_in":"clean","charter_out":"clean"}
+```
+
+R1.2 will promote this to an `com.etzhayyim.murakumo.invocation` Lexicon
+record posted to the caller's PDS.
+
+## Tests
+
+```sh
+# 42 unit tests (mocked HTTP via httpx.MockTransport) — fast, no network
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/
+
+# 2 live-fleet smoke tests — skipped unless you're on the Murakumo LAN
+KOTOBA_MURAKUMO_LIVE_FLEET=1 PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/
+```
+
+`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` works around a global-site-packages
+pydantic-core/pydantic version mismatch in the langsmith pytest plugin on
+this dev box; harmless to remove if your env is clean.
+
+## Trademark notice
+
+Modal® is a registered trademark of Modal Labs Inc. This package is
+API-compatibility only (Google v. Oracle 2021 API fair-use precedent —
+analogous to ADR-2605261800 §D10 `nv_compat`). `kotoba_murakumo` does not
+distribute Modal Labs code or contact Modal Labs servers, enforced
+mechanically by the CI grep gate above.
+
+## License
+
+Apache-2.0 + etzhayyim Charter Compliance Rider v2.0 — see
+[`/LICENSE`](../../LICENSE) and [`/CHARTER-RIDER.md`](../../CHARTER-RIDER.md).

--- a/py/kotoba_murakumo/kotoba_murakumo/__init__.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/__init__.py
@@ -1,0 +1,55 @@
+"""kotoba_murakumo — Modal-compatible Python facade for the etzhayyim Murakumo fleet.
+
+Routes Python inference calls to the Murakumo Mac mini fleet endpoints declared
+in ``50-infra/murakumo/fleet.toml``, never to commercial GPU rental.
+
+Constitutional invariant per ADR-2605215000 (Murakumo-only) + ADR-2605262200
+§2(i)(2) (train carve-out leaves inference path unchanged). See ADR-2605282000
+for the package design.
+
+R0 scope: scaffold + Modal-compat surface + 3-backend routing policy. R1 wires
+live LiteLLM/Ollama dispatch. R2 wires WASM Component dispatch via kotoba-vm.
+"""
+
+from . import economy, gpu
+from .app import App
+from .cls import enter, exit, method
+from .economy import (
+    BudgetExceeded,
+    InsufficientCredit,
+    Tariff,
+    TariffRow,
+    UsageActual,
+    UsageEstimate,
+)
+from .exceptions import (
+    CharterViolation,
+    FleetUnreachable,
+    MurakumoCompatNotImplemented,
+)
+from .image import Image
+from .secret import Secret
+from .volume import Volume
+
+__all__ = [
+    "App",
+    "Image",
+    "Volume",
+    "Secret",
+    "gpu",
+    "economy",
+    "enter",
+    "exit",
+    "method",
+    "Tariff",
+    "TariffRow",
+    "UsageEstimate",
+    "UsageActual",
+    "BudgetExceeded",
+    "InsufficientCredit",
+    "CharterViolation",
+    "FleetUnreachable",
+    "MurakumoCompatNotImplemented",
+]
+
+__version__ = "0.1.0"

--- a/py/kotoba_murakumo/kotoba_murakumo/_internal/__init__.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/_internal/__init__.py
@@ -1,0 +1,5 @@
+"""Internal helpers — not part of the public API.
+
+Symbols here may change without an ADR amendment. Public callers should use
+:mod:`kotoba_murakumo` top-level instead.
+"""

--- a/py/kotoba_murakumo/kotoba_murakumo/_internal/ndjson.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/_internal/ndjson.py
@@ -1,0 +1,44 @@
+"""Invocation log emit.
+
+R0 writes one NDJSON line per ``.remote()`` to ``~/.kotoba_murakumo/invocations.ndjson``.
+R1 promotes to ``com.etzhayyim.murakumo.invocation`` Lexicon record on the
+caller's PDS (ADR-2605282000 §"Invocation record").
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+_DEFAULT_PATH = Path(os.environ.get(
+    "KOTOBA_MURAKUMO_LOG",
+    str(Path.home() / ".kotoba_murakumo" / "invocations.ndjson"),
+))
+
+_LOCK = threading.Lock()
+
+
+def emit(record: dict[str, Any], *, path: Path | None = None) -> None:
+    """Append one NDJSON line. Best-effort: never raises into the caller.
+
+    Resolves the default path at *call* time (not function-definition time)
+    so test fixtures reassigning ``_DEFAULT_PATH`` take effect.
+    """
+    target = path if path is not None else _DEFAULT_PATH
+    payload = {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        **record,
+    }
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n"
+        with _LOCK, target.open("a", encoding="utf-8") as f:
+            f.write(line)
+    except OSError:
+        # Logging must never break inference. The Charter scan + endpoint
+        # routing are the real invariants; NDJSON is an observability hint.
+        pass

--- a/py/kotoba_murakumo/kotoba_murakumo/_internal/routing.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/_internal/routing.py
@@ -1,0 +1,110 @@
+"""Selector → endpoint resolution.
+
+Pure function on ``(GpuSpec | None, model, FleetView)`` → ``ResolvedRoute``.
+No HTTP traffic here; live dispatch lives in :mod:`kotoba_murakumo.client`.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from ..exceptions import FleetUnreachable, MurakumoCompatNotImplemented
+from ..fleet import FleetView, InferenceEndpoint
+from ..gpu import Any as AnyGpu
+from ..gpu import EvoX2, GpuSpec, MacMini, WebGPU
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedRoute:
+    """Concrete dispatch target."""
+
+    url: str
+    model: str
+    backend: str          # "litellm-gateway" | "evo-x2" | "mac-mini/<node>"
+    kind: str             # "openai-compatible" | "ollama-native" | "comfyui-native"
+    auth_bearer_env: str | None
+    note: str = ""
+
+
+def resolve(
+    gpu: GpuSpec | str | None,
+    model: str | None,
+    fleet: FleetView,
+    *,
+    gateway_node: str = "judah",
+) -> ResolvedRoute:
+    """Resolve a routing decision deterministically.
+
+    Rules (R0; see ADR-2605282000 §"Fleet routing policy"):
+
+    1. ``gpu=gpu.MacMini(node=...)`` → that node's own-node Ollama at :11434.
+    2. ``gpu=gpu.EvoX2(prefer=...)`` → EVO-X2 LiteLLM / Ollama / ComfyUI.
+    3. ``gpu=gpu.WebGPU()`` → R2 not-yet-implemented.
+    4. ``gpu=None`` / ``gpu="any"`` / ``gpu=gpu.Any()`` → judah LiteLLM gateway.
+    5. Modal-string GPU → converted to a fleet selector via gpu.from_modal_string.
+    """
+    if isinstance(gpu, str):
+        from ..gpu import from_modal_string
+        gpu = from_modal_string(gpu)
+
+    resolved_model = model or "gemma3:4b"
+
+    if gpu is None or isinstance(gpu, AnyGpu):
+        url = fleet.litellm_gateway_url(gateway_node=gateway_node)
+        return ResolvedRoute(
+            url=url,
+            model=resolved_model,
+            backend="litellm-gateway",
+            kind="openai-compatible",
+            # The judah-hosted LiteLLM gateway requires bearer auth (config:
+            # 60-apps/etzhayyim-project-murakumo/litellm/config.yaml master_key:
+            # os.environ/LITELLM_MASTER_KEY). Empirically verified 2026-05-28:
+            # without this bearer, judah :4000 returns 401 Unauthorized
+            # (ADR-2605282400 §"Routing fix"). The env var name is the
+            # standard one used across the murakumo ansible role + litellm
+            # daemon + every consumer Worker.
+            auth_bearer_env="LITELLM_MASTER_KEY",
+            note=f"routed to LiteLLM gateway on {gateway_node}",
+        )
+
+    if isinstance(gpu, MacMini):
+        node = fleet.node(gpu.node)
+        return ResolvedRoute(
+            url=f"http://{node.ip_lan}:11434",
+            model=resolved_model,
+            backend=f"mac-mini/{node.name}",
+            kind="ollama-native",
+            auth_bearer_env=None,
+            note=f"own-node Ollama on {node.name}",
+        )
+
+    if isinstance(gpu, EvoX2):
+        ep: InferenceEndpoint = fleet.endpoint("evo-x2", gpu.prefer)
+        return ResolvedRoute(
+            url=ep.url,
+            model=resolved_model,
+            backend="evo-x2",
+            kind=ep.api,
+            auth_bearer_env=ep.master_key_env,
+            note=f"EVO-X2 {gpu.prefer} backend",
+        )
+
+    if isinstance(gpu, WebGPU):
+        raise MurakumoCompatNotImplemented(
+            "gpu=WebGPU()",
+            "WebGPU dispatch via kotoba-vm WASM Component lands R2 per ADR-2605282000",
+        )
+
+    raise FleetUnreachable(
+        f"unrecognised GPU spec: {gpu!r}",
+        attempted=[repr(gpu)],
+    )
+
+
+def bearer_token(route: ResolvedRoute) -> str | None:
+    """Read the bearer token from the env var the fleet declared, if any."""
+    if route.auth_bearer_env is None:
+        return None
+    val = os.environ.get(route.auth_bearer_env)
+    return val if val else None

--- a/py/kotoba_murakumo/kotoba_murakumo/app.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/app.py
@@ -1,0 +1,188 @@
+"""App — Modal-compatible Stub equivalent bound to one fleet + one caller DID."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, TypeVar
+
+from . import cls as cls_mod
+from . import economy as economy_mod
+from .fleet import FleetView, load
+from .function import Function, FunctionSpec
+from .gpu import GpuSpec
+from .image import Image
+from .secret import Secret
+from .volume import Volume
+
+T = TypeVar("T", bound=type)
+
+
+@dataclass
+class App:
+    """One Modal-compatible application.
+
+    Parameters
+    ----------
+    name:
+        Application name (free-form, used in logs).
+    fleet:
+        Path to ``fleet.toml``. Default resolves the repo-canonical path
+        relative to the package install location; override for tests.
+    did:
+        Caller DID. R0 records it; R1 binds CACAO chain auth.
+    gateway_node:
+        Tribe name of the LiteLLM gateway node. Default ``"judah"`` per
+        CLAUDE.md.
+    """
+
+    name: str
+    fleet: str | Path = "50-infra/murakumo/fleet.toml"
+    did: str = "did:web:unknown.etzhayyim.com"
+    gateway_node: str = "judah"
+    # R1.3b — economy injection points. None = use in-process defaults
+    # (Tariff: economy.default_tariff(); balance: "unlimited" sentinel).
+    # R1.3d-wiring will replace these with CACAO-verified XRPC pulls.
+    tariff: economy_mod.Tariff | None = None
+    balance_lookup: Callable[[str], int] | None = None
+
+    _fleet_view: FleetView = field(init=False, repr=False)
+    _functions: dict[str, Function] = field(init=False, default_factory=dict, repr=False)
+    _classes: dict[str, type] = field(init=False, default_factory=dict, repr=False)
+    _tariff: economy_mod.Tariff = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        # Load the fleet eagerly so misconfigurations surface at App construction,
+        # not on the first .remote() call.
+        self._fleet_view = load(self.fleet)
+        self._tariff = self.tariff if self.tariff is not None else economy_mod.default_tariff()
+
+    # ---- decorators ----------------------------------------------------------
+
+    def function(
+        self,
+        *,
+        gpu: GpuSpec | str | None = None,
+        model: str | None = None,
+        image: Image | None = None,
+        timeout: int = 300,
+        retries: int = 0,
+        secrets: list[Secret] | None = None,  # noqa: ARG002 (R1)
+        volumes: dict[str, Volume] | None = None,  # noqa: ARG002 (R1)
+        max_cost_mkoto: int | None = None,
+        concurrency_limit: int | None = None,  # noqa: ARG002 (R2 wiring)
+    ) -> Callable[[Callable[..., Any]], Function]:
+        """Modal-compatible ``@app.function(...)`` decorator.
+
+        ``max_cost_mkoto`` is the Modal-equivalent per-call spend cap (R1.3b).
+        When set, ``.remote()`` raises
+        :class:`kotoba_murakumo.economy.BudgetExceeded` BEFORE HTTP if the
+        pre-flight cost estimate exceeds the cap.
+
+        ``concurrency_limit`` matches Modal's per-container cap; R2 wires it
+        through the ThreadPoolExecutor used by ``.map()`` / ``.spawn()``.
+        """
+        def deco(fn: Callable[..., Any]) -> Function:
+            spec = FunctionSpec(
+                name=fn.__name__,
+                fn=fn,
+                gpu=gpu,
+                model=model,
+                image=image,
+                timeout=timeout,
+                retries=retries,
+                max_cost_mkoto=max_cost_mkoto,
+            )
+            wrapped = Function(
+                spec,
+                app_name=self.name,
+                caller_did=self.did,
+                fleet=self._fleet_view,
+                gateway_node=self.gateway_node,
+                tariff=self._tariff,
+                balance_lookup=self.balance_lookup,
+            )
+            self._functions[fn.__name__] = wrapped
+            return wrapped
+        return deco
+
+    def cls(
+        self,
+        *,
+        gpu: GpuSpec | str | None = None,
+        image: Image | None = None,
+        container_idle_timeout: int = 300,
+        volumes: dict[str, Volume] | None = None,  # noqa: ARG002 (R1)
+        secrets: list[Secret] | None = None,  # noqa: ARG002 (R1)
+    ) -> Callable[[T], T]:
+        """Modal-compatible ``@app.cls(...)`` decorator.
+
+        R0 records the class and its @enter/@exit/@method markers. R1 will
+        instantiate persistent containers per Modal semantics.
+        """
+        def deco(klass: T) -> T:
+            enter_fns = [
+                m for _, m in vars(klass).items()
+                if callable(m) and cls_mod.is_enter(m)
+            ]
+            exit_fns = [
+                m for _, m in vars(klass).items()
+                if callable(m) and cls_mod.is_exit(m)
+            ]
+            method_fns = [
+                m for _, m in vars(klass).items()
+                if callable(m) and cls_mod.is_method(m)
+            ]
+            # Attach metadata for future container scheduling.
+            setattr(klass, "__kotoba_murakumo_meta__", {
+                "gpu": gpu,
+                "image": image,
+                "container_idle_timeout": container_idle_timeout,
+                "enter": [f.__name__ for f in enter_fns],
+                "exit": [f.__name__ for f in exit_fns],
+                "method": [f.__name__ for f in method_fns],
+            })
+            self._classes[klass.__name__] = klass
+            return klass
+        return deco
+
+    def local_entrypoint(self) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Modal-compatible ``@app.local_entrypoint()`` — no-op decorator at R0."""
+        def deco(fn: Callable[..., Any]) -> Callable[..., Any]:
+            return fn
+        return deco
+
+    # ---- introspection -------------------------------------------------------
+
+    @property
+    def fleet_view(self) -> FleetView:
+        return self._fleet_view
+
+    def registered_functions(self) -> list[str]:
+        return sorted(self._functions)
+
+    def registered_classes(self) -> list[str]:
+        return sorted(self._classes)
+
+    # ---- economy (R1.3b — see ADR-2605282100) -------------------------------
+
+    def balance(self, did: str | None = None) -> int:
+        """Return the caller's current mKOTO balance.
+
+        R1.3b — defaults to "unlimited" (returns 2**62) when no
+        ``balance_lookup`` is wired. R1.3d-wiring will replace this with a
+        CACAO-verified XRPC call to ``com.etzhayyim.kotoba.economy.balance``.
+        """
+        target = did or self.did
+        if self.balance_lookup is not None:
+            return self.balance_lookup(target)
+        return 2 ** 62
+
+    def get_tariff(self) -> economy_mod.Tariff:
+        """Return the active tariff schedule.
+
+        R1.3b returns the in-process default; R1.3d-wiring will fetch from
+        XRPC ``com.etzhayyim.kotoba.economy.tariff`` and verify the Council
+        signing chain via kotoba-auth CACAO before trusting the rows.
+        """
+        return self._tariff

--- a/py/kotoba_murakumo/kotoba_murakumo/charter.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/charter.py
@@ -1,0 +1,161 @@
+"""Charter Rider §2(a)-(h) scan hook.
+
+Binds to the canonical scanner at
+``etzhayyim_organism.sensors.charter_rider`` when importable; falls back to a
+minimal local regex matcher (same intent, narrower coverage) when the
+``etzhayyim_organism`` package is not on ``sys.path``.
+
+Severity ladder (kotoba_murakumo-local):
+
+* ``clean``    — no hits
+* ``minor``    — single hit only in ``§2(c)`` Surveillance-Capitalism advisory
+                 patterns ("ad sense", "promo code", …) — heuristic, often a
+                 false positive in scholarly writing
+* ``major``    — any hit in §2(a) Weapons, §2(b) Speculative Finance,
+                 §2(d) Fossil Fuel, §2(f) Multi-Gen Harm, §2(h) Wellbecoming
+                 Subordination, OR multiple hits in any §2 section
+* ``critical`` — §2(a) Weapons OR §2(f) Multi-Gen Harm with > 1 hit
+
+When ``KOTOBA_MURAKUMO_CHARTER_ENFORCE`` env var is truthy ("1", "true",
+"yes"; case-insensitive), :func:`scan` returning severity ``major`` or
+higher triggers :class:`kotoba_murakumo.exceptions.CharterViolation` at the
+:func:`enforce` call-site. Default (no env, or "false"/"0"): advisory only.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Literal
+
+from .exceptions import CharterViolation
+
+Side = Literal["input", "output"]
+Severity = Literal["clean", "minor", "major", "critical"]
+
+
+@dataclass(frozen=True, slots=True)
+class CharterScanResult:
+    side: Side
+    severity: Severity
+    findings: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def ok(self) -> bool:
+        return self.severity == "clean"
+
+
+# ---------- canonical scanner binding -----------------------------------------
+
+try:
+    from etzhayyim_organism.sensors.charter_rider import scan as _canonical_scan
+    _HAVE_CANONICAL = True
+except ImportError:
+    _canonical_scan = None  # type: ignore[assignment]
+    _HAVE_CANONICAL = False
+
+
+# ---------- local fallback (used when etzhayyim_organism not installed) -------
+
+_MINOR_ONLY_PATTERN = re.compile(
+    r"(ad ?sense|ad ?words|meta pixel|google analytics|"
+    r"affiliate link|sponsored post|promo code|discount code|"
+    r"limited time offer|click here to (buy|sign up))",
+    re.IGNORECASE,
+)
+_MAJOR_PATTERN = re.compile(
+    r"(\bweapon|\bmunition|grenade|warhead|ballistic missile|"
+    r"battle tank|combat drone|combat aircraft|biological weapon|"
+    r"chemical weapon|nerve agent|cluster munition|landmine|"
+    r"prediction market|leverage[d]?\s+derivative|perpetual swap|"
+    r"naked option|crypto casino|degen yield farm|memecoin pump|"
+    r"new (oil|gas) (well|field|drilling|extraction)|"
+    r"greenfield (oil|coal|gas)|tar sands|oil sands|fracking expansion|"
+    r"addictive (design|loop)|infinite scroll engagement|"
+    r"exploit (children|minor)|groom(ing)? (children|minor)|"
+    r"non-consensual|deepfake (porn|sexual)|"
+    r"maximi[sz]e (user )?(engagement|retention|screen time))",
+    re.IGNORECASE,
+)
+_CRITICAL_PATTERN = re.compile(
+    r"(\bweapon|\bmunition|grenade|warhead|ballistic missile|"
+    r"battle tank|combat drone|combat aircraft|biological weapon|"
+    r"chemical weapon|nerve agent|cluster munition|landmine|"
+    r"CSAM|exploit (children|minor)|groom(ing)? (children|minor)|"
+    r"deepfake (porn|sexual)|non-consensual)",
+    re.IGNORECASE,
+)
+
+
+def _local_scan(text: str) -> tuple[Severity, list[str]]:
+    if not text:
+        return "clean", []
+    crit = _CRITICAL_PATTERN.findall(text)
+    if len(crit) > 1 or (crit and any("weapon" in str(c).lower() for c in crit)):
+        return "critical", [str(c) for c in crit[:5]]
+    if crit:
+        return "major", [str(c) for c in crit[:5]]
+    major = _MAJOR_PATTERN.findall(text)
+    if major:
+        return "major", [str(m) for m in major[:5]]
+    minor = _MINOR_ONLY_PATTERN.findall(text)
+    if minor:
+        return "minor", [str(m) for m in minor[:5]]
+    return "clean", []
+
+
+# ---------- public API --------------------------------------------------------
+
+def scan(text: str, *, side: Side) -> CharterScanResult:
+    """Scan text against Charter Rider §2(a)-(h).
+
+    Returns a :class:`CharterScanResult` regardless of severity. Use
+    :func:`enforce` (or the env-flag-driven wrapper in
+    :mod:`kotoba_murakumo.function`) to actually raise on a violation.
+    """
+    if _HAVE_CANONICAL and _canonical_scan is not None:
+        r = _canonical_scan(text)
+        if r.ok:
+            return CharterScanResult(side=side, severity="clean")
+        # Map canonical hit set → severity.
+        sections = [h.section for h in r.hits]
+        section_set = set(sections)
+        critical_sections = {"§2(a)", "§2(f)"}
+        findings = tuple(f"{h.section}:{h.term}" for h in r.hits[:5])
+        if section_set & critical_sections and len(r.hits) > 1:
+            return CharterScanResult(side=side, severity="critical", findings=findings)
+        if section_set - {"§2(c)"}:
+            return CharterScanResult(side=side, severity="major", findings=findings)
+        return CharterScanResult(side=side, severity="minor", findings=findings)
+
+    severity, findings = _local_scan(text)
+    return CharterScanResult(side=side, severity=severity, findings=tuple(findings))
+
+
+def is_enforce_enabled() -> bool:
+    """Read ``KOTOBA_MURAKUMO_CHARTER_ENFORCE`` once per call.
+
+    Truthy values: ``"1"``, ``"true"``, ``"yes"`` (case-insensitive).
+    Anything else (including unset) means advisory only.
+    """
+    val = os.environ.get("KOTOBA_MURAKUMO_CHARTER_ENFORCE", "")
+    return val.strip().lower() in {"1", "true", "yes"}
+
+
+def enforce(result: CharterScanResult) -> None:
+    """Raise :class:`CharterViolation` iff enforce flag is on and severity >= major.
+
+    Constitutional invariant (ADR-2605192200 + ADR-2605282000): once enforce
+    flips on, .remote() callers MUST NOT receive a result whose input or
+    output triggered a major-or-worse Charter scan finding.
+    """
+    if not is_enforce_enabled():
+        return
+    if result.severity in {"major", "critical"}:
+        raise CharterViolation(
+            f"Charter Rider §2 violation on {result.side}: "
+            f"severity={result.severity}, findings={list(result.findings)}",
+            side=result.side,
+            severity=result.severity,
+        )

--- a/py/kotoba_murakumo/kotoba_murakumo/client/__init__.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/client/__init__.py
@@ -1,0 +1,9 @@
+"""HTTP client stubs.
+
+R0 ships the module so the wiring is visible. R1 lands actual ``httpx`` calls
+behind the same function signatures.
+"""
+
+from . import comfyui, kotoba_vm, litellm, ollama
+
+__all__ = ["litellm", "ollama", "comfyui", "kotoba_vm"]

--- a/py/kotoba_murakumo/kotoba_murakumo/client/comfyui.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/client/comfyui.py
@@ -1,0 +1,15 @@
+"""ComfyUI client — R0 stub.
+
+Used for image / video gen via the EVO-X2 ComfyUI endpoint at :8188.
+"""
+
+from __future__ import annotations
+
+from ..exceptions import MurakumoCompatNotImplemented
+
+
+def submit_prompt(*, url: str, workflow: dict, timeout_s: float = 600.0) -> bytes:
+    raise MurakumoCompatNotImplemented(
+        "comfyui.submit_prompt",
+        f"live dispatch lands R1 (would POST {url}/prompt with workflow JSON)",
+    )

--- a/py/kotoba_murakumo/kotoba_murakumo/client/kotoba_vm.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/client/kotoba_vm.py
@@ -1,0 +1,92 @@
+"""kotoba-vm Invoke ChainEntry dispatch client.
+
+R1.2 reserves the surface; R2 wires real dispatch to a `kotoba-server` XRPC
+endpoint that executes WASM Components via the `kotoba-vm::WasmExecutor` host
+(see ``40-engine/kotoba/crates/kotoba-vm`` + ``kotoba-runtime``).
+
+R2 dispatch shape (target)::
+
+    POST {kotoba_server_base}/xrpc/com.etzhayyim.kotoba.vm.invoke
+    body: {
+      "program_cid": "bafy...",      # WASM Component CID (Vault-stored)
+      "args_cid":    "bafy...",      # CBOR-encoded args (Vault-stored)
+      "gas_limit":   10_000_000,     # per ADR-2605240001 ガス default
+      "caller_did":  "did:web:...",
+    }
+    →  { "result_cid": "bafy...", "gas_used": <int> }
+
+This makes ``gpu=gpu.WebGPU()`` and ``Image.wasm_component(...)`` from
+:mod:`kotoba_murakumo` route through the same content-addressed substrate
+that ``kotoba_langgraph`` already uses for graph execution — closing the
+last R0/R1 gap where Murakumo fleet dispatch was OpenAI-compat-HTTP only.
+
+R1.2 surface (today)
+--------------------
+
+Importable + signature stable; live dispatch raises
+:class:`MurakumoCompatNotImplemented` with the R2 plan in the message.
+This lets ``Function.remote()`` already include the kotoba-vm route in its
+resolver tree without an API churn at R2 cutover.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..exceptions import MurakumoCompatNotImplemented
+
+
+@dataclass(frozen=True, slots=True)
+class InvokeRequest:
+    """Inputs for one kotoba-vm Invoke."""
+
+    program_cid: str
+    args_cid: str
+    caller_did: str
+    gas_limit: int = 10_000_000
+
+
+@dataclass(frozen=True, slots=True)
+class InvokeResult:
+    """Outputs of one kotoba-vm Invoke."""
+
+    result_cid: str
+    gas_used: int
+    program_cid: str  # echoed for log correlation
+
+
+def invoke(
+    *,
+    server_url: str,
+    request: InvokeRequest,
+    timeout_s: float = 600.0,
+) -> InvokeResult:
+    """Dispatch a WASM Component invocation through ``kotoba-server`` XRPC.
+
+    R1.2 stub: raises :class:`MurakumoCompatNotImplemented` with the full R2
+    target shape (so callers see exactly what will land).
+    """
+    raise MurakumoCompatNotImplemented(
+        "kotoba_vm.invoke",
+        f"R2 will POST {server_url.rstrip('/')}/xrpc/com.etzhayyim.kotoba.vm.invoke "
+        f"with body={{program_cid={request.program_cid!r}, args_cid={request.args_cid!r}, "
+        f"caller_did={request.caller_did!r}, gas_limit={request.gas_limit}}} → "
+        "InvokeResult(result_cid, gas_used, program_cid). "
+        "Lexicon com.etzhayyim.kotoba.vm.invoke lands in the same R2 commit. "
+        "See ADR-2605282000 §'Subrepo integration status' R1.2→R2 closure plan."
+    )
+
+
+async def invoke_async(
+    *,
+    server_url: str,
+    request: InvokeRequest,
+    timeout_s: float = 600.0,
+) -> InvokeResult:
+    """Async sibling of :func:`invoke`; same R2 wire shape."""
+    raise MurakumoCompatNotImplemented(
+        "kotoba_vm.invoke_async",
+        f"R2 async dispatch — see kotoba_vm.invoke for the target POST shape. "
+        f"Will POST {server_url.rstrip('/')}/xrpc/com.etzhayyim.kotoba.vm.invoke."
+    )

--- a/py/kotoba_murakumo/kotoba_murakumo/client/litellm.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/client/litellm.py
@@ -1,0 +1,135 @@
+"""LiteLLM (OpenAI-compatible chat-completions) client.
+
+Wire format mirrors ``kotoba-llm::http_infer`` (Rust): POST
+``/v1/chat/completions`` with ``Authorization: Bearer <master_key>`` when
+``auth_bearer`` is provided.
+
+Sync, async, and streaming variants share the same request body. The endpoint
+URL passed in is the base (e.g. ``http://192.168.1.17:4000``); this module
+appends ``/v1/chat/completions`` itself so the route resolver in
+:mod:`kotoba_murakumo._internal.routing` can keep talking in base-URL terms.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, AsyncIterator
+
+import httpx
+
+
+def _build_request(
+    *,
+    url: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    max_tokens: int,
+    stream: bool,
+) -> tuple[str, dict[str, Any], dict[str, str]]:
+    endpoint = url.rstrip("/") + "/v1/chat/completions"
+    body = {
+        "model": model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "stream": stream,
+    }
+    headers = {"Content-Type": "application/json"}
+    return endpoint, body, headers
+
+
+def _add_bearer(headers: dict[str, str], auth_bearer: str | None) -> None:
+    if auth_bearer:
+        headers["Authorization"] = f"Bearer {auth_bearer}"
+
+
+def _extract_text(payload: dict[str, Any]) -> str:
+    try:
+        return payload["choices"][0]["message"]["content"]
+    except (KeyError, IndexError, TypeError) as e:
+        raise ValueError(
+            f"missing choices[0].message.content in LiteLLM response: {payload!r}"
+        ) from e
+
+
+def chat_completions(
+    *,
+    url: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    auth_bearer: str | None = None,
+    max_tokens: int = 1024,
+    timeout_s: float = 120.0,
+) -> str:
+    """Synchronous chat-completions call. Returns assistant text."""
+    endpoint, body, headers = _build_request(
+        url=url, model=model, messages=messages, max_tokens=max_tokens, stream=False,
+    )
+    _add_bearer(headers, auth_bearer)
+    with httpx.Client(timeout=timeout_s) as client:
+        resp = client.post(endpoint, json=body, headers=headers)
+        resp.raise_for_status()
+        return _extract_text(resp.json())
+
+
+async def chat_completions_async(
+    *,
+    url: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    auth_bearer: str | None = None,
+    max_tokens: int = 1024,
+    timeout_s: float = 120.0,
+) -> str:
+    """Async chat-completions call. Returns assistant text."""
+    endpoint, body, headers = _build_request(
+        url=url, model=model, messages=messages, max_tokens=max_tokens, stream=False,
+    )
+    _add_bearer(headers, auth_bearer)
+    async with httpx.AsyncClient(timeout=timeout_s) as client:
+        resp = await client.post(endpoint, json=body, headers=headers)
+        resp.raise_for_status()
+        return _extract_text(resp.json())
+
+
+async def chat_completions_stream(
+    *,
+    url: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    auth_bearer: str | None = None,
+    max_tokens: int = 1024,
+    timeout_s: float = 120.0,
+) -> AsyncIterator[str]:
+    """Async SSE stream. Yields assistant token strings as they arrive.
+
+    Parses the OpenAI chat-completions SSE format::
+
+        data: {"choices":[{"delta":{"content":"hel"}}]}
+        data: {"choices":[{"delta":{"content":"lo"}}]}
+        data: [DONE]
+    """
+    endpoint, body, headers = _build_request(
+        url=url, model=model, messages=messages, max_tokens=max_tokens, stream=True,
+    )
+    _add_bearer(headers, auth_bearer)
+    async with httpx.AsyncClient(timeout=timeout_s) as client:
+        async with client.stream("POST", endpoint, json=body, headers=headers) as resp:
+            resp.raise_for_status()
+            async for raw in resp.aiter_lines():
+                line = raw.strip()
+                if not line or not line.startswith("data:"):
+                    continue
+                payload = line[len("data:"):].strip()
+                if payload == "[DONE]":
+                    return
+                try:
+                    chunk = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                try:
+                    delta = chunk["choices"][0]["delta"]
+                except (KeyError, IndexError, TypeError):
+                    continue
+                tok = delta.get("content") or ""
+                if tok:
+                    yield tok

--- a/py/kotoba_murakumo/kotoba_murakumo/client/ollama.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/client/ollama.py
@@ -1,0 +1,45 @@
+"""Ollama-direct client.
+
+Ollama exposes the OpenAI-compatible endpoint at ``/v1/chat/completions`` so
+the wire format is identical to :mod:`kotoba_murakumo.client.litellm`. We
+keep a separate module so R2 can wire Ollama-specific knobs (``num_ctx``,
+``num_gpu``, ``keep_alive``) without touching the LiteLLM signature.
+
+Used for the own-node ``gemma3:4b`` fallback per ``fleet.toml``
+``failover.on_unreachable``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import litellm as _litellm
+
+
+def chat_completions(
+    *,
+    url: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    max_tokens: int = 1024,
+    timeout_s: float = 120.0,
+) -> str:
+    """Synchronous chat-completions against own-node Ollama (no bearer auth)."""
+    return _litellm.chat_completions(
+        url=url, model=model, messages=messages,
+        auth_bearer=None, max_tokens=max_tokens, timeout_s=timeout_s,
+    )
+
+
+async def chat_completions_async(
+    *,
+    url: str,
+    model: str,
+    messages: list[dict[str, Any]],
+    max_tokens: int = 1024,
+    timeout_s: float = 120.0,
+) -> str:
+    return await _litellm.chat_completions_async(
+        url=url, model=model, messages=messages,
+        auth_bearer=None, max_tokens=max_tokens, timeout_s=timeout_s,
+    )

--- a/py/kotoba_murakumo/kotoba_murakumo/cls.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/cls.py
@@ -1,0 +1,52 @@
+"""Modal-compatible class decorators: @enter / @exit / @method.
+
+These are module-level decorators (same as Modal). The actual class
+registration is done by ``App.cls`` in :mod:`kotoba_murakumo.app`; these
+decorators only mark the methods so ``App.cls`` can find them.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, TypeVar
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+_ENTER_MARK = "__kotoba_murakumo_enter__"
+_EXIT_MARK = "__kotoba_murakumo_exit__"
+_METHOD_MARK = "__kotoba_murakumo_method__"
+
+
+def enter() -> Callable[[F], F]:
+    """Mark a method as the cold-start hook (Modal's ``@enter``)."""
+    def deco(fn: F) -> F:
+        setattr(fn, _ENTER_MARK, True)
+        return fn
+    return deco
+
+
+def exit() -> Callable[[F], F]:  # noqa: A001 (Modal name)
+    """Mark a method as the shutdown hook (Modal's ``@exit``)."""
+    def deco(fn: F) -> F:
+        setattr(fn, _EXIT_MARK, True)
+        return fn
+    return deco
+
+
+def method() -> Callable[[F], F]:
+    """Mark a method as a remotely-callable RPC entry (Modal's ``@method``)."""
+    def deco(fn: F) -> F:
+        setattr(fn, _METHOD_MARK, True)
+        return fn
+    return deco
+
+
+def is_enter(fn: Any) -> bool:
+    return bool(getattr(fn, _ENTER_MARK, False))
+
+
+def is_exit(fn: Any) -> bool:
+    return bool(getattr(fn, _EXIT_MARK, False))
+
+
+def is_method(fn: Any) -> bool:
+    return bool(getattr(fn, _METHOD_MARK, False))

--- a/py/kotoba_murakumo/kotoba_murakumo/economy.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/economy.py
@@ -1,0 +1,318 @@
+"""mKOTO economy + Modal billing-parity surface.
+
+R1.3b — see ADR-2605282100 for the 6-layer charter. This module ships:
+
+* :class:`Tariff` + :class:`TariffRow` — versioned, signed schedule
+* :class:`UsageEstimate` — pre-flight cost estimate (Modal dashboard parity)
+* :class:`UsageActual` — post-call billing record (Modal dashboard parity)
+* :class:`BudgetExceeded` / :class:`InsufficientCredit` — pre-dispatch
+  exceptions raised BEFORE HTTP goes out so callers can surface a donation
+  prompt UI without burning compute
+
+R1.3b binds to a **local default tariff** loaded from
+:data:`DEFAULT_TARIFF_PATH` (development convenience). R1.3d-wiring replaces
+the loader with a CACAO-verified read from kotoba-server XRPC
+``com.etzhayyim.kotoba.economy.tariff``. The Python API signature is stable;
+only the data source changes.
+
+Charter §1.5 + §2(b) compliance: mKOTO is an internal accounting Datom unit,
+not a service price. External callers see "donation acknowledged → mKOTO
+credit posted" — never "subscribe for $X/month". See ADR-2605282100 N1-N8.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal
+
+from .exceptions import MurakumoError
+
+Mkoto = int  # uint-64 saturated to i64::MAX at Quad boundary (kotoba native unit)
+
+# 1 KOTO = 10^6 mKOTO (matches kotoba-server::attestation.rs)
+MKOTO_PER_KOTO: Mkoto = 1_000_000
+
+
+# ---------- exceptions --------------------------------------------------------
+
+
+class EconomyError(MurakumoError):
+    """Base class for economy-related errors."""
+
+
+class BudgetExceeded(EconomyError):
+    """Pre-dispatch: ``max_cost_mkoto`` cap exceeded by the estimate.
+
+    Carries the cap + estimate so callers can surface a UI ("this call would
+    cost X mKOTO; cap is Y; raise cap or split into smaller calls").
+    """
+
+    def __init__(self, *, cap_mkoto: Mkoto, estimated_mkoto: Mkoto, fn_name: str) -> None:
+        super().__init__(
+            f"BudgetExceeded({fn_name}): estimated {estimated_mkoto} mKOTO > cap {cap_mkoto} mKOTO"
+        )
+        self.cap_mkoto = cap_mkoto
+        self.estimated_mkoto = estimated_mkoto
+        self.fn_name = fn_name
+
+
+class InsufficientCredit(EconomyError):
+    """Pre-dispatch: caller DID's balance is below the cost estimate.
+
+    Carries balance + required so the donation prompt UI can show the gap
+    in concrete terms ("you have X mKOTO; this call needs Y; donate Z USDC
+    to top up").
+    """
+
+    def __init__(self, *, did: str, balance_mkoto: Mkoto, required_mkoto: Mkoto) -> None:
+        super().__init__(
+            f"InsufficientCredit({did}): balance {balance_mkoto} mKOTO < required {required_mkoto} mKOTO"
+        )
+        self.did = did
+        self.balance_mkoto = balance_mkoto
+        self.required_mkoto = required_mkoto
+
+
+# ---------- tariff ------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class TariffRow:
+    """One backend's pricing.
+
+    ``gas_per_1k_mkoto`` applies only to ``webgpu-wasm`` (kotoba-vm Invoke);
+    HTTP-routed backends use ``gpu_second_mkoto`` + ``egress_mb_mkoto``.
+    """
+
+    backend: str                       # e.g. "litellm-gateway" | "evo-x2-litellm"
+    gpu_second_mkoto: Mkoto = 0
+    egress_mb_mkoto: Mkoto = 0
+    gas_per_1k_mkoto: Mkoto = 0
+
+
+@dataclass(frozen=True, slots=True)
+class Tariff:
+    """Posted price schedule.
+
+    R1.3b: loaded from a local JSON file. R1.3d-wiring: loaded via CACAO-
+    verified XRPC ``com.etzhayyim.kotoba.economy.tariff`` and verified
+    against the Council signing-DID allow-list.
+    """
+
+    version: str                       # e.g. "2026-05-28"
+    rows: tuple[TariffRow, ...]
+    signed_by: tuple[str, ...] = ()    # DIDs of Council signers (R1.3d-wiring)
+    signed_at: str = ""                # ISO-8601 UTC
+
+    def for_backend(self, backend: str) -> TariffRow:
+        for r in self.rows:
+            if r.backend == backend:
+                return r
+        raise KeyError(
+            f"no tariff row for backend {backend!r}; "
+            f"available={[r.backend for r in self.rows]}"
+        )
+
+    @classmethod
+    def from_json(cls, payload: dict[str, Any]) -> "Tariff":
+        rows = tuple(
+            TariffRow(
+                backend=r["backend"],
+                gpu_second_mkoto=int(r.get("gpu_second_mkoto", 0)),
+                egress_mb_mkoto=int(r.get("egress_mb_mkoto", 0)),
+                gas_per_1k_mkoto=int(r.get("gas_per_1k_mkoto", 0)),
+            )
+            for r in payload.get("rows", [])
+        )
+        return cls(
+            version=payload["version"],
+            rows=rows,
+            signed_by=tuple(payload.get("signed_by", [])),
+            signed_at=payload.get("signed_at", ""),
+        )
+
+    @classmethod
+    def load(cls, path: Path | str) -> "Tariff":
+        with Path(path).open("r", encoding="utf-8") as f:
+            return cls.from_json(json.load(f))
+
+
+# Default development tariff. R1.3a §"Initial tariff" defines the rates;
+# Council Lv6+ ≥3 attestation is required before R2 to bind these on-chain.
+_DEFAULT_TARIFF_ROWS = (
+    TariffRow("litellm-gateway", gpu_second_mkoto=100, egress_mb_mkoto=10),
+    TariffRow("evo-x2",          gpu_second_mkoto=250, egress_mb_mkoto=10),
+    TariffRow("mac-mini/judah",  gpu_second_mkoto=30,  egress_mb_mkoto=5),
+)
+
+
+def default_tariff() -> Tariff:
+    """In-process default tariff (R1.3b development).
+
+    Backend names match :class:`kotoba_murakumo._internal.routing.ResolvedRoute.backend`.
+    For per-node Mac mini backends not enumerated here, the same per-node rate
+    as ``mac-mini/judah`` applies (resolved by :func:`row_for_route`).
+    """
+    return Tariff(
+        version="2026-05-28-dev",
+        rows=_DEFAULT_TARIFF_ROWS,
+        signed_by=(),
+        signed_at="",
+    )
+
+
+def row_for_route(tariff: Tariff, backend: str) -> TariffRow:
+    """Resolve a TariffRow for a ResolvedRoute.backend value.
+
+    Per-node Mac mini backends ("mac-mini/<tribe>") fall back to the
+    "mac-mini/judah" row if the specific tribe is not enumerated.
+    """
+    try:
+        return tariff.for_backend(backend)
+    except KeyError:
+        if backend.startswith("mac-mini/"):
+            return tariff.for_backend("mac-mini/judah")
+        raise
+
+
+# ---------- usage records -----------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class UsageEstimate:
+    """Pre-flight cost estimate."""
+
+    gpu_seconds_est: float
+    egress_bytes_est: int
+    cost_mkoto_est: Mkoto
+    tariff_version: str
+    backend: str
+
+
+@dataclass(frozen=True, slots=True)
+class UsageActual:
+    """Post-call billing record."""
+
+    gpu_seconds: float
+    egress_bytes: int
+    prompt_chars: int
+    completion_chars: int
+    cost_mkoto: Mkoto
+    tariff_version: str
+    backend: str
+    latency_ms: int
+    invocation_id: str = ""
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return {
+            "gpu_seconds": self.gpu_seconds,
+            "egress_bytes": self.egress_bytes,
+            "prompt_chars": self.prompt_chars,
+            "completion_chars": self.completion_chars,
+            "cost_mkoto": self.cost_mkoto,
+            "tariff_version": self.tariff_version,
+            "backend": self.backend,
+            "latency_ms": self.latency_ms,
+            "invocation_id": self.invocation_id,
+        }
+
+
+# ---------- estimator + actual-meter ------------------------------------------
+
+
+# Calibration: rough character-to-token ratio (R1.3b heuristic).
+# GPT-style tokenizers ~4 chars/token; Gemma ~3.5; Llama ~3.7. 3.8 is a safe
+# midpoint for cost-estimation overestimate (caller never under-budgets).
+_CHARS_PER_TOKEN: float = 3.8
+
+# Output size heuristic — for the pre-flight estimate we cannot know the
+# completion length; assume max_tokens worth of output at the same ratio.
+# R2 may calibrate this from per-model historical actuals.
+_EST_COMPLETION_TOKENS_DEFAULT: int = 256
+
+# Per-backend gpu-seconds-per-1k-tokens heuristic. Calibrated against the
+# observed throughputs in CLAUDE.md "Performance" + fleet.toml verified_perf:
+# llama3.2:3b @ evo-x2 = 83 tok/s → 12.05 ms/tok → 12.05 s/1k tok.
+# gemma3:4b @ mac-mini = ~50 tok/s estimate → 20 s/1k tok.
+# llama3.3:70b @ evo-x2 = 1.18 tok/s → 847 ms/tok → 847 s/1k tok.
+_S_PER_1K_TOKENS_BY_BACKEND: dict[str, float] = {
+    "litellm-gateway":  12.0,   # gateway routes to evo-x2 by default
+    "evo-x2":           12.0,
+    "mac-mini/judah":   20.0,
+    # unrecognized backends fall back to litellm-gateway estimate
+}
+
+
+def estimate(
+    *,
+    tariff: Tariff,
+    backend: str,
+    prompt_chars: int,
+    expected_completion_tokens: int = _EST_COMPLETION_TOKENS_DEFAULT,
+) -> UsageEstimate:
+    """Pre-flight cost estimate.
+
+    Heuristic: gpu_seconds = (prompt_tokens + completion_tokens) × s/1k.
+    Egress = completion_chars (UTF-8 ≈ 1 byte/char ASCII; safe-overestimates
+    on multi-byte codepoints since we count chars). Cost = backend-tariff
+    × usage.
+
+    Always rounds up to the nearest mKOTO (caller never under-budgets).
+    """
+    row = row_for_route(tariff, backend)
+    s_per_1k = _S_PER_1K_TOKENS_BY_BACKEND.get(backend) \
+        or _S_PER_1K_TOKENS_BY_BACKEND.get("litellm-gateway", 12.0)
+
+    prompt_tokens_est = max(1, int(prompt_chars / _CHARS_PER_TOKEN))
+    total_tokens_est = prompt_tokens_est + max(0, expected_completion_tokens)
+    gpu_seconds_est = (total_tokens_est / 1000.0) * s_per_1k
+    egress_bytes_est = max(0, expected_completion_tokens) * int(_CHARS_PER_TOKEN)
+
+    gpu_cost = _ceil_mul(gpu_seconds_est, row.gpu_second_mkoto)
+    egress_cost = _ceil_mul(egress_bytes_est / (1024 * 1024), row.egress_mb_mkoto)
+    cost = gpu_cost + egress_cost
+
+    return UsageEstimate(
+        gpu_seconds_est=gpu_seconds_est,
+        egress_bytes_est=egress_bytes_est,
+        cost_mkoto_est=cost,
+        tariff_version=tariff.version,
+        backend=backend,
+    )
+
+
+def actual(
+    *,
+    tariff: Tariff,
+    backend: str,
+    prompt_chars: int,
+    completion_chars: int,
+    latency_ms: int,
+    invocation_id: str = "",
+) -> UsageActual:
+    """Post-call billing record computed from real latency + response size."""
+    row = row_for_route(tariff, backend)
+    gpu_seconds = latency_ms / 1000.0
+    egress_bytes = completion_chars  # ASCII safe-overestimate
+    gpu_cost = _ceil_mul(gpu_seconds, row.gpu_second_mkoto)
+    egress_cost = _ceil_mul(egress_bytes / (1024 * 1024), row.egress_mb_mkoto)
+    return UsageActual(
+        gpu_seconds=gpu_seconds,
+        egress_bytes=egress_bytes,
+        prompt_chars=prompt_chars,
+        completion_chars=completion_chars,
+        cost_mkoto=gpu_cost + egress_cost,
+        tariff_version=tariff.version,
+        backend=backend,
+        latency_ms=latency_ms,
+        invocation_id=invocation_id,
+    )
+
+
+def _ceil_mul(x: float, rate: Mkoto) -> Mkoto:
+    """Multiply + ceil to nearest mKOTO (caller never under-budgets)."""
+    import math
+    return Mkoto(math.ceil(x * rate))

--- a/py/kotoba_murakumo/kotoba_murakumo/exceptions.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/exceptions.py
@@ -1,0 +1,53 @@
+"""Public exception types for kotoba_murakumo.
+
+These are part of the API contract: callers MAY catch them; the package will
+not change their hierarchy or class names without an ADR amendment.
+"""
+
+from __future__ import annotations
+
+
+class MurakumoError(Exception):
+    """Base class for all kotoba_murakumo errors."""
+
+
+class FleetUnreachable(MurakumoError):
+    """Raised when no fleet endpoint can satisfy a routing decision.
+
+    R0+ surfaces the attempted endpoint chain rather than silently substituting
+    another vendor (ADR-2605282000 N4).
+    """
+
+    def __init__(self, message: str, *, attempted: list[str] | None = None) -> None:
+        super().__init__(message)
+        self.attempted = list(attempted) if attempted else []
+
+
+class CharterViolation(MurakumoError):
+    """Raised when Charter Rider §2(a)-(h) scan finds a major-severity issue.
+
+    R0 hook is advisory; R1 flips to enforce per ADR-2605282000 §"Charter Rider
+    §2 scan hook".
+    """
+
+    def __init__(self, message: str, *, side: str, severity: str) -> None:
+        super().__init__(message)
+        self.side = side
+        self.severity = severity
+
+
+class MurakumoCompatNotImplemented(MurakumoError, NotImplementedError):
+    """Raised when a Modal-API surface is intentionally unsupported on Murakumo.
+
+    Examples (R0): ``Image.from_registry`` (commercial registry forbidden),
+    ``web_endpoint`` (use yoro / kotoba-server XRPC instead), ``Sandbox`` (no
+    container runtime in fleet — use WASM Component).
+
+    Carries the canonical constitutional / routing reason so callers can decide
+    whether to refactor or escalate.
+    """
+
+    def __init__(self, surface: str, reason: str) -> None:
+        super().__init__(f"{surface}: {reason}")
+        self.surface = surface
+        self.reason = reason

--- a/py/kotoba_murakumo/kotoba_murakumo/fleet.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/fleet.py
@@ -1,0 +1,148 @@
+"""fleet.toml loader.
+
+The fleet is the SSoT (ADR-2605215000 + ADR-2605282000). This module reads it
+once and exposes a typed view; it never invents endpoints not in the file.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .exceptions import FleetUnreachable
+
+
+@dataclass(frozen=True, slots=True)
+class FleetNode:
+    """One Mac mini node from ``[[nodes]]``."""
+
+    name: str
+    hostname: str
+    ip_lan: str
+    role: str
+    cells: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class InferenceEndpoint:
+    """One row from ``[inference_backends.<name>.endpoints.<kind>]``."""
+
+    backend: str  # "evo-x2"
+    kind: str     # "ollama" | "litellm" | "comfyui"
+    url: str
+    api: str
+    auth: str
+    master_key_env: str | None = None
+    models: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class FleetView:
+    """Read-only typed view over fleet.toml."""
+
+    path: Path
+    name: str
+    nodes: dict[str, FleetNode] = field(default_factory=dict)
+    endpoints: dict[tuple[str, str], InferenceEndpoint] = field(default_factory=dict)
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    def node(self, name: str) -> FleetNode:
+        try:
+            return self.nodes[name]
+        except KeyError:
+            raise FleetUnreachable(
+                f"node {name!r} not in fleet {self.name!r}",
+                attempted=[name],
+            ) from None
+
+    def endpoint(self, backend: str, kind: str) -> InferenceEndpoint:
+        try:
+            return self.endpoints[(backend, kind)]
+        except KeyError:
+            raise FleetUnreachable(
+                f"endpoint {backend}/{kind} not in fleet {self.name!r}",
+                attempted=[f"{backend}/{kind}"],
+            ) from None
+
+    def litellm_gateway_url(self, *, gateway_node: str = "judah") -> str:
+        """Resolve the LiteLLM gateway URL.
+
+        Per CLAUDE.md substrate boundary: the LiteLLM gateway lives on judah
+        (192.168.1.17:4000). The EVO-X2 LiteLLM at 192.168.1.70:4000 is a
+        backend, not the gateway — they are intentionally distinct.
+        """
+        try:
+            node = self.node(gateway_node)
+        except FleetUnreachable as e:
+            raise FleetUnreachable(
+                f"LiteLLM gateway node {gateway_node!r} not in fleet",
+                attempted=e.attempted,
+            ) from None
+        return f"http://{node.ip_lan}:4000"
+
+
+def load(path: str | Path) -> FleetView:
+    """Parse fleet.toml and return a typed view.
+
+    Raises ``FleetUnreachable`` if the file is missing — there is no implicit
+    fallback per ADR-2605282000 N4.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FleetUnreachable(
+            f"fleet.toml not found at {p}; refusing to route anywhere else "
+            "per ADR-2605215000 + ADR-2605282000",
+            attempted=[str(p)],
+        )
+
+    with p.open("rb") as f:
+        raw = tomllib.load(f)
+
+    fleet_block = raw.get("fleet", {})
+    name = fleet_block.get("name", p.stem)
+
+    nodes: dict[str, FleetNode] = {}
+    for n in raw.get("nodes", []):
+        node = FleetNode(
+            name=n["name"],
+            hostname=n.get("hostname", ""),
+            ip_lan=n.get("ip_lan", ""),
+            role=n.get("role", ""),
+            cells=tuple(n.get("cells", [])),
+        )
+        nodes[node.name] = node
+
+    endpoints: dict[tuple[str, str], InferenceEndpoint] = {}
+    # fleet.toml writes each backend as ``[[inference_backends]]`` (array)
+    # immediately followed by ``[inference_backends.<name>.endpoints.<kind>]``
+    # blocks. tomllib resolves the latter into a sub-table whose key is the
+    # backend name *inside the array element*, e.g.::
+    #
+    #   raw["inference_backends"][0]["evo-x2"]["endpoints"]["litellm"] = {...}
+    #
+    # so we walk that shape rather than expecting a separate top-level dict.
+    for backend_block in raw.get("inference_backends", []):
+        backend = backend_block.get("name")
+        if not backend:
+            continue
+        nested = backend_block.get(backend, {})
+        for kind, cfg in nested.get("endpoints", {}).items():
+            endpoints[(backend, kind)] = InferenceEndpoint(
+                backend=backend,
+                kind=kind,
+                url=cfg["url"],
+                api=cfg.get("api", "openai-compatible"),
+                auth=cfg.get("auth", "lan-only"),
+                master_key_env=cfg.get("master_key_env"),
+                models=tuple(cfg.get("models", [])),
+            )
+
+    return FleetView(
+        path=p.resolve(),
+        name=name,
+        nodes=nodes,
+        endpoints=endpoints,
+        raw=raw,
+    )

--- a/py/kotoba_murakumo/kotoba_murakumo/function.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/function.py
@@ -1,0 +1,528 @@
+"""Function wrapper — live dispatch + Modal .remote / .remote_async / .spawn / .map / .stream.
+
+R1.1: replaces R0 stubs with httpx-backed dispatch to the Murakumo fleet.
+
+Charter Rider §2(a)-(h) scan runs on both the input prompt and the returned
+text. When ``KOTOBA_MURAKUMO_CHARTER_ENFORCE`` is on and severity >= major,
+:class:`CharterViolation` raises **before** the result is returned to the
+caller (constitutional invariant per ADR-2605192200 + ADR-2605282000).
+
+Every dispatch emits one NDJSON line to
+``~/.kotoba_murakumo/invocations.ndjson`` carrying caller DID, resolved
+endpoint, model, latency, and Charter scan severities. R1.2 will promote this
+to the ``com.etzhayyim.murakumo.invocation`` Lexicon record on the caller's
+PDS.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+import threading
+import time
+import uuid
+from collections.abc import AsyncIterator, Iterable
+from dataclasses import dataclass
+from typing import Any, Callable, Generic, TypeVar
+
+from . import charter, economy
+from ._internal import ndjson, routing
+from .exceptions import FleetUnreachable, MurakumoCompatNotImplemented
+from .fleet import FleetView
+from .gpu import GpuSpec
+from .image import Image
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True, slots=True)
+class FunctionSpec:
+    name: str
+    fn: Callable[..., Any]
+    gpu: GpuSpec | str | None
+    model: str | None
+    image: Image | None
+    timeout: int
+    retries: int
+    # R1.3b — Modal-equivalent per-call spend cap. None = unbounded.
+    # When set, .remote() raises BudgetExceeded BEFORE HTTP if the
+    # pre-flight cost estimate exceeds this cap.
+    max_cost_mkoto: int | None = None
+
+
+class FunctionCall(Generic[T]):
+    """Async handle returned by :meth:`Function.spawn`.
+
+    Modal-shaped: callers either ``await``-the-handle (Modal pattern uses
+    ``.get()``) or call :meth:`get` synchronously to block.
+    """
+
+    def __init__(self, *, call_id: str, future: concurrent.futures.Future[T]) -> None:
+        self.call_id = call_id
+        self._future = future
+
+    def get(self, timeout: float | None = None) -> T:
+        """Block until the spawned dispatch finishes; return its result."""
+        return self._future.result(timeout=timeout)
+
+    def cancel(self) -> bool:
+        return self._future.cancel()
+
+    def done(self) -> bool:
+        return self._future.done()
+
+
+# Module-level executor used by .spawn and .map sync paths. Threads are cheap
+# (each call is one outbound HTTP), and the LiteLLM gateway already handles
+# server-side concurrency limits.
+_EXECUTOR = concurrent.futures.ThreadPoolExecutor(
+    max_workers=32,
+    thread_name_prefix="kotoba-murakumo",
+)
+
+
+class Function:
+    """One ``@app.function``-decorated callable bound to an App + fleet."""
+
+    def __init__(
+        self,
+        spec: FunctionSpec,
+        *,
+        app_name: str,
+        caller_did: str,
+        fleet: FleetView,
+        gateway_node: str = "judah",
+        tariff: economy.Tariff | None = None,
+        balance_lookup: Callable[[str], int] | None = None,
+    ) -> None:
+        self._spec = spec
+        self._app_name = app_name
+        self._caller_did = caller_did
+        self._fleet = fleet
+        self._gateway_node = gateway_node
+        # R1.3b — tariff defaults to in-process schedule when none injected.
+        # R1.3d-wiring will replace this with a CACAO-verified XRPC pull.
+        self._tariff = tariff if tariff is not None else economy.default_tariff()
+        # R1.3b — balance lookup defaults to "unlimited" so existing call sites
+        # are unaffected. App.balance() callers can inject a real lookup that
+        # talks to kotoba-server com.etzhayyim.kotoba.economy.balance.
+        self._balance_lookup = balance_lookup or (lambda _did: 2**62)
+
+    # ---- introspection passthrough -------------------------------------------
+
+    @property
+    def __name__(self) -> str:  # type: ignore[override]
+        return self._spec.name
+
+    @property
+    def __wrapped__(self) -> Callable[..., Any]:
+        return self._spec.fn
+
+    # ---- public Modal-shaped API ---------------------------------------------
+
+    # ---- economy hooks (R1.3b — see ADR-2605282100) ------------------------
+
+    @property
+    def tariff(self) -> economy.Tariff:
+        return self._tariff
+
+    def estimate(self, *args: Any, **kwargs: Any) -> economy.UsageEstimate:
+        """Pre-flight cost estimate — Modal dashboard parity.
+
+        Resolves the same route the live dispatch would take, then computes
+        a backend-tariff-aware UsageEstimate. No HTTP traffic; safe to call
+        from cost-budgeting UIs.
+        """
+        prompt = self._extract_prompt(args, kwargs)
+        route = routing.resolve(
+            self._spec.gpu, self._spec.model, self._fleet,
+            gateway_node=self._gateway_node,
+        )
+        return economy.estimate(
+            tariff=self._tariff,
+            backend=route.backend,
+            prompt_chars=len(prompt),
+        )
+
+    def _budget_preflight(
+        self,
+        *,
+        prompt: str,
+        route: "routing.ResolvedRoute",
+    ) -> economy.UsageEstimate:
+        """Run the budget + balance preflight; raise before HTTP if either fails.
+
+        Constitutional invariant: external callers MUST have non-zero balance
+        before the .remote() dispatch goes out (ADR-2605282100 N3). When the
+        injected balance_lookup yields > 2^60, treat as "unlimited" (default
+        for tests + non-economy-aware call sites).
+        """
+        est = economy.estimate(
+            tariff=self._tariff,
+            backend=route.backend,
+            prompt_chars=len(prompt),
+        )
+        cap = self._spec.max_cost_mkoto
+        if cap is not None and est.cost_mkoto_est > cap:
+            raise economy.BudgetExceeded(
+                cap_mkoto=cap,
+                estimated_mkoto=est.cost_mkoto_est,
+                fn_name=self._spec.name,
+            )
+        balance = self._balance_lookup(self._caller_did)
+        # 2^60 sentinel = "no economy lookup wired" (default). Skip check.
+        if balance < (2 ** 60) and balance < est.cost_mkoto_est:
+            raise economy.InsufficientCredit(
+                did=self._caller_did,
+                balance_mkoto=balance,
+                required_mkoto=est.cost_mkoto_est,
+            )
+        return est
+
+    # ---- public Modal-shaped API -------------------------------------------
+
+    def local(self, *args: Any, **kwargs: Any) -> Any:
+        """Run the wrapped body in-process, bypassing dispatch entirely."""
+        return self._spec.fn(*args, **kwargs)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """Modal semantics: direct call inside a remote container is local()."""
+        return self.local(*args, **kwargs)
+
+    def remote(self, *args: Any, **kwargs: Any) -> str:
+        """Synchronous fleet dispatch. Returns assistant text."""
+        return self._dispatch_sync(args, kwargs)
+
+    async def remote_async(self, *args: Any, **kwargs: Any) -> str:
+        """Async fleet dispatch. Returns assistant text."""
+        return await self._dispatch_async(args, kwargs)
+
+    def spawn(self, *args: Any, **kwargs: Any) -> FunctionCall[str]:
+        """Fire-and-forget dispatch. Returns a :class:`FunctionCall` handle.
+
+        The handle resolves to the same string :meth:`remote` would return.
+        """
+        future = _EXECUTOR.submit(self._dispatch_sync, args, kwargs)
+        return FunctionCall(call_id=uuid.uuid4().hex, future=future)
+
+    def map(
+        self,
+        iterable: Iterable[Any],
+        *,
+        concurrency: int = 8,
+        order_outputs: bool = True,
+    ) -> Iterable[str]:
+        """Modal-compat batch map.
+
+        R1.1: thread-pool over up to ``concurrency`` in-flight HTTP calls.
+        R2 will fan out across fleet nodes via kotoba-net.
+
+        ``order_outputs=True`` returns results in input order (Modal default).
+        Set ``False`` for as-completed iteration.
+        """
+        items = list(iterable)
+        if not items:
+            return iter(())
+
+        if order_outputs:
+            results: list[str | BaseException] = [None] * len(items)  # type: ignore[list-item]
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=max(1, concurrency),
+                thread_name_prefix="kotoba-murakumo-map",
+            ) as ex:
+                fut_to_idx = {
+                    ex.submit(self._dispatch_sync, (item,), {}): i
+                    for i, item in enumerate(items)
+                }
+                for fut in concurrent.futures.as_completed(fut_to_idx):
+                    idx = fut_to_idx[fut]
+                    try:
+                        results[idx] = fut.result()
+                    except BaseException as e:  # noqa: BLE001
+                        results[idx] = e
+            for r in results:
+                if isinstance(r, BaseException):
+                    raise r
+                yield r  # type: ignore[misc]
+            return
+
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=max(1, concurrency),
+            thread_name_prefix="kotoba-murakumo-map",
+        ) as ex:
+            futs = [ex.submit(self._dispatch_sync, (item,), {}) for item in items]
+            for fut in concurrent.futures.as_completed(futs):
+                yield fut.result()
+
+    def starmap(
+        self,
+        iterable: Iterable[tuple[Any, ...]],
+        *,
+        concurrency: int = 8,
+        order_outputs: bool = True,
+    ) -> Iterable[str]:
+        """Like :meth:`map` but each item is a tuple unpacked into ``*args``."""
+        # Reuse map's threading by adapting items into a single-arg form;
+        # _dispatch_sync extracts the prompt from positional args.
+        def _adapt(t: tuple[Any, ...]) -> Any:
+            return t[0] if t else ""
+        return self.map(
+            (_adapt(t) for t in iterable),
+            concurrency=concurrency,
+            order_outputs=order_outputs,
+        )
+
+    async def stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[str]:
+        """Async SSE stream. Yields assistant tokens as they arrive.
+
+        Routes only through OpenAI-compatible endpoints (LiteLLM gateway,
+        EVO-X2 LiteLLM, EVO-X2 ollama, own-node ollama). ComfyUI image-gen
+        and R2 WASM Component dispatch do not support token streaming.
+        """
+        from .client import litellm as litellm_client
+
+        prompt = self._extract_prompt(args, kwargs)
+        scan_in = charter.scan(prompt, side="input")
+        charter.enforce(scan_in)
+
+        route = routing.resolve(
+            self._spec.gpu, self._spec.model, self._fleet,
+            gateway_node=self._gateway_node,
+        )
+        if route.kind not in {"openai-compatible", "ollama-native"}:
+            raise MurakumoCompatNotImplemented(
+                f"Function.stream ({self._spec.name})",
+                f"streaming not supported on {route.kind!r} backends "
+                f"(resolved to {route.backend})",
+            )
+
+        bearer = routing.bearer_token(route)
+        t0 = time.monotonic()
+        result_chars = 0
+        try:
+            async for tok in litellm_client.chat_completions_stream(
+                url=route.url,
+                model=route.model,
+                messages=[{"role": "user", "content": prompt}],
+                auth_bearer=bearer,
+                max_tokens=1024,
+                timeout_s=float(self._spec.timeout),
+            ):
+                result_chars += len(tok)
+                yield tok
+        finally:
+            elapsed_ms = int((time.monotonic() - t0) * 1000)
+            ndjson.emit(self._record_dict(
+                route=route, prompt=prompt, result_chars=result_chars,
+                latency_ms=elapsed_ms, phase="stream",
+                charter_in=scan_in.severity, charter_out="n/a-stream",
+            ))
+
+    # ---- internal dispatch ---------------------------------------------------
+
+    def _dispatch_sync(self, args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+        from .client import litellm as litellm_client
+        from .client import ollama as ollama_client
+
+        prompt = self._extract_prompt(args, kwargs)
+        scan_in = charter.scan(prompt, side="input")
+        charter.enforce(scan_in)
+
+        route = routing.resolve(
+            self._spec.gpu, self._spec.model, self._fleet,
+            gateway_node=self._gateway_node,
+        )
+        # R1.3b — budget + balance preflight; raises BudgetExceeded /
+        # InsufficientCredit BEFORE HTTP per ADR-2605282100 §"Per-call debit flow".
+        est = self._budget_preflight(prompt=prompt, route=route)
+        bearer = routing.bearer_token(route)
+
+        t0 = time.monotonic()
+        try:
+            if route.kind == "openai-compatible":
+                result = litellm_client.chat_completions(
+                    url=route.url, model=route.model,
+                    messages=[{"role": "user", "content": prompt}],
+                    auth_bearer=bearer, max_tokens=1024,
+                    timeout_s=float(self._spec.timeout),
+                )
+            elif route.kind == "ollama-native":
+                result = ollama_client.chat_completions(
+                    url=route.url, model=route.model,
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=1024,
+                    timeout_s=float(self._spec.timeout),
+                )
+            elif route.kind == "comfyui-native":
+                raise MurakumoCompatNotImplemented(
+                    f"Function.remote ({self._spec.name})",
+                    "ComfyUI image-gen dispatch lands R1.2 per ADR-2605282000",
+                )
+            else:
+                raise FleetUnreachable(
+                    f"unsupported backend kind {route.kind!r} on route {route.backend}",
+                    attempted=[route.url],
+                )
+        except httpx_error_classes() as e:  # type: ignore[misc]
+            elapsed_ms = int((time.monotonic() - t0) * 1000)
+            ndjson.emit(self._record_dict(
+                route=route, prompt=prompt, result_chars=0,
+                latency_ms=elapsed_ms, phase="sync-error",
+                charter_in=scan_in.severity, charter_out="n/a-error",
+                error=type(e).__name__,
+            ))
+            raise FleetUnreachable(
+                f"{route.backend} dispatch failed: {e}",
+                attempted=[route.url],
+            ) from e
+
+        scan_out = charter.scan(result, side="output")
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        usage = economy.actual(
+            tariff=self._tariff, backend=route.backend,
+            prompt_chars=len(prompt), completion_chars=len(result),
+            latency_ms=elapsed_ms,
+        )
+        ndjson.emit(self._record_dict(
+            route=route, prompt=prompt, result_chars=len(result),
+            latency_ms=elapsed_ms, phase="sync",
+            charter_in=scan_in.severity, charter_out=scan_out.severity,
+            cost_mkoto=usage.cost_mkoto,
+            tariff_version=usage.tariff_version,
+            cost_estimated_mkoto=est.cost_mkoto_est,
+        ))
+        charter.enforce(scan_out)
+        return result
+
+    async def _dispatch_async(
+        self, args: tuple[Any, ...], kwargs: dict[str, Any],
+    ) -> str:
+        from .client import litellm as litellm_client
+        from .client import ollama as ollama_client
+
+        prompt = self._extract_prompt(args, kwargs)
+        scan_in = charter.scan(prompt, side="input")
+        charter.enforce(scan_in)
+
+        route = routing.resolve(
+            self._spec.gpu, self._spec.model, self._fleet,
+            gateway_node=self._gateway_node,
+        )
+        est = self._budget_preflight(prompt=prompt, route=route)
+        bearer = routing.bearer_token(route)
+
+        t0 = time.monotonic()
+        try:
+            if route.kind == "openai-compatible":
+                result = await litellm_client.chat_completions_async(
+                    url=route.url, model=route.model,
+                    messages=[{"role": "user", "content": prompt}],
+                    auth_bearer=bearer, max_tokens=1024,
+                    timeout_s=float(self._spec.timeout),
+                )
+            elif route.kind == "ollama-native":
+                result = await ollama_client.chat_completions_async(
+                    url=route.url, model=route.model,
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=1024,
+                    timeout_s=float(self._spec.timeout),
+                )
+            elif route.kind == "comfyui-native":
+                raise MurakumoCompatNotImplemented(
+                    f"Function.remote_async ({self._spec.name})",
+                    "ComfyUI image-gen dispatch lands R1.2 per ADR-2605282000",
+                )
+            else:
+                raise FleetUnreachable(
+                    f"unsupported backend kind {route.kind!r}",
+                    attempted=[route.url],
+                )
+        except httpx_error_classes() as e:  # type: ignore[misc]
+            elapsed_ms = int((time.monotonic() - t0) * 1000)
+            ndjson.emit(self._record_dict(
+                route=route, prompt=prompt, result_chars=0,
+                latency_ms=elapsed_ms, phase="async-error",
+                charter_in=scan_in.severity, charter_out="n/a-error",
+                error=type(e).__name__,
+            ))
+            raise FleetUnreachable(
+                f"{route.backend} dispatch failed: {e}",
+                attempted=[route.url],
+            ) from e
+
+        scan_out = charter.scan(result, side="output")
+        elapsed_ms = int((time.monotonic() - t0) * 1000)
+        usage = economy.actual(
+            tariff=self._tariff, backend=route.backend,
+            prompt_chars=len(prompt), completion_chars=len(result),
+            latency_ms=elapsed_ms,
+        )
+        ndjson.emit(self._record_dict(
+            route=route, prompt=prompt, result_chars=len(result),
+            latency_ms=elapsed_ms, phase="async",
+            charter_in=scan_in.severity, charter_out=scan_out.severity,
+            cost_mkoto=usage.cost_mkoto,
+            tariff_version=usage.tariff_version,
+            cost_estimated_mkoto=est.cost_mkoto_est,
+        ))
+        charter.enforce(scan_out)
+        return result
+
+    # ---- helpers -------------------------------------------------------------
+
+    @staticmethod
+    def _extract_prompt(args: tuple[Any, ...], kwargs: dict[str, Any]) -> str:
+        if args and isinstance(args[0], str):
+            return args[0]
+        for k in ("prompt", "text", "input"):
+            v = kwargs.get(k)
+            if isinstance(v, str):
+                return v
+        return ""
+
+    def _record_dict(
+        self, *, route: "routing.ResolvedRoute", prompt: str,
+        result_chars: int, latency_ms: int, phase: str,
+        charter_in: str, charter_out: str,
+        error: str | None = None,
+        cost_mkoto: int | None = None,
+        cost_estimated_mkoto: int | None = None,
+        tariff_version: str | None = None,
+    ) -> dict[str, Any]:
+        rec = {
+            "app": self._app_name,
+            "fn": self._spec.name,
+            "caller_did": self._caller_did,
+            "endpoint": route.url,
+            "backend": route.backend,
+            "model": route.model,
+            "prompt_chars": len(prompt),
+            "result_chars": result_chars,
+            "latency_ms": latency_ms,
+            "phase": phase,
+            "charter_in": charter_in,
+            "charter_out": charter_out,
+        }
+        if cost_mkoto is not None:
+            rec["cost_mkoto"] = cost_mkoto
+        if cost_estimated_mkoto is not None:
+            rec["cost_estimated_mkoto"] = cost_estimated_mkoto
+        if tariff_version is not None:
+            rec["tariff_version"] = tariff_version
+        if error:
+            rec["error"] = error
+        return rec
+
+
+# ---- internal: httpx error classes lazy import (so the module imports cleanly
+# even before httpx is installed by tests that monkeypatch dispatch) ----------
+
+def httpx_error_classes() -> tuple[type[BaseException], ...]:
+    try:
+        import httpx
+        return (httpx.HTTPError, httpx.ConnectError, httpx.ReadTimeout)
+    except ImportError:
+        return (OSError,)

--- a/py/kotoba_murakumo/kotoba_murakumo/gpu.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/gpu.py
@@ -1,0 +1,121 @@
+"""GPU type selectors.
+
+Each class describes a *requested* compute resource. Resolution to a concrete
+fleet endpoint happens in :mod:`kotoba_murakumo._internal.routing`.
+
+Modal-style string GPUs ("A10G", "A100", "H100", "T4", "L4") are accepted via
+:func:`from_modal_string` and mapped to fleet equivalents. NVIDIA-class
+requests log a warning but always route to ROCm EVO-X2 — there is no NVIDIA
+hardware in the fleet (ADR-2605282000 N5: honesty, not bait-and-switch).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class GpuSpec:
+    """Base class for fleet GPU selectors."""
+
+    kind: str
+
+
+@dataclass(frozen=True, slots=True)
+class EvoX2(GpuSpec):
+    """EVO-X2 Windows ROCm node (gfx1151, 32 GB VRAM, 192.168.1.70).
+
+    Default endpoint: LiteLLM at :4000. Set ``prefer="ollama"`` for direct
+    ollama :11434, or ``prefer="comfyui"`` for image gen :8188.
+    """
+
+    prefer: str = "litellm"   # "litellm" | "ollama" | "comfyui"
+    vram_gib: int | None = None
+
+    def __init__(self, *, prefer: str = "litellm", vram_gib: int | None = None) -> None:
+        object.__setattr__(self, "kind", "evo-x2")
+        object.__setattr__(self, "prefer", prefer)
+        object.__setattr__(self, "vram_gib", vram_gib)
+
+
+@dataclass(frozen=True, slots=True)
+class MacMini(GpuSpec):
+    """One Mac mini node, addressed by tribe name.
+
+    Uses the node's own-node Ollama (gemma3:4b default).
+    """
+
+    node: str
+
+    def __init__(self, *, node: str) -> None:
+        object.__setattr__(self, "kind", "mac-mini")
+        object.__setattr__(self, "node", node)
+
+
+@dataclass(frozen=True, slots=True)
+class WebGPU(GpuSpec):
+    """WebGPU compute on any fleet node (Metal on Mac mini, Vulkan on EVO-X2).
+
+    R2 scope. R0 raises ``MurakumoCompatNotImplemented`` when actually
+    dispatched.
+    """
+
+    def __init__(self) -> None:
+        object.__setattr__(self, "kind", "webgpu")
+
+
+@dataclass(frozen=True, slots=True)
+class Any(GpuSpec):
+    """Let the LiteLLM gateway route by model name.
+
+    Equivalent to passing ``gpu=None`` or ``gpu="any"``.
+    """
+
+    def __init__(self) -> None:
+        object.__setattr__(self, "kind", "any")
+
+
+# ---------- Modal-string compatibility ----------------------------------------
+
+# Modal GPU strings → fleet equivalents.
+# NVIDIA-class strings all map to EVO-X2 with a warning at resolve time.
+_MODAL_GPU_MAP: dict[str, type[GpuSpec]] = {
+    "T4": EvoX2,
+    "L4": EvoX2,
+    "A10G": EvoX2,
+    "A100": EvoX2,
+    "A100-40GB": EvoX2,
+    "A100-80GB": EvoX2,
+    "H100": EvoX2,
+    "H200": EvoX2,
+    "L40S": EvoX2,
+    "any": Any,
+}
+
+
+def from_modal_string(s: str) -> GpuSpec:
+    """Resolve a Modal-style ``gpu="A10G"`` string to a fleet selector.
+
+    NVIDIA-class strings log a one-line warning so the caller knows the routing
+    is honest (ROCm EVO-X2, not NVIDIA).
+    """
+    cls = _MODAL_GPU_MAP.get(s)
+    if cls is None:
+        from .exceptions import MurakumoCompatNotImplemented
+        raise MurakumoCompatNotImplemented(
+            f"gpu={s!r}",
+            f"unknown Modal GPU string; fleet exposes {sorted(_MODAL_GPU_MAP)}",
+        )
+    if cls is EvoX2 and s != "EvoX2":
+        logger.warning(
+            "gpu=%r requested; fleet has no NVIDIA hardware — routed to EVO-X2 "
+            "(ROCm gfx1151, 32 GB VRAM). Expect throughput delta vs Modal.",
+            s,
+        )
+    return cls()
+
+
+__all__ = ["GpuSpec", "EvoX2", "MacMini", "WebGPU", "Any", "from_modal_string"]

--- a/py/kotoba_murakumo/kotoba_murakumo/image.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/image.py
@@ -1,0 +1,109 @@
+"""Image — Modal-compatible build spec.
+
+R0: records intent (chain of mutations) without executing anything. The image
+ID is the SHA-256 of the canonical JSON representation, which is also the
+content-address used for the future kotoba-kse Vault binding (R1).
+
+Modal compatibility surface intentionally narrow:
+
+* ``Image.debian_slim(python_version=...)`` → identity image carrying the
+  requested python version as metadata.
+* ``.pip_install(*pkgs)`` → records the pkg list for R1 Charter Rider scan.
+* ``.run_commands(*cmds)`` → records the cmd list.
+* ``.env({...})`` → records env additions.
+* ``.wasm_component(path)`` → records that the image *is* a WASM Component
+  bytes file (the long-term path; LLM-only callers won't touch this).
+
+Surfaces that always raise ``MurakumoCompatNotImplemented``:
+
+* ``Image.from_registry(...)`` — commercial registry forbidden per Charter
+  Rider §2(c)+(e); ADR-2605282000 N2.
+* ``Image.from_dockerhub(...)`` — same reason.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+from .exceptions import MurakumoCompatNotImplemented
+
+
+@dataclass(frozen=True, slots=True)
+class _Op:
+    op: str
+    args: tuple[Any, ...]
+    kwargs: tuple[tuple[str, Any], ...]
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return {
+            "op": self.op,
+            "args": list(self.args),
+            "kwargs": dict(self.kwargs),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Image:
+    base: str
+    ops: tuple[_Op, ...] = field(default_factory=tuple)
+
+    # ---- constructors --------------------------------------------------------
+
+    @classmethod
+    def debian_slim(cls, python_version: str = "3.11") -> "Image":
+        return cls(base=f"debian-slim:py{python_version}")
+
+    @classmethod
+    def wasm_component(cls, path: str) -> "Image":
+        return cls(base=f"wasm-component:{path}")
+
+    @classmethod
+    def from_registry(cls, tag: str) -> "Image":  # noqa: ARG003
+        raise MurakumoCompatNotImplemented(
+            "Image.from_registry",
+            "commercial container registries forbidden per Charter Rider §2(c)+(e) "
+            "and ADR-2605282000 N2 — use Image.wasm_component or Image.debian_slim",
+        )
+
+    @classmethod
+    def from_dockerhub(cls, tag: str) -> "Image":  # noqa: ARG003
+        raise MurakumoCompatNotImplemented(
+            "Image.from_dockerhub",
+            "Docker Hub forbidden per Charter Rider §2(c)+(e); see ADR-2605282000 N2",
+        )
+
+    # ---- chainable ops -------------------------------------------------------
+
+    def _push(self, op: str, *args: Any, **kwargs: Any) -> "Image":
+        return Image(
+            base=self.base,
+            ops=self.ops + (_Op(op=op, args=args, kwargs=tuple(kwargs.items())),),
+        )
+
+    def pip_install(self, *packages: str) -> "Image":
+        return self._push("pip_install", *packages)
+
+    def run_commands(self, *commands: str) -> "Image":
+        return self._push("run_commands", *commands)
+
+    def env(self, vars: dict[str, str]) -> "Image":
+        return self._push("env", **vars)
+
+    # ---- identity ------------------------------------------------------------
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return {"base": self.base, "ops": [o.to_jsonable() for o in self.ops]}
+
+    @property
+    def image_id(self) -> str:
+        """Content-address (sha256) of the canonical JSON representation.
+
+        R1: also used as the kotoba-kse Vault key.
+        """
+        canonical = json.dumps(
+            self.to_jsonable(), sort_keys=True, separators=(",", ":")
+        ).encode("utf-8")
+        return hashlib.sha256(canonical).hexdigest()

--- a/py/kotoba_murakumo/kotoba_murakumo/modal_compat.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/modal_compat.py
@@ -1,0 +1,136 @@
+"""Drop-in ``import modal`` shim.
+
+Usage::
+
+    import kotoba_murakumo.modal_compat as modal
+
+    stub = modal.App("my-inference")
+
+    @stub.function(gpu="A10G")
+    def f(x: str) -> str: ...
+
+Every name here intentionally matches Modal's public surface. Where the surface
+diverges (rare: ``Image.from_registry``, ``Sandbox``, ``web_endpoint``), the
+divergence raises :class:`kotoba_murakumo.exceptions.MurakumoCompatNotImplemented`
+with the constitutional reason — never silent.
+
+Modal® is a registered trademark of Modal Labs Inc. This shim is API-compat
+only (Google v. Oracle 2021 API fair-use, analogous to ADR-2605261800 §D10
+``nv_compat``). It does not link to Modal Labs servers.
+"""
+
+from __future__ import annotations
+
+from .app import App
+from .cls import enter, exit, method
+from .exceptions import (
+    CharterViolation,
+    FleetUnreachable,
+    MurakumoCompatNotImplemented,
+)
+from .image import Image
+from .secret import Secret
+from .volume import Volume
+
+# Modal historically called this `Stub`; alias for legacy code.
+Stub = App
+
+
+# Modal exposes its GPU classes via ``modal.gpu`` *and* via string ``gpu="A10G"``.
+# We honor both — the App.function decorator accepts either form.
+class _GpuNamespace:
+    from .gpu import (
+        Any,
+        EvoX2,
+        MacMini,
+        WebGPU,
+    )
+
+    # NVIDIA-class names: each returns an EvoX2 selector (with warning logged
+    # on resolve). This is the honest mapping per ADR-2605282000 N5.
+    @staticmethod
+    def T4() -> "EvoX2":  # type: ignore[name-defined]
+        from .gpu import EvoX2
+        return EvoX2()
+
+    @staticmethod
+    def L4() -> "EvoX2":  # type: ignore[name-defined]
+        from .gpu import EvoX2
+        return EvoX2()
+
+    @staticmethod
+    def A10G() -> "EvoX2":  # type: ignore[name-defined]
+        from .gpu import EvoX2
+        return EvoX2()
+
+    @staticmethod
+    def A100(*, memory: int = 40) -> "EvoX2":  # type: ignore[name-defined]  # noqa: ARG004
+        from .gpu import EvoX2
+        return EvoX2()
+
+    @staticmethod
+    def H100() -> "EvoX2":  # type: ignore[name-defined]
+        from .gpu import EvoX2
+        return EvoX2()
+
+    @staticmethod
+    def H200() -> "EvoX2":  # type: ignore[name-defined]
+        from .gpu import EvoX2
+        return EvoX2()
+
+
+gpu = _GpuNamespace()
+
+
+# Modal surfaces that we deliberately don't support: declared here so callers
+# see a single canonical reason string.
+
+def web_endpoint(*args, **kwargs):  # noqa: ARG001
+    raise MurakumoCompatNotImplemented(
+        "modal.web_endpoint",
+        "expose HTTP via yoro / kotoba-server XRPC instead; ADR-2605282000",
+    )
+
+
+def asgi_app(*args, **kwargs):  # noqa: ARG001
+    raise MurakumoCompatNotImplemented(
+        "modal.asgi_app",
+        "expose HTTP via yoro / kotoba-server XRPC instead; ADR-2605282000",
+    )
+
+
+def fastapi_endpoint(*args, **kwargs):  # noqa: ARG001
+    raise MurakumoCompatNotImplemented(
+        "modal.fastapi_endpoint",
+        "expose HTTP via yoro / kotoba-server XRPC instead; ADR-2605282000",
+    )
+
+
+class Sandbox:
+    """Modal ``modal.Sandbox`` is intentionally unsupported."""
+
+    def __init__(self, *args, **kwargs) -> None:  # noqa: ARG002
+        raise MurakumoCompatNotImplemented(
+            "modal.Sandbox",
+            "no container runtime in fleet; use Image.wasm_component instead; ADR-2605282000",
+        )
+
+
+__all__ = [
+    "App",
+    "Stub",
+    "Image",
+    "Volume",
+    "Secret",
+    "gpu",
+    "enter",
+    "exit",
+    "method",
+    "web_endpoint",
+    "asgi_app",
+    "fastapi_endpoint",
+    "Sandbox",
+    "CharterViolation",
+    "FleetUnreachable",
+    "MurakumoCompatNotImplemented",
+]

--- a/py/kotoba_murakumo/kotoba_murakumo/secret.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/secret.py
@@ -1,0 +1,32 @@
+"""Secret — env-backed key lookup.
+
+R0: reads from process env. R1: encrypted Vault entries gated on caller DID
+(kotoba-signal + kotoba-auth CACAO chain).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class Secret:
+    values: dict[str, str]
+
+    @classmethod
+    def from_name(cls, name: str, *, env_keys: list[str] | None = None) -> "Secret":
+        """Modal semantics: a 'named secret' is a bundle of env entries.
+
+        R0: ``env_keys`` lists the env vars to pull. If omitted, only the
+        env var named ``name`` is loaded.
+        """
+        keys = env_keys or [name]
+        return cls(values={k: os.environ.get(k, "") for k in keys})
+
+    @classmethod
+    def from_dict(cls, mapping: dict[str, str]) -> "Secret":
+        return cls(values=dict(mapping))
+
+    def get(self, key: str, default: str = "") -> str:
+        return self.values.get(key, default)

--- a/py/kotoba_murakumo/kotoba_murakumo/volume.py
+++ b/py/kotoba_murakumo/kotoba_murakumo/volume.py
@@ -1,0 +1,41 @@
+"""Volume — persistent storage handle.
+
+R0: in-process name registry (no IO). R1: each Volume binds to a kotoba-kse
+Vault CID with pin/unpin via Kubo.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+_REGISTRY: dict[str, "Volume"] = {}
+
+
+@dataclass(frozen=True, slots=True)
+class Volume:
+    name: str
+    cid: str | None = None
+    create_if_missing: bool = False
+
+    @classmethod
+    def from_name(
+        cls,
+        name: str,
+        *,
+        cid: str | None = None,
+        create_if_missing: bool = False,
+    ) -> "Volume":
+        existing = _REGISTRY.get(name)
+        if existing is not None:
+            return existing
+        if not create_if_missing and cid is None:
+            # Modal semantics: from_name with no create_if_missing raises if the
+            # volume doesn't exist. We match that, but the underlying store is
+            # the local registry at R0.
+            raise KeyError(
+                f"Volume {name!r} not registered; pass create_if_missing=True "
+                "or cid=<...> to bind"
+            )
+        v = cls(name=name, cid=cid, create_if_missing=create_if_missing)
+        _REGISTRY[name] = v
+        return v

--- a/py/kotoba_murakumo/pyproject.toml
+++ b/py/kotoba_murakumo/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "kotoba-murakumo"
+version = "0.1.0"
+description = "Modal-compatible Python facade for the etzhayyim Murakumo Mac mini fleet (kotoba-backed, religious-corp Murakumo-only inference per ADR-2605215000)"
+requires-python = ">=3.11"
+license = { text = "Apache-2.0" }
+authors = [{ name = "etzhayyim", email = "council@etzhayyim.com" }]
+dependencies = ["httpx>=0.27"]
+
+[project.optional-dependencies]
+test = ["pytest>=8"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["kotoba_murakumo"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+  "live_fleet: tests that contact the real Murakumo fleet (skipped unless KOTOBA_MURAKUMO_LIVE_FLEET=1)",
+]
+
+[tool.pyright]
+pythonVersion = "3.11"
+typeCheckingMode = "standard"

--- a/py/kotoba_murakumo/tests/conftest.py
+++ b/py/kotoba_murakumo/tests/conftest.py
@@ -1,0 +1,75 @@
+"""Shared test fixtures.
+
+Anchors the canonical ``fleet.toml`` path and gates the live-fleet smoke
+tests behind ``KOTOBA_MURAKUMO_LIVE_FLEET=1``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+def repo_root() -> Path:
+    # tests/ → kotoba_murakumo/ → py/ → kotoba/ → 40-engine/ → monorepo root
+    # kotoba_murakumo lives inside the kotoba submodule but is a religious-corp
+    # downstream consumer: its canonical inputs (fleet.toml, the lint gate) live
+    # in the etzhayyim monorepo, NOT in a standalone kotoba checkout.
+    return Path(__file__).resolve().parents[5]
+
+
+def monorepo_fleet() -> Path:
+    return repo_root() / "50-infra/murakumo/fleet.toml"
+
+
+@pytest.fixture(scope="session")
+def fleet_path() -> Path:
+    return monorepo_fleet()
+
+
+@pytest.fixture(autouse=True)
+def _ndjson_in_tmp(tmp_path, monkeypatch) -> Path:
+    """Redirect invocation NDJSON to tmp so tests don't pollute ~/."""
+    p = tmp_path / "invocations.ndjson"
+    monkeypatch.setenv("KOTOBA_MURAKUMO_LOG", str(p))
+    # The ndjson module reads the env var at import time; patch the
+    # already-evaluated default too so the redirect actually takes effect.
+    from kotoba_murakumo._internal import ndjson as nd
+    monkeypatch.setattr(nd, "_DEFAULT_PATH", p)
+    return p
+
+
+@pytest.fixture(autouse=True)
+def _charter_advisory_by_default(monkeypatch) -> None:
+    """Most tests assume advisory mode; opt-in to enforce via the env var."""
+    monkeypatch.delenv("KOTOBA_MURAKUMO_CHARTER_ENFORCE", raising=False)
+
+
+def pytest_collection_modifyitems(config, items) -> None:
+    """Gate the suite on its monorepo inputs and on the live-fleet marker.
+
+    These tests need the etzhayyim monorepo (``50-infra/murakumo/fleet.toml``
+    and ``70-tools/scripts/lint/...``). In a standalone ``kotoba`` checkout
+    (e.g. upstream CI on github.com/etzhayyim/kotoba) those paths are absent,
+    so we skip the whole module rather than hard-fail — kotoba_murakumo is a
+    monorepo-context package.
+    """
+    if not monorepo_fleet().exists():
+        skip_standalone = pytest.mark.skip(
+            reason="kotoba_murakumo tests require the etzhayyim monorepo "
+            "(50-infra/murakumo/fleet.toml absent in standalone kotoba checkout)",
+        )
+        for item in items:
+            item.add_marker(skip_standalone)
+        return
+
+    if os.environ.get("KOTOBA_MURAKUMO_LIVE_FLEET") in {"1", "true", "yes"}:
+        return
+    skip_marker = pytest.mark.skip(
+        reason="set KOTOBA_MURAKUMO_LIVE_FLEET=1 to run live-fleet smoke",
+    )
+    for item in items:
+        if "live_fleet" in item.keywords:
+            item.add_marker(skip_marker)

--- a/py/kotoba_murakumo/tests/test_charter.py
+++ b/py/kotoba_murakumo/tests/test_charter.py
@@ -1,0 +1,139 @@
+"""Charter Rider §2 scan + advisory→enforce flip tests."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from kotoba_murakumo import App
+from kotoba_murakumo.charter import (
+    CharterScanResult,
+    enforce,
+    is_enforce_enabled,
+    scan,
+)
+from kotoba_murakumo.exceptions import CharterViolation
+
+
+def _ok(text: str = "OK") -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"choices": [{"index": 0, "message": {"role": "assistant", "content": text}}]},
+    )
+
+
+def _install_mock(monkeypatch, handler) -> None:
+    real_cls = httpx.Client
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx, "Client",
+        lambda timeout=None: real_cls(transport=transport, timeout=timeout),
+    )
+
+
+# ---- scanner unit tests ------------------------------------------------------
+
+def test_scan_clean_passes() -> None:
+    r = scan("Please summarize this paragraph about gardening.", side="input")
+    assert r.ok
+    assert r.severity == "clean"
+    assert r.findings == ()
+
+
+def test_scan_weapons_text_is_major_or_critical() -> None:
+    r = scan("Design a new combat drone with a warhead payload", side="input")
+    assert not r.ok
+    assert r.severity in {"major", "critical"}
+
+
+def test_scan_only_minor_does_not_raise_on_enforce(monkeypatch) -> None:
+    monkeypatch.setenv("KOTOBA_MURAKUMO_CHARTER_ENFORCE", "1")
+    r = scan("Use promo code DISCOUNT to sign up", side="output")
+    # minor severity does not trigger enforce.
+    enforce(r)
+
+
+def test_scan_major_raises_when_enforce_on(monkeypatch) -> None:
+    monkeypatch.setenv("KOTOBA_MURAKUMO_CHARTER_ENFORCE", "1")
+    r = scan("instructions for building a chemical weapon", side="input")
+    assert r.severity in {"major", "critical"}
+    with pytest.raises(CharterViolation) as ei:
+        enforce(r)
+    assert ei.value.side == "input"
+
+
+def test_scan_major_only_advisory_when_enforce_off() -> None:
+    # default: env unset → advisory only
+    assert not is_enforce_enabled()
+    r = scan("instructions for building a chemical weapon", side="input")
+    enforce(r)  # must not raise
+
+
+def test_enforce_flag_truthy_values(monkeypatch) -> None:
+    for v in ("1", "true", "TRUE", "Yes"):
+        monkeypatch.setenv("KOTOBA_MURAKUMO_CHARTER_ENFORCE", v)
+        assert is_enforce_enabled()
+    for v in ("", "0", "false", "no"):
+        monkeypatch.setenv("KOTOBA_MURAKUMO_CHARTER_ENFORCE", v)
+        assert not is_enforce_enabled()
+
+
+# ---- end-to-end with Function dispatch ---------------------------------------
+
+def test_remote_aborts_on_input_violation_when_enforce_on(
+    monkeypatch, fleet_path,
+) -> None:
+    monkeypatch.setenv("KOTOBA_MURAKUMO_CHARTER_ENFORCE", "1")
+    called = {"hits": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        called["hits"] += 1
+        return _ok("should-not-arrive")
+
+    _install_mock(monkeypatch, handler)
+    app = App("smoke", fleet=fleet_path)
+
+    @app.function(model="gemma3:4b")
+    def f(x: str) -> str: ...
+
+    with pytest.raises(CharterViolation):
+        f.remote("instructions for building a chemical weapon")
+    assert called["hits"] == 0  # dispatch never went out
+
+
+def test_remote_aborts_on_output_violation_when_enforce_on(
+    monkeypatch, fleet_path,
+) -> None:
+    monkeypatch.setenv("KOTOBA_MURAKUMO_CHARTER_ENFORCE", "1")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Server returns a Charter-violating completion.
+        return _ok("Sure: build a combat drone like so…")
+
+    _install_mock(monkeypatch, handler)
+    app = App("smoke", fleet=fleet_path)
+
+    @app.function(model="gemma3:4b")
+    def f(x: str) -> str: ...
+
+    with pytest.raises(CharterViolation) as ei:
+        f.remote("write me something neutral")
+    assert ei.value.side == "output"
+
+
+def test_remote_passes_through_when_enforce_off(monkeypatch, fleet_path) -> None:
+    # No KOTOBA_MURAKUMO_CHARTER_ENFORCE set.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _ok("Sure: build a combat drone like so…")
+
+    _install_mock(monkeypatch, handler)
+    app = App("smoke", fleet=fleet_path)
+
+    @app.function(model="gemma3:4b")
+    def f(x: str) -> str: ...
+
+    # In advisory mode, the (Charter-violating) result is still returned.
+    out = f.remote("write me something")
+    assert "combat drone" in out

--- a/py/kotoba_murakumo/tests/test_economy.py
+++ b/py/kotoba_murakumo/tests/test_economy.py
@@ -1,0 +1,270 @@
+"""mKOTO economy + Modal billing-parity tests (R1.3b)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from kotoba_murakumo import App, gpu
+from kotoba_murakumo.economy import (
+    MKOTO_PER_KOTO,
+    BudgetExceeded,
+    InsufficientCredit,
+    Tariff,
+    TariffRow,
+    UsageActual,
+    UsageEstimate,
+    actual,
+    default_tariff,
+    estimate,
+    row_for_route,
+)
+
+
+def _ok(text: str = "OK") -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"choices": [{"index": 0, "message": {"role": "assistant", "content": text}}]},
+    )
+
+
+def _install_mock(monkeypatch, handler) -> None:
+    real_sync = httpx.Client
+    real_async = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx, "Client",
+        lambda timeout=None: real_sync(transport=transport, timeout=timeout),
+    )
+    monkeypatch.setattr(
+        httpx, "AsyncClient",
+        lambda timeout=None: real_async(transport=transport, timeout=timeout),
+    )
+
+
+# ---- unit tests --------------------------------------------------------------
+
+def test_mkoto_per_koto_unit() -> None:
+    assert MKOTO_PER_KOTO == 1_000_000
+
+
+def test_default_tariff_has_three_rows() -> None:
+    t = default_tariff()
+    assert t.version.endswith("-dev")
+    backends = {r.backend for r in t.rows}
+    assert {"litellm-gateway", "evo-x2", "mac-mini/judah"} <= backends
+
+
+def test_tariff_for_backend_lookup() -> None:
+    t = default_tariff()
+    row = t.for_backend("evo-x2")
+    assert row.gpu_second_mkoto == 250
+    assert row.egress_mb_mkoto == 10
+    with pytest.raises(KeyError):
+        t.for_backend("nonexistent-backend")
+
+
+def test_row_for_route_fallback_for_unknown_mac_mini_tribe() -> None:
+    t = default_tariff()
+    # Specific tribe not enumerated → falls back to judah row.
+    r = row_for_route(t, "mac-mini/simeon")
+    assert r.backend == "mac-mini/judah"
+    assert r.gpu_second_mkoto == 30
+
+
+def test_tariff_from_and_to_json_roundtrip() -> None:
+    payload = {
+        "version": "2026-05-28-test",
+        "rows": [
+            {"backend": "x", "gpu_second_mkoto": 5, "egress_mb_mkoto": 2},
+        ],
+        "signed_by": ["did:web:a", "did:web:b"],
+        "signed_at": "2026-05-28T20:00:00Z",
+    }
+    t = Tariff.from_json(payload)
+    assert t.version == "2026-05-28-test"
+    assert t.signed_by == ("did:web:a", "did:web:b")
+    assert t.for_backend("x").gpu_second_mkoto == 5
+
+
+def test_tariff_load_from_file(tmp_path) -> None:
+    p = tmp_path / "tariff.json"
+    p.write_text(json.dumps({
+        "version": "2026-05-28-file",
+        "rows": [{"backend": "y", "gpu_second_mkoto": 7}],
+    }), encoding="utf-8")
+    t = Tariff.load(p)
+    assert t.version == "2026-05-28-file"
+    assert t.for_backend("y").gpu_second_mkoto == 7
+
+
+def test_estimate_safe_overestimates() -> None:
+    t = default_tariff()
+    # 100 chars prompt, expected_completion_tokens=256 default.
+    est_ = estimate(
+        tariff=t, backend="litellm-gateway",
+        prompt_chars=100,
+    )
+    assert est_.cost_mkoto_est > 0
+    assert est_.gpu_seconds_est > 0
+    assert est_.tariff_version == t.version
+    assert est_.backend == "litellm-gateway"
+
+
+def test_estimate_evo_x2_more_expensive_than_mac_mini() -> None:
+    t = default_tariff()
+    e_evo = estimate(tariff=t, backend="evo-x2", prompt_chars=100)
+    e_mac = estimate(tariff=t, backend="mac-mini/judah", prompt_chars=100)
+    assert e_evo.cost_mkoto_est > e_mac.cost_mkoto_est
+
+
+def test_actual_uses_latency_for_gpu_seconds() -> None:
+    t = default_tariff()
+    a = actual(
+        tariff=t, backend="litellm-gateway",
+        prompt_chars=10, completion_chars=20, latency_ms=2500,
+    )
+    assert a.gpu_seconds == 2.5
+    assert a.cost_mkoto > 0
+    assert isinstance(a.to_jsonable(), dict)
+
+
+# ---- integration: pre-dispatch budget check ----------------------------------
+
+def test_budget_exceeded_raises_before_http(monkeypatch, fleet_path) -> None:
+    dispatched = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        dispatched["count"] += 1
+        return _ok("should-not-arrive")
+
+    _install_mock(monkeypatch, handler)
+    app = App("smoke", fleet=fleet_path)
+
+    @app.function(model="gemma3:4b", max_cost_mkoto=1)  # cap 1 mKOTO
+    def f(x: str) -> str: ...
+
+    with pytest.raises(BudgetExceeded) as ei:
+        f.remote("hello world this is a longer prompt")
+    assert ei.value.cap_mkoto == 1
+    assert ei.value.estimated_mkoto > 1
+    assert ei.value.fn_name == "f"
+    assert dispatched["count"] == 0
+
+
+def test_insufficient_credit_raises_before_http(monkeypatch, fleet_path) -> None:
+    dispatched = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        dispatched["count"] += 1
+        return _ok("should-not-arrive")
+
+    _install_mock(monkeypatch, handler)
+
+    # Inject a balance_lookup that returns 1 mKOTO for any DID.
+    app = App(
+        "smoke",
+        fleet=fleet_path,
+        did="did:web:poor.etzhayyim.com",
+        balance_lookup=lambda did: 1,
+    )
+
+    @app.function(model="gemma3:4b")
+    def f(x: str) -> str: ...
+
+    with pytest.raises(InsufficientCredit) as ei:
+        f.remote("hello world")
+    assert ei.value.did == "did:web:poor.etzhayyim.com"
+    assert ei.value.balance_mkoto == 1
+    assert ei.value.required_mkoto > 1
+    assert dispatched["count"] == 0
+
+
+def test_unlimited_balance_default_does_not_raise(monkeypatch, fleet_path) -> None:
+    """When no balance_lookup is wired, the App acts as unlimited (sentinel)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _ok("fine")
+
+    _install_mock(monkeypatch, handler)
+    app = App("smoke", fleet=fleet_path)  # no balance_lookup
+
+    @app.function(model="gemma3:4b")
+    def f(x: str) -> str: ...
+
+    assert f.remote("anything") == "fine"
+
+
+def test_function_estimate_returns_usage_estimate(fleet_path) -> None:
+    app = App("smoke", fleet=fleet_path)
+
+    @app.function(gpu=gpu.EvoX2(), model="llama3.3:70b", max_cost_mkoto=1_000_000)
+    def heavy(x: str) -> str: ...
+
+    est_ = heavy.estimate("hello")
+    assert isinstance(est_, UsageEstimate)
+    assert est_.backend == "evo-x2"
+    assert est_.cost_mkoto_est > 0
+    assert est_.tariff_version.endswith("-dev")
+
+
+def test_remote_ndjson_carries_cost_and_tariff(monkeypatch, fleet_path, tmp_path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _ok("RESULT-OK")
+
+    _install_mock(monkeypatch, handler)
+    log = tmp_path / "log.ndjson"
+    from kotoba_murakumo._internal import ndjson as nd
+    monkeypatch.setattr(nd, "_DEFAULT_PATH", log)
+
+    app = App("smoke", fleet=fleet_path, did="did:web:c.etzhayyim.com")
+
+    @app.function(model="gemma3:4b")
+    def f(x: str) -> str: ...
+
+    f.remote("PROMPT")
+    rec = json.loads(log.read_text(encoding="utf-8").strip())
+    assert "cost_mkoto" in rec
+    assert "cost_estimated_mkoto" in rec
+    assert "tariff_version" in rec
+    assert rec["cost_mkoto"] >= 0
+    assert rec["tariff_version"].endswith("-dev")
+
+
+def test_app_balance_and_tariff_accessors(fleet_path) -> None:
+    app = App(
+        "smoke", fleet=fleet_path, did="did:web:a.etzhayyim.com",
+        balance_lookup=lambda did: 42_000 if did == "did:web:a.etzhayyim.com" else 0,
+    )
+    assert app.balance() == 42_000
+    assert app.balance("did:web:other.etzhayyim.com") == 0
+
+    t = app.get_tariff()
+    assert isinstance(t, Tariff)
+    assert t.for_backend("litellm-gateway").gpu_second_mkoto == 100
+
+
+def test_app_balance_unlimited_when_no_lookup(fleet_path) -> None:
+    app = App("smoke", fleet=fleet_path)
+    assert app.balance() == 2 ** 62
+
+
+def test_custom_tariff_injected_at_app_level(fleet_path) -> None:
+    custom = Tariff(
+        version="custom-v1",
+        rows=(
+            TariffRow("litellm-gateway", gpu_second_mkoto=999, egress_mb_mkoto=999),
+        ),
+    )
+    app = App("smoke", fleet=fleet_path, tariff=custom)
+
+    @app.function(model="gemma3:4b")
+    def f(x: str) -> str: ...
+
+    est_ = f.estimate("x")
+    assert est_.tariff_version == "custom-v1"
+    # Way more expensive than default
+    assert est_.cost_mkoto_est > 1000

--- a/py/kotoba_murakumo/tests/test_fleet_load.py
+++ b/py/kotoba_murakumo/tests/test_fleet_load.py
@@ -1,0 +1,47 @@
+"""fleet.toml loader smoke test.
+
+Uses the canonical fleet.toml at ``50-infra/murakumo/fleet.toml`` so we catch
+schema drift in the SSoT, not just a synthetic fixture.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kotoba_murakumo.exceptions import FleetUnreachable
+from kotoba_murakumo.fleet import load
+
+
+def _repo_root() -> Path:
+    # tests/ → kotoba_murakumo/ → py/ → kotoba/ → 40-engine/ → repo root
+    return Path(__file__).resolve().parents[5]
+
+
+def test_load_canonical_fleet() -> None:
+    fleet = load(_repo_root() / "50-infra/murakumo/fleet.toml")
+
+    assert fleet.name == "etzhayyim-murakumo"
+
+    # 10 tribes documented in CLAUDE.md (Status row + fleet.toml). The minimum
+    # we require is that judah is present (LiteLLM gateway lives here).
+    assert "judah" in fleet.nodes
+    judah = fleet.node("judah")
+    assert judah.ip_lan == "192.168.1.17"
+
+    # EVO-X2 endpoints declared by the SSoT.
+    litellm_ep = fleet.endpoint("evo-x2", "litellm")
+    assert litellm_ep.url == "http://192.168.1.70:4000"
+    assert litellm_ep.master_key_env == "EVO_X2_LITELLM_KEY"
+
+    ollama_ep = fleet.endpoint("evo-x2", "ollama")
+    assert ollama_ep.url == "http://192.168.1.70:11434"
+
+    # Gateway URL is judah :4000 per CLAUDE.md.
+    assert fleet.litellm_gateway_url() == "http://192.168.1.17:4000"
+
+
+def test_missing_fleet_raises() -> None:
+    with pytest.raises(FleetUnreachable):
+        load("/nonexistent/fleet.toml")

--- a/py/kotoba_murakumo/tests/test_function_dispatch.py
+++ b/py/kotoba_murakumo/tests/test_function_dispatch.py
@@ -1,0 +1,205 @@
+"""End-to-end ``Function.remote/.remote_async/.spawn/.map/.stream`` via mock HTTP."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from kotoba_murakumo import App, gpu
+from kotoba_murakumo.exceptions import FleetUnreachable
+
+
+def _ok(text: str = "OK") -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={"choices": [{"index": 0, "message": {"role": "assistant", "content": text}}]},
+    )
+
+
+def _install_mock_clients(monkeypatch, handler) -> None:
+    real_sync = httpx.Client
+    real_async = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx, "Client",
+        lambda timeout=None: real_sync(transport=transport, timeout=timeout),
+    )
+    monkeypatch.setattr(
+        httpx, "AsyncClient",
+        lambda timeout=None: real_async(transport=transport, timeout=timeout),
+    )
+
+
+def test_remote_returns_string_through_litellm_gateway(monkeypatch, fleet_path) -> None:
+    captured: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["body"] = json.loads(request.content.decode())
+        return _ok(f"echo:{captured['body']['messages'][0]['content']}")
+
+    _install_mock_clients(monkeypatch, handler)
+
+    app = App("smoke", fleet=fleet_path, did="did:web:test.etzhayyim.com")
+
+    @app.function(model="gemma3:4b")  # gpu=None → litellm-gateway
+    def reply(text: str) -> str: ...
+
+    out = reply.remote("hello")
+    assert out == "echo:hello"
+    assert captured["url"] == "http://192.168.1.17:4000/v1/chat/completions"
+    assert captured["body"]["model"] == "gemma3:4b"
+
+
+def test_remote_through_mac_mini_node_ollama(monkeypatch, fleet_path) -> None:
+    seen_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_urls.append(str(request.url))
+        return _ok("own-node")
+
+    _install_mock_clients(monkeypatch, handler)
+    app = App("smoke", fleet=fleet_path)
+
+    @app.function(gpu=gpu.MacMini(node="judah"), model="gemma3:4b")
+    def f(x: str) -> str: ...
+
+    assert f.remote("ping") == "own-node"
+    # judah ip_lan == 192.168.1.17, ollama at :11434
+    assert seen_urls[0] == "http://192.168.1.17:11434/v1/chat/completions"
+
+
+def test_remote_through_evo_x2_litellm_uses_bearer(monkeypatch, fleet_path) -> None:
+    seen_headers: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_headers.update(request.headers)
+        return _ok("evo")
+
+    _install_mock_clients(monkeypatch, handler)
+    monkeypatch.setenv("EVO_X2_LITELLM_KEY", "shh-secret")
+    app = App("smoke", fleet=fleet_path)
+
+    @app.function(gpu=gpu.EvoX2(), model="llama3.3:70b")
+    def heavy(x: str) -> str: ...
+
+    heavy.remote("analyze this")
+    assert seen_headers.get("authorization") == "Bearer shh-secret"
+
+
+def test_remote_async_returns_string(monkeypatch, fleet_path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _ok("async-result")
+
+    _install_mock_clients(monkeypatch, handler)
+    app = App("smoke", fleet=fleet_path)
+
+    @app.function(model="gemma3:4b")
+    def f(x: str) -> str: ...
+
+    out = asyncio.run(f.remote_async("hi"))
+    assert out == "async-result"
+
+
+def test_spawn_returns_handle_and_get_blocks_for_result(monkeypatch, fleet_path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _ok("spawned")
+
+    _install_mock_clients(monkeypatch, handler)
+    app = App("smoke", fleet=fleet_path)
+
+    @app.function(model="gemma3:4b")
+    def f(x: str) -> str: ...
+
+    handle = f.spawn("hi")
+    assert isinstance(handle.call_id, str) and len(handle.call_id) == 32
+    assert handle.get(timeout=5) == "spawned"
+    assert handle.done()
+
+
+def test_map_returns_results_in_input_order(monkeypatch, fleet_path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content.decode())
+        prompt = body["messages"][0]["content"]
+        return _ok(f"r:{prompt}")
+
+    _install_mock_clients(monkeypatch, handler)
+    app = App("smoke", fleet=fleet_path)
+
+    @app.function(model="gemma3:4b")
+    def f(x: str) -> str: ...
+
+    out = list(f.map(["a", "b", "c", "d"], concurrency=4, order_outputs=True))
+    assert out == ["r:a", "r:b", "r:c", "r:d"]
+
+
+def test_stream_yields_tokens(monkeypatch, fleet_path) -> None:
+    chunks = [
+        b'data: {"choices":[{"delta":{"content":"to"}}]}\n',
+        b'data: {"choices":[{"delta":{"content":"ken"}}]}\n',
+        b'data: {"choices":[{"delta":{"content":"-stream"}}]}\n',
+        b"data: [DONE]\n",
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"".join(chunks))
+
+    _install_mock_clients(monkeypatch, handler)
+    app = App("smoke", fleet=fleet_path)
+
+    @app.function(model="gemma3:4b")
+    def f(x: str) -> str: ...
+
+    async def collect() -> list[str]:
+        out: list[str] = []
+        async for tok in f.stream("hi"):
+            out.append(tok)
+        return out
+
+    tokens = asyncio.run(collect())
+    assert tokens == ["to", "ken", "-stream"]
+
+
+def test_remote_writes_invocation_ndjson(monkeypatch, fleet_path, tmp_path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _ok("RESULT")
+
+    _install_mock_clients(monkeypatch, handler)
+    log = tmp_path / "log.ndjson"
+    monkeypatch.setenv("KOTOBA_MURAKUMO_LOG", str(log))
+    from kotoba_murakumo._internal import ndjson as nd
+    monkeypatch.setattr(nd, "_DEFAULT_PATH", log)
+
+    app = App("smoke", fleet=fleet_path, did="did:web:caller.etzhayyim.com")
+
+    @app.function(model="gemma3:4b")
+    def f(x: str) -> str: ...
+
+    f.remote("PROMPT")
+    rec = json.loads(log.read_text(encoding="utf-8").strip())
+    assert rec["app"] == "smoke"
+    assert rec["fn"] == "f"
+    assert rec["caller_did"] == "did:web:caller.etzhayyim.com"
+    assert rec["model"] == "gemma3:4b"
+    assert rec["endpoint"] == "http://192.168.1.17:4000"
+    assert rec["result_chars"] == len("RESULT")
+    assert rec["phase"] == "sync"
+    assert rec["charter_in"] == "clean"
+    assert rec["charter_out"] == "clean"
+
+
+def test_remote_http_error_becomes_fleet_unreachable(monkeypatch, fleet_path) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, text="upstream down")
+
+    _install_mock_clients(monkeypatch, handler)
+    app = App("smoke", fleet=fleet_path)
+
+    @app.function(model="gemma3:4b")
+    def f(x: str) -> str: ...
+
+    with pytest.raises(FleetUnreachable):
+        f.remote("hi")

--- a/py/kotoba_murakumo/tests/test_kotoba_vm_client.py
+++ b/py/kotoba_murakumo/tests/test_kotoba_vm_client.py
@@ -1,0 +1,60 @@
+"""R1.2 — kotoba_vm client surface reservation.
+
+The R2 wire shape is locked in today via a NotImplementedError that carries
+the target POST URL + body fields so callers see exactly what will land.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kotoba_murakumo.client import kotoba_vm
+from kotoba_murakumo.client.kotoba_vm import InvokeRequest, InvokeResult
+from kotoba_murakumo.exceptions import MurakumoCompatNotImplemented
+
+
+def test_invoke_request_and_result_dataclasses_present() -> None:
+    req = InvokeRequest(
+        program_cid="bafyA",
+        args_cid="bafyB",
+        caller_did="did:web:caller.etzhayyim.com",
+        gas_limit=42,
+    )
+    assert req.program_cid == "bafyA"
+    assert req.args_cid == "bafyB"
+    assert req.gas_limit == 42
+
+    res = InvokeResult(result_cid="bafyC", gas_used=17, program_cid="bafyA")
+    assert res.result_cid == "bafyC"
+    assert res.gas_used == 17
+
+
+def test_invoke_raises_with_r2_plan_in_message() -> None:
+    req = InvokeRequest(
+        program_cid="bafyA", args_cid="bafyB",
+        caller_did="did:web:x.etzhayyim.com",
+    )
+    with pytest.raises(MurakumoCompatNotImplemented) as ei:
+        kotoba_vm.invoke(server_url="http://judah.local:8088", request=req)
+    msg = str(ei.value)
+    # Target XRPC NSID is present so callers know exactly the R2 endpoint.
+    assert "com.etzhayyim.kotoba.vm.invoke" in msg
+    assert "judah.local:8088" in msg
+    assert "bafyA" in msg
+
+
+def test_invoke_async_signature_present() -> None:
+    """Async sibling is importable + raises with R2 reason."""
+    import asyncio
+
+    async def run() -> None:
+        req = InvokeRequest(
+            program_cid="bafyA", args_cid="bafyB",
+            caller_did="did:web:x.etzhayyim.com",
+        )
+        with pytest.raises(MurakumoCompatNotImplemented):
+            await kotoba_vm.invoke_async(
+                server_url="http://judah.local:8088", request=req,
+            )
+
+    asyncio.run(run())

--- a/py/kotoba_murakumo/tests/test_litellm_client.py
+++ b/py/kotoba_murakumo/tests/test_litellm_client.py
@@ -1,0 +1,151 @@
+"""LiteLLM client — unit tests via httpx.MockTransport."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from kotoba_murakumo.client import litellm as litellm_client
+
+
+def _ok_response(text: str = "hello world") -> httpx.Response:
+    return httpx.Response(
+        200,
+        json={
+            "id": "chatcmpl-test",
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": text}}],
+        },
+    )
+
+
+def _patch_sync(monkeypatch, handler) -> None:
+    real_cls = httpx.Client
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx, "Client",
+        lambda timeout=None: real_cls(transport=transport, timeout=timeout),
+    )
+
+
+def _patch_async(monkeypatch, handler) -> None:
+    real_cls = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx, "AsyncClient",
+        lambda timeout=None: real_cls(transport=transport, timeout=timeout),
+    )
+
+
+def test_chat_completions_sends_openai_shape(monkeypatch) -> None:
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["headers"] = dict(request.headers)
+        seen["body"] = json.loads(request.content.decode())
+        return _ok_response("hi back")
+
+    _patch_sync(monkeypatch, handler)
+
+    out = litellm_client.chat_completions(
+        url="http://192.168.1.17:4000",
+        model="gemma3:4b",
+        messages=[{"role": "user", "content": "hi"}],
+        auth_bearer="secret-key",
+    )
+
+    assert out == "hi back"
+    assert seen["url"] == "http://192.168.1.17:4000/v1/chat/completions"
+    assert seen["headers"]["authorization"] == "Bearer secret-key"
+    assert seen["body"]["model"] == "gemma3:4b"
+    assert seen["body"]["stream"] is False
+
+
+def test_chat_completions_omits_bearer_when_none(monkeypatch) -> None:
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["headers"] = dict(request.headers)
+        return _ok_response()
+
+    _patch_sync(monkeypatch, handler)
+
+    litellm_client.chat_completions(
+        url="http://192.168.1.70:11434",
+        model="gemma3:4b",
+        messages=[{"role": "user", "content": "hi"}],
+        auth_bearer=None,
+    )
+    assert "authorization" not in seen["headers"]
+
+
+def test_chat_completions_async(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _ok_response("async-out")
+
+    _patch_async(monkeypatch, handler)
+
+    out = asyncio.run(litellm_client.chat_completions_async(
+        url="http://192.168.1.17:4000",
+        model="gemma3:4b",
+        messages=[{"role": "user", "content": "x"}],
+    ))
+    assert out == "async-out"
+
+
+def test_chat_completions_stream_yields_tokens(monkeypatch) -> None:
+    chunks = [
+        b'data: {"choices":[{"delta":{"content":"hel"}}]}\n',
+        b'data: {"choices":[{"delta":{"content":"lo "}}]}\n',
+        b'data: {"choices":[{"delta":{"content":"world"}}]}\n',
+        b"data: [DONE]\n",
+    ]
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, content=b"".join(chunks))
+
+    _patch_async(monkeypatch, handler)
+
+    async def collect() -> list[str]:
+        out: list[str] = []
+        async for tok in litellm_client.chat_completions_stream(
+            url="http://192.168.1.17:4000",
+            model="gemma3:4b",
+            messages=[{"role": "user", "content": "x"}],
+        ):
+            out.append(tok)
+        return out
+
+    out = asyncio.run(collect())
+    assert out == ["hel", "lo ", "world"]
+
+
+def test_chat_completions_raises_on_500(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    _patch_sync(monkeypatch, handler)
+
+    with pytest.raises(httpx.HTTPStatusError):
+        litellm_client.chat_completions(
+            url="http://192.168.1.17:4000",
+            model="gemma3:4b",
+            messages=[{"role": "user", "content": "x"}],
+        )
+
+
+def test_chat_completions_raises_on_malformed_response(monkeypatch) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"choices": []})
+
+    _patch_sync(monkeypatch, handler)
+
+    with pytest.raises(ValueError, match="missing choices"):
+        litellm_client.chat_completions(
+            url="http://192.168.1.17:4000",
+            model="gemma3:4b",
+            messages=[{"role": "user", "content": "x"}],
+        )

--- a/py/kotoba_murakumo/tests/test_live_fleet_smoke.py
+++ b/py/kotoba_murakumo/tests/test_live_fleet_smoke.py
@@ -1,0 +1,50 @@
+"""Live-fleet smoke tests.
+
+Skipped unless ``KOTOBA_MURAKUMO_LIVE_FLEET=1``. Run from a host on the
+Murakumo LAN (192.168.1.0/24) with judah :4000 + evo-x2 :11434 reachable.
+
+Mark each test with ``@pytest.mark.live_fleet``; ``conftest.py`` auto-skips
+unless the env var is set.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from kotoba_murakumo import App, gpu
+
+pytestmark = pytest.mark.live_fleet
+
+
+def _lan_reachable(host: str, port: int, *, timeout_s: float = 1.0) -> bool:
+    try:
+        with socket.create_connection((host, port), timeout=timeout_s):
+            return True
+    except OSError:
+        return False
+
+
+def test_live_litellm_gateway_round_trip(fleet_path) -> None:
+    if not _lan_reachable("192.168.1.17", 4000):
+        pytest.skip("judah :4000 not reachable from this host")
+    app = App("live-smoke", fleet=fleet_path, did="did:web:smoke.etzhayyim.com")
+
+    @app.function(model="gemma3:4b")  # routed to judah :4000
+    def echo(prompt: str) -> str: ...
+
+    out = echo.remote("Reply with the single word: alive")
+    assert isinstance(out, str) and len(out) > 0
+
+
+def test_live_evo_x2_ollama_round_trip(fleet_path) -> None:
+    if not _lan_reachable("192.168.1.70", 11434):
+        pytest.skip("evo-x2 :11434 not reachable from this host")
+    app = App("live-smoke", fleet=fleet_path)
+
+    @app.function(gpu=gpu.EvoX2(prefer="ollama"), model="llama3.2:3b")
+    def reply(prompt: str) -> str: ...
+
+    out = reply.remote("Reply with one short word.")
+    assert isinstance(out, str) and len(out) > 0

--- a/py/kotoba_murakumo/tests/test_modal_compat.py
+++ b/py/kotoba_murakumo/tests/test_modal_compat.py
@@ -1,0 +1,114 @@
+"""Modal-compat surface — verify import shape + R0 stub semantics."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import json
+
+import httpx
+
+import kotoba_murakumo.modal_compat as modal
+from kotoba_murakumo.exceptions import MurakumoCompatNotImplemented
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[5]
+
+
+def test_modal_compat_surface_present() -> None:
+    # Names a Modal app expects at the top level.
+    assert hasattr(modal, "App")
+    assert hasattr(modal, "Stub")              # legacy alias
+    assert modal.Stub is modal.App
+    assert hasattr(modal, "Image")
+    assert hasattr(modal, "Volume")
+    assert hasattr(modal, "Secret")
+    assert hasattr(modal, "gpu")
+    for name in ("enter", "exit", "method"):
+        assert callable(getattr(modal, name))
+
+
+def test_modal_gpu_strings_map_to_evo_x2() -> None:
+    from kotoba_murakumo.gpu import EvoX2
+
+    for fn in (modal.gpu.T4, modal.gpu.L4, modal.gpu.A10G, modal.gpu.H100, modal.gpu.H200):
+        assert isinstance(fn(), EvoX2)
+    assert isinstance(modal.gpu.A100(memory=80), EvoX2)
+
+
+def test_modal_function_decorator_registers_and_local_works() -> None:
+    fleet_path = _repo_root() / "50-infra/murakumo/fleet.toml"
+    app = modal.App("smoke", fleet=fleet_path, did="did:web:test.etzhayyim.com")
+
+    @app.function(gpu="A10G", model="llama3.2:3b")
+    def echo(x: str) -> str:
+        return f"echo:{x}"
+
+    # Modal compat: .local() runs in-process.
+    assert echo.local("hi") == "echo:hi"
+    # Direct call also runs locally (Modal semantics inside a remote container).
+    assert echo("hi") == "echo:hi"
+    # App tracks it.
+    assert "echo" in app.registered_functions()
+
+
+def test_modal_remote_dispatches_via_litellm_gateway(monkeypatch) -> None:
+    """R1.1: .remote() actually dispatches to judah :4000 through the LiteLLM gateway."""
+    fleet_path = _repo_root() / "50-infra/murakumo/fleet.toml"
+    seen_url: dict = {}
+    real_cls = httpx.Client
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_url["url"] = str(request.url)
+        seen_url["model"] = json.loads(request.content.decode())["model"]
+        return httpx.Response(
+            200,
+            json={"choices": [{"message": {"role": "assistant", "content": "ok"}}]},
+        )
+
+    transport = httpx.MockTransport(handler)
+    monkeypatch.setattr(
+        httpx, "Client",
+        lambda timeout=None: real_cls(transport=transport, timeout=timeout),
+    )
+
+    app = modal.App("smoke", fleet=fleet_path)
+
+    @app.function(model="gemma3:4b")  # gpu=None → LiteLLM gateway
+    def f(x: str) -> str: ...
+
+    out = f.remote("hello")
+    assert out == "ok"
+    assert seen_url["url"] == "http://192.168.1.17:4000/v1/chat/completions"
+    assert seen_url["model"] == "gemma3:4b"
+
+
+def test_modal_unsupported_surfaces_fail_loud() -> None:
+    with pytest.raises(MurakumoCompatNotImplemented):
+        modal.Image.from_registry("nvidia/cuda:12.4.0-base")
+    with pytest.raises(MurakumoCompatNotImplemented):
+        modal.web_endpoint()
+    with pytest.raises(MurakumoCompatNotImplemented):
+        modal.Sandbox()
+
+
+def test_modal_cls_records_enter_method() -> None:
+    fleet_path = _repo_root() / "50-infra/murakumo/fleet.toml"
+    app = modal.App("smoke", fleet=fleet_path)
+
+    @app.cls(gpu="A100")
+    class Server:
+        @modal.enter()
+        def load(self) -> None: ...
+
+        @modal.method()
+        def generate(self, prompt: str) -> str:
+            return prompt
+
+    meta = getattr(Server, "__kotoba_murakumo_meta__")
+    assert "load" in meta["enter"]
+    assert "generate" in meta["method"]
+    assert "Server" in app.registered_classes()

--- a/py/kotoba_murakumo/tests/test_no_modal_labs_gate.py
+++ b/py/kotoba_murakumo/tests/test_no_modal_labs_gate.py
@@ -1,0 +1,53 @@
+"""Self-test for the CI grep gate."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_gate_passes_on_real_source_tree() -> None:
+    repo_root = Path(__file__).resolve().parents[5]
+    script = repo_root / "70-tools/scripts/lint/verify_no_modal_labs_calls.py"
+    assert script.exists(), f"missing gate script: {script}"
+
+    r = subprocess.run(
+        [sys.executable, str(script)],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, (
+        f"CI grep gate failed:\nstdout: {r.stdout}\nstderr: {r.stderr}"
+    )
+    assert "clean" in r.stdout
+
+
+def test_gate_flags_injected_violation(tmp_path) -> None:
+    """If we drop a violating .py into the package dir, the gate must flag it."""
+    repo_root = Path(__file__).resolve().parents[5]
+    script = repo_root / "70-tools/scripts/lint/verify_no_modal_labs_calls.py"
+
+    # Build a temporary fake repo with the same path structure.
+    fake_pkg = (
+        tmp_path / "40-engine/kotoba/py/kotoba_murakumo/kotoba_murakumo"
+    )
+    fake_pkg.mkdir(parents=True)
+    bad = fake_pkg / "evil.py"
+    bad.write_text(
+        '"""bad module"""\nimport modal\n'
+        'BASE = "https://api.modal.com/v1/functions"\n',
+        encoding="utf-8",
+    )
+
+    r = subprocess.run(
+        [sys.executable, str(script), "--root", str(tmp_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 1, (
+        f"gate should have flagged the injected violation but exited "
+        f"{r.returncode}\nstdout={r.stdout}\nstderr={r.stderr}"
+    )
+    assert "modal.com" in r.stderr or "modal" in r.stderr

--- a/py/kotoba_murakumo/tests/test_routing.py
+++ b/py/kotoba_murakumo/tests/test_routing.py
@@ -1,0 +1,73 @@
+"""Routing decisions — pure function, no HTTP."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kotoba_murakumo import gpu
+from kotoba_murakumo._internal.routing import resolve
+from kotoba_murakumo.exceptions import FleetUnreachable, MurakumoCompatNotImplemented
+from kotoba_murakumo.fleet import load
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[5]
+
+
+@pytest.fixture(scope="module")
+def fleet():
+    return load(_repo_root() / "50-infra/murakumo/fleet.toml")
+
+
+def test_none_routes_to_litellm_gateway(fleet) -> None:
+    r = resolve(None, "gemma3:4b", fleet)
+    assert r.backend == "litellm-gateway"
+    assert r.url == "http://192.168.1.17:4000"
+    assert r.kind == "openai-compatible"
+    # The judah-hosted LiteLLM gateway requires bearer auth per
+    # ADR-2605282400 §"Routing fix" (empirically verified 2026-05-28 —
+    # without this the gateway returns 401 Unauthorized).
+    assert r.auth_bearer_env == "LITELLM_MASTER_KEY"
+
+
+def test_any_str_routes_to_litellm_gateway(fleet) -> None:
+    r = resolve("any", "gemma3:4b", fleet)
+    assert r.backend == "litellm-gateway"
+
+
+def test_mac_mini_routes_to_own_node_ollama(fleet) -> None:
+    r = resolve(gpu.MacMini(node="judah"), "gemma3:4b", fleet)
+    assert r.backend == "mac-mini/judah"
+    assert r.url == "http://192.168.1.17:11434"
+    assert r.kind == "ollama-native"
+
+
+def test_evo_x2_default_prefers_litellm(fleet) -> None:
+    r = resolve(gpu.EvoX2(), "llama3.3:70b", fleet)
+    assert r.backend == "evo-x2"
+    assert r.url == "http://192.168.1.70:4000"
+    assert r.auth_bearer_env == "EVO_X2_LITELLM_KEY"
+
+
+def test_evo_x2_prefer_ollama(fleet) -> None:
+    r = resolve(gpu.EvoX2(prefer="ollama"), "llama3.2:3b", fleet)
+    assert r.url == "http://192.168.1.70:11434"
+    assert r.kind == "openai-compatible"  # ollama exposes OpenAI-compat
+
+
+def test_modal_string_a100_routes_to_evo_x2(fleet) -> None:
+    r = resolve("A100", "llama3.2:3b", fleet)
+    assert r.backend == "evo-x2"
+
+
+def test_webgpu_lands_r2(fleet) -> None:
+    with pytest.raises(MurakumoCompatNotImplemented) as ei:
+        resolve(gpu.WebGPU(), "any", fleet)
+    assert "R2" in str(ei.value)
+
+
+def test_unknown_node_raises(fleet) -> None:
+    with pytest.raises(FleetUnreachable):
+        resolve(gpu.MacMini(node="not-a-tribe"), "gemma3:4b", fleet)


### PR DESCRIPTION
Re-integrates the `kotoba_murakumo` Modal-compatible Python facade into this repo at `py/kotoba_murakumo/`, as a sibling of `py/kotoba_langgraph/`.

## What
- Modal-API-shape facade routing inference exclusively to the etzhayyim Murakumo Mac mini fleet (LiteLLM gateway / EVO-X2 / own-node Ollama), Murakumo-only invariant per ADR-2605215000, plus the mKOTO economy + Charter Rider §2 dispatch scan.
- Originally landed inside this repo, then relocated out to the etzhayyim monorepo (ADR-2605282300) because the **git-subrepo** merge-base had been force-pushed away, making subrepo sync impossible. Under **git submodules** that sync problem no longer applies, so the consumer rejoins the engine repo.

## Path fixes for the new depth
`tests/ → kotoba_murakumo/ → py/ → kotoba/ → 40-engine/ → monorepo root`
- `resolve().parents[3] → parents[5]` across conftest, test_no_modal_labs_gate, test_modal_compat, test_routing, test_fleet_load.
- gate self-test fake-pkg path → `40-engine/kotoba/py/kotoba_murakumo/kotoba_murakumo`.

## Standalone-checkout guard
`kotoba_murakumo` is a **monorepo-context** package — its canonical inputs (`50-infra/murakumo/fleet.toml`, the `70-tools` lint gate) live in the etzhayyim monorepo, not in a bare `kotoba` clone. `conftest.py` now skips the whole suite when `fleet.toml` is absent, so upstream CI on a standalone checkout stays green.

## Tests
62 pass / 2 `live_fleet` skipped in the monorepo context; all skip in a standalone checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
