### PR TITLE
feat(py): add kotoba_iso20022 cleanroom ISO 20022 codec (engine-core)

### DIFF
--- a/py/kotoba_iso20022/CHANGELOG.md
+++ b/py/kotoba_iso20022/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog — kotoba_iso20022
+
+All notable changes to the cleanroom ISO 20022 codec. Pre-1.0; the public
+surface in `kotoba_iso20022/__init__.py` is the compatibility contract.
+
+## [0.1.0] — unreleased
+
+Cleanroom ISO 20022 payment-message codec for the kawase-yui interop wire,
+built purely from the open published standard (no proprietary SWIFT SDK).
+
+### Messages
+- **pain.001** CustomerCreditTransferInitiation — build + parse
+- **pain.002** CustomerPaymentStatusReport — build + parse
+- **pacs.008** FIToFICustomerCreditTransfer — build + parse
+- **pacs.002** FIToFIPaymentStatusReport — build + parse
+- **pacs.004** PaymentReturn — build + parse (reversal reconciliation)
+- **camt.053** BankToCustomerStatement — build + parse
+- **camt.054** BankToCustomerDebitCreditNotification — build + parse
+- **head.001** Business Application Header + CBPR+ `<Envelope>` (BAH
+  `MsgDefIdr` ↔ Document match enforced)
+
+### Validation
+- ISO 13616 IBAN (ISO 7064 MOD 97-10), ISO 9362 BIC, ISO 4217 currency,
+  ISO 20022 `ActiveCurrencyAndAmount` constraints, CBPR+ UETR (UUIDv4)
+
+### CBPR+ conformance
+- `conformance.py` — 11 Usage-Guideline rules (CBPR-001…011): NbOfTxs,
+  UETR mandatory + UUIDv4, settlement amount, ChrgBr ∈ {DEBT,CRED,SHAR},
+  agent BICFI required + no-Name-with-BICFI, CtrlSum, party names, BAH
+  MsgDefIdr + `swift.cbprplus.*` BizSvc
+
+### kotoba / kawase integration
+- `datoms.py` — message → append-only EAVT facts; content-addressed entity
+  (UETR→TxId→EndToEndId); camt entries reconcile onto the ingress entity
+- `bridge.py` + `com.etzhayyim.iso20022.ingressAttestation` Lexicon —
+  one record per transaction/entry; `linkedDepositCid` reconciles against
+  `com.etzhayyim.kawase.depositAttestation`; party names omitted by default
+  (kawase-yui G10 PII discipline)
+
+### Helpers
+- `helpers.py` — `new_uetr()`, `control_sum_of()`,
+  `pacs008_group_header()` / `pain001_group_header()` (auto NbOfTxs +
+  CtrlSum so a hand-built message satisfies CBPR-001/008)
+
+### Quality
+- Dependency-free (stdlib only), Python ≥ 3.11
+- 231 tests, 97% branch / 99% line coverage
+- Passes `mypy --strict` clean (all 9 modules)
+- Full SWIFT IBAN-registry country-length set (ISO 13616); breadth
+  round-trip + cross-currency (incl. 0- and 3-fraction-digit) tests
+- Property-based serialization-idempotence fuzz (seeded, 750+ generated
+  messages: build(parse(build(m)))==build(m)) + golden wire-bytes regression lock
+- CI gate `.github/workflows/kotoba-iso20022-ci.yml`: ruff lint + pytest
+  (Python 3.11–3.13) + `mypy --strict` + `coverage --fail-under=90` +
+  Lexicon validation, on push/PR/nightly
+- ruff-clean (E/F/W/B/UP/SIM/I/C4/PIE/RET); PEP 604 unions throughout
+- Charter-clean: format library only — no network, no chain, no money
+  movement, no Travel-Rule KYC

--- a/py/kotoba_iso20022/README.md
+++ b/py/kotoba_iso20022/README.md
@@ -1,0 +1,284 @@
+# kotoba_iso20022 — cleanroom ISO 20022 payment-message codec
+
+A dependency-free, charter-clean reimplementation of the three ISO 20022
+message definitions the **kawase-yui (為替結)** cross-border actor
+(ADR-2605282200) needs at its **interop / ingress boundary** — built purely
+from the *open published* ISO 20022 standard, with **no proprietary SWIFT
+SDK** and no vendor schema files at runtime.
+
+This is the traditional-finance analogue of the CLAUDE.md substrate rule
+*"AT-Protocol MST = ingress/interop wire"*: here the wire is the global
+ISO 20022 banking network (the format **SWIFT itself migrated to** via the
+CBPR+ programme), and this module translates between that wire and the
+canonical **kotoba EAVT Datom log**.
+
+## Why this exists
+
+kawase-yui settles adherent-to-adherent over **Base L2 stablecoins**
+(USDC/EURC/…), never fiat. But an adherent *on/off-ramps* through the real
+banking system, which speaks ISO 20022. When a real bank credit transfer
+touches a kawase corridor, it must become **auditable, append-only kotoba
+history** (Wellbecoming `as-of`, no mutation). This codec is the format
+layer that makes that ingress possible without taking on a proprietary
+vendor dependency.
+
+## Scope (what this is — and is NOT)
+
+| | |
+|---|---|
+| **Is** | a pure XML **codec** + open-standard validators + kotoba Datom mapping |
+| **Is** | cleanroom — implemented from the public ISO 20022 element grammar only |
+| **Is NOT** | a network client — it opens no socket, calls no bank, joins no SWIFT |
+| **Is NOT** | a money-movement path — no chain, no transfer, no custody |
+| **Is NOT** | a Travel-Rule / FATF passport-KYC engine — the **Adherent SBT remains the KYC** (kawase-yui G10) |
+| **Is NOT** | a chargeback/reversal path — ingress Datoms are assertion-only, never retracted (kawase-yui G11 mirror) |
+| **Is NOT** | a commercial-MSB integration — no Wise/WU/MoneyGram/etc. (kawase-yui G7) |
+
+## Cleanroom provenance
+
+Every wire detail comes from the **open published standard**, not vendor code:
+
+- **Message structure** — `GrpHdr` / `PmtInf` / `CdtTrfTxInf` / `PmtId` /
+  `IntrBkSttlmAmt` / `OrgnlGrpInfAndSts` … from the ISO 20022 message
+  components.
+- **Namespace** — the official URN scheme
+  `urn:iso:std:iso:20022:tech:xsd:<msgdef>` (e.g.
+  `urn:iso:std:iso:20022:tech:xsd:pacs.008.001.08`), emitted as the
+  canonical default-namespace `<Document xmlns="…">` form.
+- **Embedded identifiers** — validated by independent reimplementations of
+  the *open* identifier standards: **ISO 13616** IBAN (check digits via
+  **ISO 7064 MOD 97-10**, the full SWIFT IBAN-registry country-length set),
+  **ISO 9362** BIC, **ISO 4217** currency, and the ISO 20022
+  `ActiveCurrencyAndAmount` lexical constraints.
+
+This is the same cleanroom posture warifu applied to ISO 8583 in
+`50-infra/warifu-gateway/` — facts of an open standard are not
+copyrightable expression, so a clean reimplementation is charter-clean
+(Charter Rider §2(c) vendor data-sovereignty + §2(e) anti-gatekeeping).
+
+## Supported message definitions
+
+Version-parameterised; defaults follow widely-deployed CBPR+/SEPA versions.
+
+| Def | Name | Default version | Direction |
+|---|---|---|---|
+| **pain.001** | CustomerCreditTransferInitiation | `pain.001.001.09` | ingress (a party instructs a transfer) |
+| **pacs.008** | FIToFICustomerCreditTransfer | `pacs.008.001.08` | inter-bank leg (the SWIFT/CBPR+ carrier) |
+| **pacs.002** | FIToFIPaymentStatusReport | `pacs.002.001.10` | acceptance / rejection / pending ack |
+| **pacs.004** | PaymentReturn | `pacs.004.001.09` | reversal (a settled transfer sent back) |
+| **camt.053** | BankToCustomerStatement | `camt.053.001.08` | reconciliation (end-of-day account statement) |
+| **camt.054** | BankToCustomerDebitCreditNotification | `camt.054.001.08` | reconciliation (debit/credit notification) |
+| **pain.002** | CustomerPaymentStatusReport | `pain.002.001.10` | pain-side ack of a pain.001 |
+| **head.001** | BusinessApplicationHeader (BAH) | `head.001.001.02` | **mandatory CBPR+ wrapper** around every message |
+
+Pass `version=` to any `build_*` / `parse_*` to target a different release.
+
+### CBPR+ Business Application Header (head.001)
+
+A bare `Document` is **not** a valid CBPR+ message on the SWIFT network — it
+must be wrapped in a Business Application Header. This module builds the BAH
+and pairs it with its `Document` in an `<Envelope>`, enforcing the CBPR+
+rule that the header's `MsgDefIdr` must match the wrapped message:
+
+```python
+from kotoba_iso20022 import build_business_message, parse_business_message
+from kotoba_iso20022.model import BusinessApplicationHeader
+
+bah = BusinessApplicationHeader(
+    from_bic="DEUTDEFF", to_bic="NWBKGB2L",
+    business_message_id="BMID-2026-0608-1",
+    message_definition="pacs.008.001.08",   # MUST match the document
+    creation_datetime="2026-06-08T09:30:00Z",
+    business_service="swift.cbprplus.02",
+)
+envelope = build_business_message(bah, pacs008_xml)   # <Envelope><AppHdr/><Document/></Envelope>
+header, document_xml = parse_business_message(envelope)  # raises on MsgDefIdr mismatch
+```
+
+### CBPR+ Usage-Guideline conformance (the rulebook over the grammar)
+
+The codec implements the *base ISO 20022* grammar; SWIFT **CBPR+** layers a
+Usage Guideline of extra constraints on top. `conformance.py` is the
+cleanroom implementation of those rules — a base-valid `pacs.008` can still
+be a non-conformant CBPR+ message, and this catches it before the wire:
+
+```python
+from kotoba_iso20022 import check_cbpr_pacs008, assert_cbpr_pacs008
+issues = check_cbpr_pacs008(msg)   # list[ConformanceIssue(rule_id, severity, location, message)]
+assert_cbpr_pacs008(msg)           # raises CbprConformanceError on any error-level issue
+```
+
+| Rule | Constraint |
+|---|---|
+| `CBPR-001` | `GrpHdr/NbOfTxs` equals the actual `CdtTrfTxInf` count |
+| `CBPR-002/003` | UETR mandatory and a lowercase **UUIDv4** |
+| `CBPR-004` | `IntrBkSttlmAmt` present with a valid ISO 4217 amount |
+| `CBPR-005` | `ChrgBr` ∈ {DEBT, CRED, SHAR} (SLEV is SEPA, not CBPR+) |
+| `CBPR-006/007` | `DbtrAgt`/`CdtrAgt` need a valid BICFI; Name not allowed alongside BICFI |
+| `CBPR-008` | `CtrlSum`, if present, equals the sum of settlement amounts |
+| `CBPR-009` | Debtor and Creditor names mandatory |
+| `CBPR-010/011` | BAH `MsgDefIdr` matches; `BizSvc` is a `swift.cbprplus.*` service |
+
+Non-adjudicating and deterministic — it reports findings, it does not move
+money, sign, or transact (kawase G2/G13 stay with the gated ingress cell).
+
+### Reconciliation (camt → ingress loop-close)
+
+A `camt.053`/`camt.054` entry that carries an `EndToEndId` maps to the
+**same** content-addressed transaction entity as the original
+`pain.001`/`pacs.008` ingress, so an inbound bank statement/notification
+*reconciles against* the earlier message instead of creating a parallel
+record — the off-ramp closing the loop in the kotoba Datom log:
+
+```python
+from kotoba_iso20022 import parse_camt054, to_datoms
+report = parse_camt054(camt054_xml)
+datoms = to_datoms(report)   # entry facts land on com.etzhayyim.iso20022/tx:<EndToEndId>
+```
+
+## Usage
+
+```python
+from decimal import Decimal
+from kotoba_iso20022 import build_pacs008, parse_pacs008, to_datoms
+from kotoba_iso20022.model import *
+
+tx = CreditTransferTransaction(
+    end_to_end_id="E2E-0001",
+    tx_id="TX-0001",
+    uetr="dced6a36-9e4b-4e2a-8b9f-2f3a4b5c6d7e",
+    interbank_amount=Amount(Decimal("1000.00"), "EUR"),
+    interbank_settlement_date="2026-06-08",
+    charge_bearer="SLEV",
+    debtor=Party("Alice Cohen"),
+    debtor_account=Account(iban="DE89370400440532013000"),
+    debtor_agent=Agent(bicfi="DEUTDEFF"),
+    creditor_agent=Agent(bicfi="NWBKGB2L"),
+    creditor=Party("Bob Levi"),
+    creditor_account=Account(iban="GB29NWBK60161331926819"),
+)
+gh = GroupHeader(message_id="MSG-1", creation_datetime="2026-06-08T09:30:00Z",
+                 number_of_txs=1, settlement_method="CLRG")
+msg = FIToFICustomerCreditTransfer(group_header=gh, transactions=(tx,))
+
+xml = build_pacs008(msg)        # → canonical ISO 20022 <Document xmlns="urn:…">
+back = parse_pacs008(xml)       # → round-trips back to the dataclass
+datoms = to_datoms(back)        # → append-only kotoba EAVT facts (ingress wire)
+```
+
+The Datom entity handle is **content-addressed on the message's own
+immutable identifiers** (UETR → TxId → EndToEndId), so re-ingesting the
+same message is idempotent and a later `pacs.002` status lands on the
+*same* transaction entity.
+
+### kawase-yui bridge (ingressAttestation Lexicon records)
+
+`bridge.py` shapes the same value-events into
+`com.etzhayyim.iso20022.ingressAttestation` AT-Protocol records (Lexicon at
+`00-contracts/lexicons/com/etzhayyim/iso20022/`) so a kawase corridor can
+attest an external bank transfer and, where it corresponds to an on-chain
+on-ramp, reconcile it against a `com.etzhayyim.kawase.depositAttestation`
+via `linkedDepositCid`:
+
+```python
+from kotoba_iso20022 import ingress_attestations
+records = ingress_attestations(
+    msg,
+    ingested_at="2026-06-08T23:00:00Z",
+    cbpr_conformant=True,            # carry the CBPR+ verdict onto the record
+    linked_deposit_cid="bafy…",      # reconcile vs a kawase depositAttestation
+)
+# one record per pacs.008/pain.001 transaction or camt.053/054 entry
+```
+
+**PII discipline (kawase-yui G10)**: party names are 要配慮 PII and are
+**omitted by default**; `include_party_names=True` is opt-in for a
+consent-bound / encrypted path. Only institution BICs (ISO 9362) are
+first-class. Status-only messages (pacs.002 / pain.002) are rejected — their
+status is carried by `to_datoms`, not the value-event record.
+
+## Layout
+
+```
+kotoba_iso20022/
+├── validate.py   # ISO 13616 IBAN / ISO 9362 BIC / ISO 4217 ccy / amount
+├── model.py      # frozen-dataclass domain model (GrpHdr / CdtTrfTxInf / …)
+├── codec.py        # build + parse XML for pain.001/002 / pacs.008/002 / camt.053/054
+├── bah.py          # head.001 BAH + CBPR+ business-message envelope (MsgDefIdr match)
+├── conformance.py  # CBPR+ Usage-Guideline rule checks over the parsed model
+├── datoms.py       # message → kotoba EAVT Datom ingress + reconciliation mapping
+├── bridge.py       # message → com.etzhayyim.iso20022.ingressAttestation records
+├── helpers.py      # new_uetr() + auto NbOfTxs/CtrlSum group-header builders
+└── __init__.py     # public surface
+tests/              # 231 tests · 97% branch / 99% line · mypy --strict + ruff clean
+```
+
+## Construction helpers
+
+`helpers.py` removes the two most common ways a hand-built message fails
+CBPR+ conformance — a miscounted `NbOfTxs` and a mismatched `CtrlSum`:
+
+```python
+from kotoba_iso20022 import new_uetr, pacs008_group_header
+tx = CreditTransferTransaction(end_to_end_id="E", uetr=new_uetr(), ...)
+gh = pacs008_group_header("MSG-1", "2026-06-08T09:30:00Z", (tx,))  # NbOfTxs+CtrlSum derived
+```
+
+## Tests
+
+```bash
+cd 40-engine/kotoba_iso20022
+PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=. python3 -m pytest tests/ -q
+# → 207 passed
+
+# with coverage (pip install coverage):
+PYTHONPATH=. coverage run -m pytest tests/ -q && coverage report
+# → 95% branch / 98% line
+
+# static typing (pip install mypy): the package passes --strict clean
+PYTHONPATH=. mypy kotoba_iso20022 --strict
+# → Success: no issues found
+```
+
+CI enforces all of the above on every PR via
+`.github/workflows/kotoba-iso20022-ci.yml` (ruff lint + pytest on Python
+3.11–3.13 + `mypy --strict` + `coverage --fail-under=90` + Lexicon validation).
+
+IBAN test vectors are the published ISO 13616 registry examples (DE/GB/FR/
+CH/BE); BIC vectors are real ISO 9362 codes. See `CHANGELOG.md` for the
+full surface.
+
+## Charter & substrate alignment
+
+- **G2 / G13** — output is kotoba EAVT Datoms (content-addressed); this
+  module *maps* but does not transact (the gated kawase ingress cell does).
+- **G10** — no Travel-Rule KYC; Adherent SBT is the KYC.
+- **G11** — ingress Datoms are assertion-only (`op=True`), never retracted.
+- **No-server-key** — pure function; no signing, no key material.
+- **Inference-free** — deterministic codec; no Murakumo/LLM call (no G12
+  surface).
+
+## Roadmap
+
+- ✅ `camt.053` / `camt.054` (statement + debit/credit notification) for the
+  off-ramp reconciliation direction — **shipped**, entries reconcile against
+  the ingress tx entity via `EndToEndId`.
+- A gated `kawase` ingress cell that calls `to_datoms` and transacts under
+  G2/G13 (Council-ratified, post-RFP).
+- ✅ Lexicon mapping `com.etzhayyim.iso20022.ingressAttestation` ↔
+  `com.etzhayyim.kawase.depositAttestation` for corridor reconciliation —
+  **shipped** (`bridge.py` + Lexicon).
+- A gated `kawase` ingress cell that calls `ingress_attestations` +
+  `to_datoms` and transacts under G2/G13 (Council-ratified, post-RFP).
+- ISO 20022 XSD conformance harness (optional dev-time check against the
+  official schema files; runtime stays schema-file-free).
+- ✅ `pain.002` customer payment-status report — **shipped**.
+- ✅ `head.001` Business Application Header + CBPR+ envelope — **shipped**.
+
+## Related
+
+- `90-docs/adr/2605282200-kawase-yui-multi-stable-adherent-remittance-mutual-aid.md` — consuming actor
+- `40-engine/kotoba_kawase/` — kawase-yui Python facade (sibling)
+- `50-infra/warifu-gateway/iso8583-map.md` — sibling cleanroom (card-side ISO 8583)
+- `90-docs/adr/2605262130` + `2605312345` — kotoba Datom first-class state
+- `/CHARTER-RIDER.md` — §2(c) + §2(e) cleanroom basis

--- a/py/kotoba_iso20022/kotoba_iso20022/__init__.py
+++ b/py/kotoba_iso20022/kotoba_iso20022/__init__.py
@@ -1,0 +1,150 @@
+"""kotoba_iso20022 — cleanroom ISO 20022 payment-message codec.
+
+A dependency-free, charter-clean reimplementation of the three ISO 20022
+message definitions the kawase-yui (為替結) cross-border actor needs at its
+interop/ingress boundary, built purely from the *open published* standard
+(no proprietary SWIFT SDK) — the same cleanroom posture warifu applied to
+ISO 8583.
+
+Why this exists: kawase-yui settles adherent-to-adherent over Base L2
+stablecoins, but a member on/off-ramps through the real banking system,
+which speaks ISO 20022 (the format SWIFT itself migrated to via CBPR+).
+This module is the *traditional-finance ingress/interop wire* — it
+translates between ISO 20022 XML and kotoba EAVT Datoms so a real bank
+transfer becomes auditable, append-only kotoba history.
+
+Boundaries (CRITICAL): this is a *format library* only. It does not open a
+network connection, does not touch a chain, does not move money, does not
+perform Travel-Rule / FATF passport KYC (the Adherent SBT remains the KYC
+per kawase-yui G10). It is datafication of an open standard.
+
+Public surface::
+
+    from kotoba_iso20022 import (
+        build_pacs008, parse_pacs008,
+        build_pain001, parse_pain001,
+        build_pacs002, parse_pacs002,
+        to_datoms,
+        validate_iban, validate_bic, validate_currency, validate_amount,
+    )
+
+Message definitions (version-parameterised; CBPR+/SEPA defaults):
+
+- pain.001 — CustomerCreditTransferInitiation
+- pacs.008 — FIToFICustomerCreditTransfer
+- pacs.002 — FIToFIPaymentStatusReport
+"""
+
+from __future__ import annotations
+
+from .bah import (
+    build_bah,
+    build_business_message,
+    parse_bah,
+    parse_business_message,
+)
+from .bridge import LEXICON_VERSION, RECORD_TYPE, ingress_attestations
+from .codec import (
+    DEFAULT_VERSIONS,
+    Iso20022CodecError,
+    build_camt053,
+    build_camt054,
+    build_pacs002,
+    build_pacs004,
+    build_pacs008,
+    build_pain001,
+    build_pain002,
+    parse_camt053,
+    parse_camt054,
+    parse_pacs002,
+    parse_pacs004,
+    parse_pacs008,
+    parse_pain001,
+    parse_pain002,
+    urn_for,
+)
+from .conformance import (
+    CbprConformanceError,
+    ConformanceIssue,
+    assert_cbpr_pacs008,
+    check_cbpr_bah,
+    check_cbpr_pacs008,
+)
+from .datoms import NS, Datom, to_datoms, tx_entity_of
+from .helpers import (
+    control_sum_of,
+    new_uetr,
+    pacs008_group_header,
+    pain001_group_header,
+)
+from .validate import (
+    InvalidAmount,
+    InvalidBic,
+    InvalidCurrency,
+    InvalidIban,
+    InvalidUetr,
+    validate_amount,
+    validate_bic,
+    validate_currency,
+    validate_iban,
+    validate_uetr,
+)
+
+__all__ = (
+    # codec
+    "build_pain001",
+    "parse_pain001",
+    "build_pacs008",
+    "parse_pacs008",
+    "build_pacs002",
+    "parse_pacs002",
+    "build_camt053",
+    "parse_camt053",
+    "build_camt054",
+    "parse_camt054",
+    "build_pain002",
+    "parse_pain002",
+    "build_pacs004",
+    "parse_pacs004",
+    # business application header (head.001) + CBPR+ envelope
+    "build_bah",
+    "parse_bah",
+    "build_business_message",
+    "parse_business_message",
+    "urn_for",
+    "DEFAULT_VERSIONS",
+    "Iso20022CodecError",
+    # datoms
+    "to_datoms",
+    "tx_entity_of",
+    "Datom",
+    "NS",
+    # kawase-yui bridge (ingressAttestation Lexicon records)
+    "ingress_attestations",
+    "RECORD_TYPE",
+    "LEXICON_VERSION",
+    # construction helpers
+    "new_uetr",
+    "control_sum_of",
+    "pacs008_group_header",
+    "pain001_group_header",
+    # validators
+    "validate_iban",
+    "validate_bic",
+    "validate_currency",
+    "validate_amount",
+    "validate_uetr",
+    "InvalidIban",
+    "InvalidBic",
+    "InvalidCurrency",
+    "InvalidAmount",
+    "InvalidUetr",
+    # CBPR+ conformance
+    "check_cbpr_pacs008",
+    "check_cbpr_bah",
+    "assert_cbpr_pacs008",
+    "ConformanceIssue",
+    "CbprConformanceError",
+)
+
+__version__ = "0.1.0"

--- a/py/kotoba_iso20022/kotoba_iso20022/bah.py
+++ b/py/kotoba_iso20022/kotoba_iso20022/bah.py
@@ -1,0 +1,194 @@
+"""Business Application Header (head.001) + CBPR+ business-message envelope.
+
+The BAH is **mandatory for every CBPR+ message** on the SWIFT network — a
+bare ``pacs.008`` Document is not a valid business message without it. This
+module is the cleanroom head.001 codec plus an envelope that pairs an
+``AppHdr`` with its business ``Document`` (the logical "ISO 20022 business
+message").
+
+Cleanroom from the open standard: the ``AppHdr`` element grammar
+(``Fr`` / ``To`` / ``BizMsgIdr`` / ``MsgDefIdr`` / ``BizSvc`` / ``CreDt``)
+and the official namespace ``urn:iso:std:iso:20022:tech:xsd:head.001.001.02``
+(the version CBPR+ uses). No proprietary SWIFT SDK.
+
+CBPR+ conformance rule enforced here: ``MsgDefIdr`` in the header MUST equal
+the wrapped Document's message definition — :func:`parse_business_message`
+raises :class:`~kotoba_iso20022.codec.Iso20022CodecError` on mismatch.
+"""
+
+from __future__ import annotations
+
+import re
+import xml.etree.ElementTree as ET
+
+from .codec import Iso20022CodecError, urn_for
+from .model import BusinessApplicationHeader
+from .validate import validate_bic
+
+__all__ = (
+    "DEFAULT_BAH_VERSION",
+    "build_bah",
+    "parse_bah",
+    "build_business_message",
+    "parse_business_message",
+)
+
+DEFAULT_BAH_VERSION = "head.001.001.02"
+
+# Pull the "<msgtype>.<variant>.<version>" id out of an ISO 20022 namespace.
+_URN_MSGDEF_RE = re.compile(r"urn:iso:std:iso:20022:tech:xsd:([a-z]+\.\d{3}\.\d{3}\.\d{2})$")
+
+
+def _q(ns: str, tag: str) -> str:
+    return f"{{{ns}}}{tag}"
+
+
+def _sub(parent: ET.Element, ns: str, tag: str, text: str | None = None) -> ET.Element:
+    el = ET.SubElement(parent, _q(ns, tag))
+    if text is not None:
+        el.text = text
+    return el
+
+
+def _text(parent: ET.Element | None, ns: str, path: str) -> str | None:
+    if parent is None:
+        return None
+    el = parent.find("/".join(_q(ns, t) for t in path.split("/")))
+    return el.text if el is not None else None
+
+
+def _strip_decl(xml: str) -> str:
+    """Drop a leading ``<?xml …?>`` declaration and surrounding whitespace."""
+    return re.sub(r"^\s*<\?xml[^>]*\?>\s*", "", xml).strip()
+
+
+def _indent_block(xml: str, prefix: str = "  ") -> str:
+    """Indent every line of an XML fragment by ``prefix``."""
+    return "\n".join(prefix + line for line in xml.splitlines())
+
+
+def build_bah(bah: BusinessApplicationHeader, version: str | None = None) -> str:
+    """Serialize a standalone ``AppHdr`` (head.001)."""
+    ns = urn_for(version or DEFAULT_BAH_VERSION)
+    ET.register_namespace("", ns)
+    root = _build_apphdr_element(bah, ns)
+    ET.indent(root, space="  ")
+    return ET.tostring(root, encoding="unicode", xml_declaration=True)
+
+
+def _build_apphdr_element(bah: BusinessApplicationHeader, ns: str) -> ET.Element:
+    root = ET.Element(_q(ns, "AppHdr"))
+    fr = _sub(root, ns, "Fr")
+    fr_fi = _sub(_sub(fr, ns, "FIId"), ns, "FinInstnId")
+    _sub(fr_fi, ns, "BICFI", validate_bic(bah.from_bic))
+    to = _sub(root, ns, "To")
+    to_fi = _sub(_sub(to, ns, "FIId"), ns, "FinInstnId")
+    _sub(to_fi, ns, "BICFI", validate_bic(bah.to_bic))
+    _sub(root, ns, "BizMsgIdr", bah.business_message_id)
+    _sub(root, ns, "MsgDefIdr", bah.message_definition)
+    if bah.business_service:
+        _sub(root, ns, "BizSvc", bah.business_service)
+    _sub(root, ns, "CreDt", bah.creation_datetime)
+    return root
+
+
+def _parse_apphdr_element(root: ET.Element, ns: str) -> BusinessApplicationHeader:
+    from_bic = _text(root, ns, "Fr/FIId/FinInstnId/BICFI")
+    to_bic = _text(root, ns, "To/FIId/FinInstnId/BICFI")
+    if not from_bic or not to_bic:
+        raise Iso20022CodecError("AppHdr missing Fr/To BICFI")
+    return BusinessApplicationHeader(
+        from_bic=from_bic,
+        to_bic=to_bic,
+        business_message_id=_text(root, ns, "BizMsgIdr") or "",
+        message_definition=_text(root, ns, "MsgDefIdr") or "",
+        creation_datetime=_text(root, ns, "CreDt") or "",
+        business_service=_text(root, ns, "BizSvc"),
+    )
+
+
+def parse_bah(xml: str, version: str | None = None) -> BusinessApplicationHeader:
+    """Parse a standalone ``AppHdr`` (head.001)."""
+    ns = urn_for(version or DEFAULT_BAH_VERSION)
+    try:
+        root = ET.fromstring(xml)
+    except ET.ParseError as exc:
+        raise Iso20022CodecError(f"not well-formed XML: {exc}") from exc
+    if root.tag != _q(ns, "AppHdr"):
+        raise Iso20022CodecError("root is not AppHdr (wrong namespace/version?)")
+    return _parse_apphdr_element(root, ns)
+
+
+def _msgdef_of_document(document_xml: str) -> str:
+    """Extract the message definition id from a Document's namespace."""
+    try:
+        doc = ET.fromstring(document_xml)
+    except ET.ParseError as exc:
+        raise Iso20022CodecError(f"document not well-formed XML: {exc}") from exc
+    m = re.match(r"\{(.+?)\}Document$", doc.tag)
+    if not m:
+        raise Iso20022CodecError("payload root is not a namespaced <Document>")
+    nm = _URN_MSGDEF_RE.match(m.group(1))
+    if not nm:
+        raise Iso20022CodecError(f"document namespace is not an ISO 20022 URN: {m.group(1)}")
+    return nm.group(1)
+
+
+def build_business_message(
+    bah: BusinessApplicationHeader,
+    document_xml: str,
+    *,
+    version: str | None = None,
+    enforce_msgdef_match: bool = True,
+) -> str:
+    """Pair an ``AppHdr`` with a business ``Document`` into one envelope.
+
+    The two are siblings under an ``<Envelope>`` root (the common transport
+    representation of an ISO 20022 business message). With
+    ``enforce_msgdef_match`` (default), the BAH ``MsgDefIdr`` must equal the
+    Document's actual message definition — the CBPR+ rule.
+    """
+    if enforce_msgdef_match:
+        actual = _msgdef_of_document(document_xml)
+        if bah.message_definition != actual:
+            raise Iso20022CodecError(
+                f"BAH MsgDefIdr {bah.message_definition!r} != document {actual!r} (CBPR+)"
+            )
+    # Compose from each child's independently-serialized form. Building one
+    # mixed-namespace ElementTree would let ElementTree's global default-
+    # namespace registration leak the payload namespace onto the bare
+    # <Envelope>; string composition keeps each child's xmlns self-contained.
+    apphdr_body = _strip_decl(build_bah(bah, version=version))
+    doc_body = _strip_decl(document_xml)
+    inner = _indent_block(apphdr_body) + "\n" + _indent_block(doc_body)
+    return f"<?xml version='1.0' encoding='utf-8'?>\n<Envelope>\n{inner}\n</Envelope>"
+
+
+def parse_business_message(
+    xml: str,
+    *,
+    version: str | None = None,
+    enforce_msgdef_match: bool = True,
+) -> tuple[BusinessApplicationHeader, str]:
+    """Split an envelope back into (header, document_xml).
+
+    Validates the CBPR+ ``MsgDefIdr`` ↔ Document match unless disabled.
+    """
+    bah_ns = urn_for(version or DEFAULT_BAH_VERSION)
+    try:
+        envelope = ET.fromstring(xml)
+    except ET.ParseError as exc:
+        raise Iso20022CodecError(f"not well-formed XML: {exc}") from exc
+    apphdr = envelope.find(_q(bah_ns, "AppHdr"))
+    document = next((c for c in envelope if c.tag.endswith("}Document")), None)
+    if apphdr is None or document is None:
+        raise Iso20022CodecError("envelope must contain AppHdr + Document siblings")
+    header = _parse_apphdr_element(apphdr, bah_ns)
+    document_xml = ET.tostring(document, encoding="unicode")
+    if enforce_msgdef_match:
+        actual = _msgdef_of_document(document_xml)
+        if header.message_definition != actual:
+            raise Iso20022CodecError(
+                f"BAH MsgDefIdr {header.message_definition!r} != document {actual!r} (CBPR+)"
+            )
+    return header, document_xml

--- a/py/kotoba_iso20022/kotoba_iso20022/bridge.py
+++ b/py/kotoba_iso20022/kotoba_iso20022/bridge.py
@@ -1,0 +1,232 @@
+"""Bridge: ISO 20022 message → kawase-yui ``ingressAttestation`` records.
+
+This is the actor-integration glue. The codec parses the open ISO 20022
+wire; :mod:`kotoba_iso20022.datoms` lands it as EAVT facts; this module
+shapes the same value-events into ``com.etzhayyim.iso20022.ingressAttestation``
+AT-Protocol records (the Lexicon at
+``00-contracts/lexicons/com/etzhayyim/iso20022/``) so a kawase corridor can
+attest an external bank transfer and, where it corresponds to an on-chain
+on-ramp, reconcile it against a ``com.etzhayyim.kawase.depositAttestation``
+via ``linkedDepositCid``.
+
+PII discipline (kawase-yui G10): party names are 要配慮 PII and are omitted
+by default; ``include_party_names=True`` is opt-in and intended only for a
+consent-bound / encrypted path. Only institution BICs (ISO 9362) are
+first-class. This module produces records; it does not transact, sign, or
+move money (kawase G2/G13 stay with the gated ingress cell).
+"""
+
+from __future__ import annotations
+
+from .datoms import tx_entity_of
+from .model import (
+    BankToCustomerDebitCreditNotification,
+    BankToCustomerStatement,
+    CreditTransferTransaction,
+    CustomerCreditTransferInitiation,
+    FIToFICustomerCreditTransfer,
+    StatementEntry,
+)
+
+__all__ = ("ingress_attestations", "RECORD_TYPE", "LEXICON_VERSION", "ValueBearingMessage")
+
+# The message kinds that carry a settlement value-event (vs. a status report).
+ValueBearingMessage = (
+    CustomerCreditTransferInitiation
+    | FIToFICustomerCreditTransfer
+    | BankToCustomerStatement
+    | BankToCustomerDebitCreditNotification
+)
+Record = dict[str, object]
+
+RECORD_TYPE = "com.etzhayyim.iso20022.ingressAttestation"
+LEXICON_VERSION = 1
+
+# Source message → the `reportedBy` family token recorded on each record.
+_REPORTED_BY = {
+    CustomerCreditTransferInitiation: "pain.001",
+    FIToFICustomerCreditTransfer: "pacs.008",
+    BankToCustomerStatement: "camt.053",
+    BankToCustomerDebitCreditNotification: "camt.054",
+}
+
+
+def _base_record(
+    *,
+    message_definition: str,
+    message_id: str,
+    end_to_end_id: str,
+    tx_entity: str,
+    amount: str,
+    currency: str,
+    reported_by: str,
+    ingested_at: str,
+    uetr: str | None = None,
+    cbpr_conformant: bool | None = None,
+    linked_deposit_cid: str | None = None,
+    datom_count: int | None = None,
+) -> Record:
+    rec: Record = {
+        "$type": RECORD_TYPE,
+        "v": LEXICON_VERSION,
+        "messageDefinition": message_definition,
+        "messageId": message_id,
+        "endToEndId": end_to_end_id,
+        "txEntity": tx_entity,
+        "amount": amount,
+        "currency": currency,
+        "reportedBy": reported_by,
+        "ingestedAt": ingested_at,
+    }
+    if uetr:
+        rec["uetr"] = uetr
+    if cbpr_conformant is not None:
+        rec["cbprConformant"] = cbpr_conformant
+    if linked_deposit_cid:
+        rec["linkedDepositCid"] = linked_deposit_cid
+    if datom_count is not None:
+        rec["datomCount"] = datom_count
+    return rec
+
+
+def _from_transaction(
+    tx: CreditTransferTransaction,
+    *,
+    message_definition: str,
+    message_id: str,
+    reported_by: str,
+    ingested_at: str,
+    include_party_names: bool,
+    cbpr_conformant: bool | None,
+    linked_deposit_cid: str | None,
+) -> Record | None:
+    amt = tx.interbank_amount or tx.instructed_amount
+    if amt is None:
+        return None
+    rec = _base_record(
+        message_definition=message_definition,
+        message_id=message_id,
+        end_to_end_id=tx.end_to_end_id,
+        tx_entity=tx_entity_of(tx),
+        amount=str(amt.value),
+        currency=amt.currency,
+        reported_by=reported_by,
+        ingested_at=ingested_at,
+        uetr=tx.uetr,
+        cbpr_conformant=cbpr_conformant,
+        linked_deposit_cid=linked_deposit_cid,
+    )
+    if tx.debtor_agent and tx.debtor_agent.bicfi:
+        rec["debtorAgentBic"] = tx.debtor_agent.bicfi
+    if tx.creditor_agent and tx.creditor_agent.bicfi:
+        rec["creditorAgentBic"] = tx.creditor_agent.bicfi
+    if include_party_names:
+        if tx.debtor and tx.debtor.name:
+            rec["debtorName"] = tx.debtor.name
+        if tx.creditor and tx.creditor.name:
+            rec["creditorName"] = tx.creditor.name
+    return rec
+
+
+def _from_entry(
+    entry: StatementEntry,
+    *,
+    message_definition: str,
+    message_id: str,
+    reported_by: str,
+    ingested_at: str,
+    cbpr_conformant: bool | None,
+    linked_deposit_cid: str | None,
+) -> Record | None:
+    ref = entry.end_to_end_id or entry.account_servicer_reference
+    if ref is None:
+        return None
+    rec = _base_record(
+        message_definition=message_definition,
+        message_id=message_id,
+        end_to_end_id=entry.end_to_end_id or ref,
+        tx_entity=f"com.etzhayyim.iso20022/tx:{ref}",
+        amount=str(entry.amount.value),
+        currency=entry.amount.currency,
+        reported_by=reported_by,
+        ingested_at=ingested_at,
+        cbpr_conformant=cbpr_conformant,
+        linked_deposit_cid=linked_deposit_cid,
+    )
+    rec["creditDebit"] = entry.credit_debit
+    rec["status"] = entry.status
+    return rec
+
+
+def ingress_attestations(
+    msg: ValueBearingMessage,
+    *,
+    ingested_at: str,
+    message_definition: str | None = None,
+    include_party_names: bool = False,
+    cbpr_conformant: bool | None = None,
+    linked_deposit_cid: str | None = None,
+) -> list[Record]:
+    """Map a value-bearing ISO 20022 message to ``ingressAttestation`` records.
+
+    One record per transaction (pain.001 / pacs.008) or per entry
+    (camt.053 / camt.054). ``message_definition`` defaults to the codec's
+    default version for the message type. Records validate against the
+    ``com.etzhayyim.iso20022.ingressAttestation`` Lexicon.
+
+    Raises :class:`TypeError` for status-only messages (pacs.002 / pain.002),
+    whose status is carried by :func:`kotoba_iso20022.to_datoms` instead.
+    """
+    from .codec import DEFAULT_VERSIONS
+
+    reported_by = _REPORTED_BY.get(type(msg))
+    if reported_by is None:
+        raise TypeError(
+            f"{type(msg).__name__} is not a value-bearing message; "
+            "status reports carry status via to_datoms()"
+        )
+    msgdef = message_definition or DEFAULT_VERSIONS[reported_by]
+    mid = msg.group_header.message_id
+    out: list[Record] = []
+
+    if isinstance(msg, CustomerCreditTransferInitiation):
+        txs = [tx for pmt in msg.payments for tx in pmt.transactions]
+        for tx in txs:
+            rec = _from_transaction(
+                tx, message_definition=msgdef, message_id=mid, reported_by=reported_by,
+                ingested_at=ingested_at, include_party_names=include_party_names,
+                cbpr_conformant=cbpr_conformant, linked_deposit_cid=linked_deposit_cid,
+            )
+            if rec:
+                out.append(rec)
+    elif isinstance(msg, FIToFICustomerCreditTransfer):
+        for tx in msg.transactions:
+            rec = _from_transaction(
+                tx, message_definition=msgdef, message_id=mid, reported_by=reported_by,
+                ingested_at=ingested_at, include_party_names=include_party_names,
+                cbpr_conformant=cbpr_conformant, linked_deposit_cid=linked_deposit_cid,
+            )
+            if rec:
+                out.append(rec)
+    elif isinstance(msg, BankToCustomerStatement):
+        for stmt in msg.statements:
+            for entry in stmt.entries:
+                rec = _from_entry(
+                    entry, message_definition=msgdef, message_id=mid,
+                    reported_by=reported_by, ingested_at=ingested_at,
+                    cbpr_conformant=cbpr_conformant, linked_deposit_cid=linked_deposit_cid,
+                )
+                if rec:
+                    out.append(rec)
+    elif isinstance(msg, BankToCustomerDebitCreditNotification):
+        for ntf in msg.notifications:
+            for entry in ntf.entries:
+                rec = _from_entry(
+                    entry, message_definition=msgdef, message_id=mid,
+                    reported_by=reported_by, ingested_at=ingested_at,
+                    cbpr_conformant=cbpr_conformant, linked_deposit_cid=linked_deposit_cid,
+                )
+                if rec:
+                    out.append(rec)
+
+    return out

--- a/py/kotoba_iso20022/kotoba_iso20022/codec.py
+++ b/py/kotoba_iso20022/kotoba_iso20022/codec.py
@@ -1,0 +1,855 @@
+"""Cleanroom ISO 20022 XML codec — build and parse, round-trip stable.
+
+Implemented purely from the published ISO 20022 message-component
+structure (``GrpHdr`` / ``PmtInf`` / ``CdtTrfTxInf`` / ``PmtId`` …) and the
+official namespace scheme::
+
+    urn:iso:std:iso:20022:tech:xsd:<msgdef>
+
+e.g. ``urn:iso:std:iso:20022:tech:xsd:pacs.008.001.08``. No proprietary
+SWIFT SDK or vendor schema file is used or required at runtime — only the
+public element grammar of the open standard (same cleanroom posture as
+warifu's ISO 8583 map). Validation of embedded identifiers (IBAN/BIC/
+currency/amount) is delegated to :mod:`kotoba_iso20022.validate`.
+
+Supported message definitions (version-parameterised; CBPR+/SEPA defaults):
+
+- pain.001 — CustomerCreditTransferInitiation (default ``pain.001.001.09``)
+- pacs.008 — FIToFICustomerCreditTransfer    (default ``pacs.008.001.08``)
+- pacs.002 — FIToFIPaymentStatusReport       (default ``pacs.002.001.10``)
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from decimal import Decimal
+
+from .model import (
+    Account,
+    AccountNotification,
+    AccountStatement,
+    Agent,
+    Amount,
+    BankToCustomerDebitCreditNotification,
+    BankToCustomerStatement,
+    CashBalance,
+    CreditTransferTransaction,
+    CustomerCreditTransferInitiation,
+    CustomerPaymentStatusReport,
+    FIToFICustomerCreditTransfer,
+    FIToFIPaymentStatusReport,
+    GroupHeader,
+    OriginalPaymentStatus,
+    Party,
+    PaymentInstruction,
+    PaymentReturn,
+    PaymentReturnTransaction,
+    PostalAddress,
+    RemittanceInfo,
+    StatementEntry,
+    TransactionStatus,
+)
+from .validate import (
+    CCY_FRACTION_DIGITS,
+    validate_amount,
+    validate_bic,
+    validate_currency,
+    validate_iban,
+)
+
+__all__ = (
+    "Iso20022CodecError",
+    "DEFAULT_VERSIONS",
+    "urn_for",
+    "build_pain001",
+    "parse_pain001",
+    "build_pacs008",
+    "parse_pacs008",
+    "build_pacs002",
+    "parse_pacs002",
+    "build_camt053",
+    "parse_camt053",
+    "build_camt054",
+    "parse_camt054",
+    "build_pain002",
+    "parse_pain002",
+    "build_pacs004",
+    "parse_pacs004",
+)
+
+DEFAULT_VERSIONS: dict[str, str] = {
+    "pain.001": "pain.001.001.09",
+    "pain.002": "pain.002.001.10",
+    "pacs.008": "pacs.008.001.08",
+    "pacs.002": "pacs.002.001.10",
+    "pacs.004": "pacs.004.001.09",
+    "camt.053": "camt.053.001.08",
+    "camt.054": "camt.054.001.08",
+}
+
+_URN_PREFIX = "urn:iso:std:iso:20022:tech:xsd:"
+
+
+class Iso20022CodecError(ValueError):
+    """Raised on malformed input during build or parse."""
+
+
+def urn_for(msgdef: str) -> str:
+    """Return the official ISO 20022 namespace URN for a message def id."""
+    return _URN_PREFIX + msgdef
+
+
+# --------------------------------------------------------------------------
+# small XML helpers (namespace-qualified element construction / lookup)
+# --------------------------------------------------------------------------
+
+
+def _q(ns: str, tag: str) -> str:
+    return f"{{{ns}}}{tag}"
+
+
+def _sub(parent: ET.Element, ns: str, tag: str, text: str | None = None) -> ET.Element:
+    el = ET.SubElement(parent, _q(ns, tag))
+    if text is not None:
+        el.text = text
+    return el
+
+
+def _find(parent: ET.Element, ns: str, path: str) -> ET.Element | None:
+    return parent.find("/".join(_q(ns, t) for t in path.split("/")))
+
+
+def _findall(parent: ET.Element, ns: str, tag: str) -> list[ET.Element]:
+    return parent.findall(_q(ns, tag))
+
+
+def _text(parent: ET.Element | None, ns: str, path: str) -> str | None:
+    if parent is None:
+        return None
+    el = _find(parent, ns, path)
+    return el.text if el is not None else None
+
+
+def _fmt_amount(amt: Amount) -> str:
+    ccy = validate_currency(amt.currency, require_active=False)
+    dec = validate_amount(amt.value, ccy)
+    digits = CCY_FRACTION_DIGITS.get(ccy, 2)
+    return f"{dec:.{digits}f}" if digits else str(int(dec))
+
+
+def _root(ns: str, container_tag: str) -> tuple[ET.Element, ET.Element]:
+    """Build ``<Document xmlns=ns><container_tag>`` and return both."""
+    # Register the message namespace as the default (no prefix) so the
+    # serialized form is the canonical ISO 20022 ``<Document xmlns="urn:…">``
+    # that SWIFT/CBPR+ validators expect, not a ``ns0:`` prefix.
+    ET.register_namespace("", ns)
+    doc = ET.Element(_q(ns, "Document"))
+    container = ET.SubElement(doc, _q(ns, container_tag))
+    return doc, container
+
+
+def _serialize(doc: ET.Element) -> str:
+    ET.indent(doc, space="  ")
+    return ET.tostring(doc, encoding="unicode", xml_declaration=True)
+
+
+# --------------------------------------------------------------------------
+# shared component builders
+# --------------------------------------------------------------------------
+
+
+def _build_group_header(parent: ET.Element, ns: str, gh: GroupHeader, *, is_pacs: bool) -> None:
+    grp = _sub(parent, ns, "GrpHdr")
+    _sub(grp, ns, "MsgId", gh.message_id)
+    _sub(grp, ns, "CreDtTm", gh.creation_datetime)
+    _sub(grp, ns, "NbOfTxs", str(gh.number_of_txs))
+    if gh.control_sum is not None:
+        _sub(grp, ns, "CtrlSum", str(gh.control_sum))
+    if is_pacs:
+        sttlm = _sub(grp, ns, "SttlmInf")
+        _sub(sttlm, ns, "SttlmMtd", gh.settlement_method or "CLRG")
+    elif gh.initiating_party is not None:
+        _build_party(grp, ns, "InitgPty", gh.initiating_party)
+
+
+def _build_party(parent: ET.Element, ns: str, tag: str, party: Party) -> None:
+    el = _sub(parent, ns, tag)
+    _sub(el, ns, "Nm", party.name)
+    if party.postal_address is not None:
+        adr = _sub(el, ns, "PstlAdr")
+        if party.postal_address.country:
+            _sub(adr, ns, "Ctry", party.postal_address.country)
+        for line in party.postal_address.address_lines:
+            _sub(adr, ns, "AdrLine", line)
+    if party.identifier is not None:
+        idn = _sub(el, ns, "Id")
+        org = _sub(idn, ns, "OrgId")
+        oth = _sub(org, ns, "Othr")
+        _sub(oth, ns, "Id", party.identifier)
+
+
+def _build_account(parent: ET.Element, ns: str, tag: str, acct: Account) -> None:
+    el = _sub(parent, ns, tag)
+    idn = _sub(el, ns, "Id")
+    if acct.iban:
+        _sub(idn, ns, "IBAN", validate_iban(acct.iban))
+    else:
+        oth = _sub(idn, ns, "Othr")
+        _sub(oth, ns, "Id", acct.other_id or "")
+    if acct.currency:
+        _sub(el, ns, "Ccy", validate_currency(acct.currency, require_active=False))
+
+
+def _build_agent(parent: ET.Element, ns: str, tag: str, agent: Agent) -> None:
+    el = _sub(parent, ns, tag)
+    fin = _sub(el, ns, "FinInstnId")
+    if agent.bicfi:
+        _sub(fin, ns, "BICFI", validate_bic(agent.bicfi))
+    if agent.name:
+        _sub(fin, ns, "Nm", agent.name)
+    if agent.clearing_member_id:
+        clr = _sub(fin, ns, "ClrSysMmbId")
+        _sub(clr, ns, "MmbId", agent.clearing_member_id)
+
+
+def _build_remittance(parent: ET.Element, ns: str, rmt: RemittanceInfo) -> None:
+    el = _sub(parent, ns, "RmtInf")
+    for line in rmt.unstructured:
+        _sub(el, ns, "Ustrd", line)
+
+
+# --------------------------------------------------------------------------
+# shared component parsers
+# --------------------------------------------------------------------------
+
+
+def _parse_amount(el: ET.Element | None) -> Amount | None:
+    if el is None or el.text is None:
+        return None
+    ccy = el.get("Ccy")
+    if not ccy:
+        raise Iso20022CodecError("amount element missing Ccy attribute")
+    return Amount(value=Decimal(el.text), currency=validate_currency(ccy, require_active=False))
+
+
+def _parse_party(el: ET.Element | None, ns: str) -> Party | None:
+    if el is None:
+        return None
+    name = _text(el, ns, "Nm") or ""
+    country = _text(el, ns, "PstlAdr/Ctry")
+    adr_el = _find(el, ns, "PstlAdr")
+    lines = tuple(
+        ln.text
+        for ln in (_findall(adr_el, ns, "AdrLine") if adr_el is not None else [])
+        if ln.text
+    )
+    postal = PostalAddress(country=country, address_lines=lines) if (country or lines) else None
+    identifier = _text(el, ns, "Id/OrgId/Othr/Id")
+    return Party(name=name, postal_address=postal, identifier=identifier)
+
+
+def _parse_account(el: ET.Element | None, ns: str) -> Account | None:
+    if el is None:
+        return None
+    iban = _text(el, ns, "Id/IBAN")
+    other = _text(el, ns, "Id/Othr/Id")
+    ccy = _text(el, ns, "Ccy")
+    return Account(iban=iban, other_id=other, currency=ccy)
+
+
+def _parse_agent(el: ET.Element | None, ns: str) -> Agent | None:
+    if el is None:
+        return None
+    return Agent(
+        bicfi=_text(el, ns, "FinInstnId/BICFI"),
+        name=_text(el, ns, "FinInstnId/Nm"),
+        clearing_member_id=_text(el, ns, "FinInstnId/ClrSysMmbId/MmbId"),
+    )
+
+
+def _addtl_info(rsn: ET.Element | None, ns: str) -> tuple[str, ...]:
+    """Collect ``AddtlInf`` text lines under a status/return reason element."""
+    if rsn is None:
+        return ()
+    return tuple(a.text for a in _findall(rsn, ns, "AddtlInf") if a.text)
+
+
+def _parse_remittance(el: ET.Element | None, ns: str) -> RemittanceInfo | None:
+    if el is None:
+        return None
+    return RemittanceInfo(
+        unstructured=tuple(u.text for u in _findall(el, ns, "Ustrd") if u.text)
+    )
+
+
+def _parse_group_header(parent: ET.Element, ns: str) -> GroupHeader:
+    grp = _find(parent, ns, "GrpHdr")
+    if grp is None:
+        raise Iso20022CodecError("missing GrpHdr")
+    ctrl = _text(grp, ns, "CtrlSum")
+    sttlm = _text(grp, ns, "SttlmInf/SttlmMtd")
+    return GroupHeader(
+        message_id=_text(grp, ns, "MsgId") or "",
+        creation_datetime=_text(grp, ns, "CreDtTm") or "",
+        number_of_txs=int(_text(grp, ns, "NbOfTxs") or "0"),
+        control_sum=Decimal(ctrl) if ctrl else None,
+        initiating_party=_parse_party(_find(grp, ns, "InitgPty"), ns),
+        settlement_method=sttlm,  # type: ignore[arg-type]
+    )
+
+
+def _root_or_raise(xml: str, ns: str, container_tag: str) -> ET.Element:
+    try:
+        doc = ET.fromstring(xml)
+    except ET.ParseError as exc:
+        raise Iso20022CodecError(f"not well-formed XML: {exc}") from exc
+    container = doc.find(_q(ns, container_tag))
+    if container is None:
+        raise Iso20022CodecError(f"missing {container_tag} (wrong namespace/version?)")
+    return container
+
+
+# --------------------------------------------------------------------------
+# pain.001 — CustomerCreditTransferInitiation
+# --------------------------------------------------------------------------
+
+
+def build_pain001(msg: CustomerCreditTransferInitiation, version: str | None = None) -> str:
+    msgdef = version or DEFAULT_VERSIONS["pain.001"]
+    ns = urn_for(msgdef)
+    doc, root = _root(ns, "CstmrCdtTrfInitn")
+    _build_group_header(root, ns, msg.group_header, is_pacs=False)
+    for pmt in msg.payments:
+        pinf = _sub(root, ns, "PmtInf")
+        _sub(pinf, ns, "PmtInfId", pmt.payment_info_id)
+        _sub(pinf, ns, "PmtMtd", pmt.payment_method)
+        _sub(pinf, ns, "ReqdExctnDt", pmt.requested_execution_date)
+        _build_party(pinf, ns, "Dbtr", pmt.debtor)
+        _build_account(pinf, ns, "DbtrAcct", pmt.debtor_account)
+        _build_agent(pinf, ns, "DbtrAgt", pmt.debtor_agent)
+        for tx in pmt.transactions:
+            cdt = _sub(pinf, ns, "CdtTrfTxInf")
+            pid = _sub(cdt, ns, "PmtId")
+            if tx.instruction_id:
+                _sub(pid, ns, "InstrId", tx.instruction_id)
+            _sub(pid, ns, "EndToEndId", tx.end_to_end_id)
+            if tx.uetr:
+                _sub(pid, ns, "UETR", tx.uetr)
+            if tx.instructed_amount is None:
+                raise Iso20022CodecError("pain.001 CdtTrfTxInf requires InstdAmt")
+            amt = _sub(cdt, ns, "Amt")
+            instd = _sub(amt, ns, "InstdAmt", _fmt_amount(tx.instructed_amount))
+            instd.set("Ccy", validate_currency(tx.instructed_amount.currency, require_active=False))
+            if tx.creditor_agent:
+                _build_agent(cdt, ns, "CdtrAgt", tx.creditor_agent)
+            if tx.creditor:
+                _build_party(cdt, ns, "Cdtr", tx.creditor)
+            if tx.creditor_account:
+                _build_account(cdt, ns, "CdtrAcct", tx.creditor_account)
+            if tx.remittance_info:
+                _build_remittance(cdt, ns, tx.remittance_info)
+    return _serialize(doc)
+
+
+def parse_pain001(xml: str, version: str | None = None) -> CustomerCreditTransferInitiation:
+    ns = urn_for(version or DEFAULT_VERSIONS["pain.001"])
+    root = _root_or_raise(xml, ns, "CstmrCdtTrfInitn")
+    gh = _parse_group_header(root, ns)
+    payments = []
+    for pinf in _findall(root, ns, "PmtInf"):
+        txs = []
+        for cdt in _findall(pinf, ns, "CdtTrfTxInf"):
+            pid = _find(cdt, ns, "PmtId")
+            txs.append(
+                CreditTransferTransaction(
+                    end_to_end_id=_text(pid, ns, "EndToEndId") or "",
+                    instruction_id=_text(pid, ns, "InstrId"),
+                    uetr=_text(pid, ns, "UETR"),
+                    instructed_amount=_parse_amount(_find(cdt, ns, "Amt/InstdAmt")),
+                    creditor_agent=_parse_agent(_find(cdt, ns, "CdtrAgt"), ns),
+                    creditor=_parse_party(_find(cdt, ns, "Cdtr"), ns),
+                    creditor_account=_parse_account(_find(cdt, ns, "CdtrAcct"), ns),
+                    remittance_info=_parse_remittance(_find(cdt, ns, "RmtInf"), ns),
+                )
+            )
+        debtor = _parse_party(_find(pinf, ns, "Dbtr"), ns)
+        debtor_acct = _parse_account(_find(pinf, ns, "DbtrAcct"), ns)
+        debtor_agt = _parse_agent(_find(pinf, ns, "DbtrAgt"), ns)
+        if debtor is None or debtor_acct is None or debtor_agt is None:
+            raise Iso20022CodecError("pain.001 PmtInf missing Dbtr/DbtrAcct/DbtrAgt")
+        payments.append(
+            PaymentInstruction(
+                payment_info_id=_text(pinf, ns, "PmtInfId") or "",
+                requested_execution_date=_text(pinf, ns, "ReqdExctnDt") or "",
+                debtor=debtor,
+                debtor_account=debtor_acct,
+                debtor_agent=debtor_agt,
+                transactions=tuple(txs),
+            )
+        )
+    return CustomerCreditTransferInitiation(group_header=gh, payments=tuple(payments))
+
+
+# --------------------------------------------------------------------------
+# pacs.008 — FIToFICustomerCreditTransfer
+# --------------------------------------------------------------------------
+
+
+def build_pacs008(msg: FIToFICustomerCreditTransfer, version: str | None = None) -> str:
+    ns = urn_for(version or DEFAULT_VERSIONS["pacs.008"])
+    doc, root = _root(ns, "FIToFICstmrCdtTrf")
+    _build_group_header(root, ns, msg.group_header, is_pacs=True)
+    for tx in msg.transactions:
+        cdt = _sub(root, ns, "CdtTrfTxInf")
+        pid = _sub(cdt, ns, "PmtId")
+        if tx.instruction_id:
+            _sub(pid, ns, "InstrId", tx.instruction_id)
+        _sub(pid, ns, "EndToEndId", tx.end_to_end_id)
+        if tx.tx_id:
+            _sub(pid, ns, "TxId", tx.tx_id)
+        if tx.uetr:
+            _sub(pid, ns, "UETR", tx.uetr)
+        if tx.interbank_amount is None:
+            raise Iso20022CodecError("pacs.008 CdtTrfTxInf requires IntrBkSttlmAmt")
+        amt = _sub(cdt, ns, "IntrBkSttlmAmt", _fmt_amount(tx.interbank_amount))
+        amt.set("Ccy", validate_currency(tx.interbank_amount.currency, require_active=False))
+        if tx.interbank_settlement_date:
+            _sub(cdt, ns, "IntrBkSttlmDt", tx.interbank_settlement_date)
+        if tx.charge_bearer:
+            _sub(cdt, ns, "ChrgBr", tx.charge_bearer)
+        if tx.debtor:
+            _build_party(cdt, ns, "Dbtr", tx.debtor)
+        if tx.debtor_account:
+            _build_account(cdt, ns, "DbtrAcct", tx.debtor_account)
+        if tx.debtor_agent:
+            _build_agent(cdt, ns, "DbtrAgt", tx.debtor_agent)
+        if tx.creditor_agent:
+            _build_agent(cdt, ns, "CdtrAgt", tx.creditor_agent)
+        if tx.creditor:
+            _build_party(cdt, ns, "Cdtr", tx.creditor)
+        if tx.creditor_account:
+            _build_account(cdt, ns, "CdtrAcct", tx.creditor_account)
+        if tx.remittance_info:
+            _build_remittance(cdt, ns, tx.remittance_info)
+    return _serialize(doc)
+
+
+def parse_pacs008(xml: str, version: str | None = None) -> FIToFICustomerCreditTransfer:
+    ns = urn_for(version or DEFAULT_VERSIONS["pacs.008"])
+    root = _root_or_raise(xml, ns, "FIToFICstmrCdtTrf")
+    gh = _parse_group_header(root, ns)
+    txs = []
+    for cdt in _findall(root, ns, "CdtTrfTxInf"):
+        pid = _find(cdt, ns, "PmtId")
+        txs.append(
+            CreditTransferTransaction(
+                end_to_end_id=_text(pid, ns, "EndToEndId") or "",
+                instruction_id=_text(pid, ns, "InstrId"),
+                tx_id=_text(pid, ns, "TxId"),
+                uetr=_text(pid, ns, "UETR"),
+                interbank_amount=_parse_amount(_find(cdt, ns, "IntrBkSttlmAmt")),
+                interbank_settlement_date=_text(cdt, ns, "IntrBkSttlmDt"),
+                charge_bearer=_text(cdt, ns, "ChrgBr"),  # type: ignore[arg-type]
+                debtor=_parse_party(_find(cdt, ns, "Dbtr"), ns),
+                debtor_account=_parse_account(_find(cdt, ns, "DbtrAcct"), ns),
+                debtor_agent=_parse_agent(_find(cdt, ns, "DbtrAgt"), ns),
+                creditor_agent=_parse_agent(_find(cdt, ns, "CdtrAgt"), ns),
+                creditor=_parse_party(_find(cdt, ns, "Cdtr"), ns),
+                creditor_account=_parse_account(_find(cdt, ns, "CdtrAcct"), ns),
+                remittance_info=_parse_remittance(_find(cdt, ns, "RmtInf"), ns),
+            )
+        )
+    return FIToFICustomerCreditTransfer(group_header=gh, transactions=tuple(txs))
+
+
+# --------------------------------------------------------------------------
+# pacs.002 — FIToFIPaymentStatusReport
+# --------------------------------------------------------------------------
+
+
+def build_pacs002(msg: FIToFIPaymentStatusReport, version: str | None = None) -> str:
+    ns = urn_for(version or DEFAULT_VERSIONS["pacs.002"])
+    doc, root = _root(ns, "FIToFIPmtStsRpt")
+    grp = _sub(root, ns, "GrpHdr")
+    _sub(grp, ns, "MsgId", msg.group_header.message_id)
+    _sub(grp, ns, "CreDtTm", msg.group_header.creation_datetime)
+    orig = _sub(root, ns, "OrgnlGrpInfAndSts")
+    _sub(orig, ns, "OrgnlMsgId", msg.original_message_id)
+    _sub(orig, ns, "OrgnlMsgNmId", msg.original_message_name_id)
+    for sts in msg.statuses:
+        ts = _sub(root, ns, "TxInfAndSts")
+        _sub(ts, ns, "StsId", sts.status_id)
+        if sts.original_end_to_end_id:
+            _sub(ts, ns, "OrgnlEndToEndId", sts.original_end_to_end_id)
+        if sts.original_tx_id:
+            _sub(ts, ns, "OrgnlTxId", sts.original_tx_id)
+        if sts.original_uetr:
+            _sub(ts, ns, "OrgnlUETR", sts.original_uetr)
+        _sub(ts, ns, "TxSts", sts.transaction_status)
+        if sts.status_reason_code or sts.additional_info:
+            rsn = _sub(ts, ns, "StsRsnInf")
+            if sts.status_reason_code:
+                rcd = _sub(rsn, ns, "Rsn")
+                _sub(rcd, ns, "Cd", sts.status_reason_code)
+            for info in sts.additional_info:
+                _sub(rsn, ns, "AddtlInf", info)
+    return _serialize(doc)
+
+
+def parse_pacs002(xml: str, version: str | None = None) -> FIToFIPaymentStatusReport:
+    ns = urn_for(version or DEFAULT_VERSIONS["pacs.002"])
+    root = _root_or_raise(xml, ns, "FIToFIPmtStsRpt")
+    grp = _find(root, ns, "GrpHdr")
+    gh = GroupHeader(
+        message_id=_text(grp, ns, "MsgId") or "",
+        creation_datetime=_text(grp, ns, "CreDtTm") or "",
+        number_of_txs=0,
+    )
+    statuses = []
+    for ts in _findall(root, ns, "TxInfAndSts"):
+        rsn = _find(ts, ns, "StsRsnInf")
+        statuses.append(
+            TransactionStatus(
+                status_id=_text(ts, ns, "StsId") or "",
+                original_end_to_end_id=_text(ts, ns, "OrgnlEndToEndId"),
+                original_tx_id=_text(ts, ns, "OrgnlTxId"),
+                original_uetr=_text(ts, ns, "OrgnlUETR"),
+                transaction_status=_text(ts, ns, "TxSts") or "ACSP",  # type: ignore[arg-type]
+                status_reason_code=_text(ts, ns, "StsRsnInf/Rsn/Cd"),
+                additional_info=_addtl_info(rsn, ns),
+            )
+        )
+    return FIToFIPaymentStatusReport(
+        group_header=gh,
+        original_message_id=_text(root, ns, "OrgnlGrpInfAndSts/OrgnlMsgId") or "",
+        original_message_name_id=_text(root, ns, "OrgnlGrpInfAndSts/OrgnlMsgNmId") or "",
+        statuses=tuple(statuses),
+    )
+
+
+# --------------------------------------------------------------------------
+# camt.053 / camt.054 — shared Bal + Ntry component build/parse
+# --------------------------------------------------------------------------
+
+
+def _build_amt(parent: ET.Element, ns: str, tag: str, amt: Amount) -> None:
+    el = _sub(parent, ns, tag, _fmt_amount(amt))
+    el.set("Ccy", validate_currency(amt.currency, require_active=False))
+
+
+def _build_balance(parent: ET.Element, ns: str, bal: CashBalance) -> None:
+    el = _sub(parent, ns, "Bal")
+    tp = _sub(el, ns, "Tp")
+    cdor = _sub(tp, ns, "CdOrPrtry")
+    _sub(cdor, ns, "Cd", bal.balance_type)
+    _build_amt(el, ns, "Amt", bal.amount)
+    _sub(el, ns, "CdtDbtInd", bal.credit_debit)
+    dt = _sub(el, ns, "Dt")
+    _sub(dt, ns, "Dt", bal.date)
+
+
+def _build_entry(parent: ET.Element, ns: str, entry: StatementEntry) -> None:
+    el = _sub(parent, ns, "Ntry")
+    _build_amt(el, ns, "Amt", entry.amount)
+    _sub(el, ns, "CdtDbtInd", entry.credit_debit)
+    _sub(el, ns, "Sts", entry.status)
+    if entry.booking_date:
+        bd = _sub(el, ns, "BookgDt")
+        _sub(bd, ns, "Dt", entry.booking_date)
+    if entry.value_date:
+        vd = _sub(el, ns, "ValDt")
+        _sub(vd, ns, "Dt", entry.value_date)
+    if entry.account_servicer_reference:
+        _sub(el, ns, "AcctSvcrRef", entry.account_servicer_reference)
+    if entry.bank_transaction_code:
+        btc = _sub(el, ns, "BkTxCd")
+        domn = _sub(btc, ns, "Domn")
+        _sub(domn, ns, "Cd", entry.bank_transaction_code)
+    if entry.end_to_end_id or entry.remittance_info:
+        dtls = _sub(el, ns, "NtryDtls")
+        txd = _sub(dtls, ns, "TxDtls")
+        if entry.end_to_end_id:
+            refs = _sub(txd, ns, "Refs")
+            _sub(refs, ns, "EndToEndId", entry.end_to_end_id)
+        if entry.remittance_info:
+            _build_remittance(txd, ns, entry.remittance_info)
+
+
+def _parse_balance(el: ET.Element, ns: str) -> CashBalance:
+    amt = _parse_amount(_find(el, ns, "Amt"))
+    if amt is None:
+        raise Iso20022CodecError("Bal missing Amt")
+    return CashBalance(
+        balance_type=_text(el, ns, "Tp/CdOrPrtry/Cd") or "OPBD",  # type: ignore[arg-type]
+        amount=amt,
+        credit_debit=_text(el, ns, "CdtDbtInd") or "CRDT",  # type: ignore[arg-type]
+        date=_text(el, ns, "Dt/Dt") or "",
+    )
+
+
+def _parse_entry(el: ET.Element, ns: str) -> StatementEntry:
+    amt = _parse_amount(_find(el, ns, "Amt"))
+    if amt is None:
+        raise Iso20022CodecError("Ntry missing Amt")
+    txd = _find(el, ns, "NtryDtls/TxDtls")
+    return StatementEntry(
+        amount=amt,
+        credit_debit=_text(el, ns, "CdtDbtInd") or "CRDT",  # type: ignore[arg-type]
+        status=_text(el, ns, "Sts") or "BOOK",  # type: ignore[arg-type]
+        booking_date=_text(el, ns, "BookgDt/Dt"),
+        value_date=_text(el, ns, "ValDt/Dt"),
+        account_servicer_reference=_text(el, ns, "AcctSvcrRef"),
+        bank_transaction_code=_text(el, ns, "BkTxCd/Domn/Cd"),
+        end_to_end_id=_text(txd, ns, "Refs/EndToEndId") if txd is not None else None,
+        remittance_info=(
+            _parse_remittance(_find(txd, ns, "RmtInf"), ns) if txd is not None else None
+        ),
+    )
+
+
+def _grphdr_min(parent: ET.Element, ns: str, gh: GroupHeader) -> None:
+    grp = _sub(parent, ns, "GrpHdr")
+    _sub(grp, ns, "MsgId", gh.message_id)
+    _sub(grp, ns, "CreDtTm", gh.creation_datetime)
+
+
+# --------------------------------------------------------------------------
+# camt.053 — BankToCustomerStatement
+# --------------------------------------------------------------------------
+
+
+def build_camt053(msg: BankToCustomerStatement, version: str | None = None) -> str:
+    ns = urn_for(version or DEFAULT_VERSIONS["camt.053"])
+    doc, root = _root(ns, "BkToCstmrStmt")
+    _grphdr_min(root, ns, msg.group_header)
+    for stmt in msg.statements:
+        s = _sub(root, ns, "Stmt")
+        _sub(s, ns, "Id", stmt.statement_id)
+        _sub(s, ns, "CreDtTm", stmt.creation_datetime)
+        _build_account(s, ns, "Acct", stmt.account)
+        for bal in stmt.balances:
+            _build_balance(s, ns, bal)
+        for entry in stmt.entries:
+            _build_entry(s, ns, entry)
+    return _serialize(doc)
+
+
+def parse_camt053(xml: str, version: str | None = None) -> BankToCustomerStatement:
+    ns = urn_for(version or DEFAULT_VERSIONS["camt.053"])
+    root = _root_or_raise(xml, ns, "BkToCstmrStmt")
+    gh = GroupHeader(
+        message_id=_text(root, ns, "GrpHdr/MsgId") or "",
+        creation_datetime=_text(root, ns, "GrpHdr/CreDtTm") or "",
+        number_of_txs=0,
+    )
+    statements = []
+    for s in _findall(root, ns, "Stmt"):
+        acct = _parse_account(_find(s, ns, "Acct"), ns)
+        if acct is None:
+            raise Iso20022CodecError("camt.053 Stmt missing Acct")
+        statements.append(
+            AccountStatement(
+                statement_id=_text(s, ns, "Id") or "",
+                creation_datetime=_text(s, ns, "CreDtTm") or "",
+                account=acct,
+                balances=tuple(_parse_balance(b, ns) for b in _findall(s, ns, "Bal")),
+                entries=tuple(_parse_entry(e, ns) for e in _findall(s, ns, "Ntry")),
+            )
+        )
+    return BankToCustomerStatement(group_header=gh, statements=tuple(statements))
+
+
+# --------------------------------------------------------------------------
+# camt.054 — BankToCustomerDebitCreditNotification
+# --------------------------------------------------------------------------
+
+
+def build_camt054(msg: BankToCustomerDebitCreditNotification, version: str | None = None) -> str:
+    ns = urn_for(version or DEFAULT_VERSIONS["camt.054"])
+    doc, root = _root(ns, "BkToCstmrDbtCdtNtfctn")
+    _grphdr_min(root, ns, msg.group_header)
+    for ntf in msg.notifications:
+        n = _sub(root, ns, "Ntfctn")
+        _sub(n, ns, "Id", ntf.notification_id)
+        _sub(n, ns, "CreDtTm", ntf.creation_datetime)
+        _build_account(n, ns, "Acct", ntf.account)
+        for entry in ntf.entries:
+            _build_entry(n, ns, entry)
+    return _serialize(doc)
+
+
+def parse_camt054(xml: str, version: str | None = None) -> BankToCustomerDebitCreditNotification:
+    ns = urn_for(version or DEFAULT_VERSIONS["camt.054"])
+    root = _root_or_raise(xml, ns, "BkToCstmrDbtCdtNtfctn")
+    gh = GroupHeader(
+        message_id=_text(root, ns, "GrpHdr/MsgId") or "",
+        creation_datetime=_text(root, ns, "GrpHdr/CreDtTm") or "",
+        number_of_txs=0,
+    )
+    notifications = []
+    for n in _findall(root, ns, "Ntfctn"):
+        acct = _parse_account(_find(n, ns, "Acct"), ns)
+        if acct is None:
+            raise Iso20022CodecError("camt.054 Ntfctn missing Acct")
+        notifications.append(
+            AccountNotification(
+                notification_id=_text(n, ns, "Id") or "",
+                creation_datetime=_text(n, ns, "CreDtTm") or "",
+                account=acct,
+                entries=tuple(_parse_entry(e, ns) for e in _findall(n, ns, "Ntry")),
+            )
+        )
+    return BankToCustomerDebitCreditNotification(
+        group_header=gh, notifications=tuple(notifications)
+    )
+
+
+# --------------------------------------------------------------------------
+# pain.002 — CustomerPaymentStatusReport (pain-side ack of pain.001)
+# --------------------------------------------------------------------------
+
+
+def _build_tx_status(parent: ET.Element, ns: str, sts: TransactionStatus) -> None:
+    ts = _sub(parent, ns, "TxInfAndSts")
+    _sub(ts, ns, "StsId", sts.status_id)
+    if sts.original_end_to_end_id:
+        _sub(ts, ns, "OrgnlEndToEndId", sts.original_end_to_end_id)
+    if sts.original_tx_id:
+        _sub(ts, ns, "OrgnlTxId", sts.original_tx_id)
+    _sub(ts, ns, "TxSts", sts.transaction_status)
+    if sts.status_reason_code or sts.additional_info:
+        rsn = _sub(ts, ns, "StsRsnInf")
+        if sts.status_reason_code:
+            _sub(_sub(rsn, ns, "Rsn"), ns, "Cd", sts.status_reason_code)
+        for info in sts.additional_info:
+            _sub(rsn, ns, "AddtlInf", info)
+
+
+def _parse_tx_status(ts: ET.Element, ns: str) -> TransactionStatus:
+    rsn = _find(ts, ns, "StsRsnInf")
+    return TransactionStatus(
+        status_id=_text(ts, ns, "StsId") or "",
+        original_end_to_end_id=_text(ts, ns, "OrgnlEndToEndId"),
+        original_tx_id=_text(ts, ns, "OrgnlTxId"),
+        transaction_status=_text(ts, ns, "TxSts") or "ACSP",  # type: ignore[arg-type]
+        status_reason_code=_text(ts, ns, "StsRsnInf/Rsn/Cd"),
+        additional_info=tuple(
+            a.text for a in (_findall(rsn, ns, "AddtlInf") if rsn is not None else []) if a.text
+        ),
+    )
+
+
+def build_pain002(msg: CustomerPaymentStatusReport, version: str | None = None) -> str:
+    ns = urn_for(version or DEFAULT_VERSIONS["pain.002"])
+    doc, root = _root(ns, "CstmrPmtStsRpt")
+    _grphdr_min(root, ns, msg.group_header)
+    orig = _sub(root, ns, "OrgnlGrpInfAndSts")
+    _sub(orig, ns, "OrgnlMsgId", msg.original_message_id)
+    _sub(orig, ns, "OrgnlMsgNmId", msg.original_message_name_id)
+    for pmt in msg.payment_statuses:
+        pinf = _sub(root, ns, "OrgnlPmtInfAndSts")
+        _sub(pinf, ns, "OrgnlPmtInfId", pmt.original_payment_info_id)
+        for sts in pmt.statuses:
+            _build_tx_status(pinf, ns, sts)
+    return _serialize(doc)
+
+
+def parse_pain002(xml: str, version: str | None = None) -> CustomerPaymentStatusReport:
+    ns = urn_for(version or DEFAULT_VERSIONS["pain.002"])
+    root = _root_or_raise(xml, ns, "CstmrPmtStsRpt")
+    gh = GroupHeader(
+        message_id=_text(root, ns, "GrpHdr/MsgId") or "",
+        creation_datetime=_text(root, ns, "GrpHdr/CreDtTm") or "",
+        number_of_txs=0,
+    )
+    payment_statuses = []
+    for pinf in _findall(root, ns, "OrgnlPmtInfAndSts"):
+        payment_statuses.append(
+            OriginalPaymentStatus(
+                original_payment_info_id=_text(pinf, ns, "OrgnlPmtInfId") or "",
+                statuses=tuple(
+                    _parse_tx_status(ts, ns) for ts in _findall(pinf, ns, "TxInfAndSts")
+                ),
+            )
+        )
+    return CustomerPaymentStatusReport(
+        group_header=gh,
+        original_message_id=_text(root, ns, "OrgnlGrpInfAndSts/OrgnlMsgId") or "",
+        original_message_name_id=_text(root, ns, "OrgnlGrpInfAndSts/OrgnlMsgNmId") or "",
+        payment_statuses=tuple(payment_statuses),
+    )
+
+
+# --------------------------------------------------------------------------
+# pacs.004 — PaymentReturn (reversal of a settled transfer)
+# --------------------------------------------------------------------------
+
+
+def build_pacs004(msg: PaymentReturn, version: str | None = None) -> str:
+    ns = urn_for(version or DEFAULT_VERSIONS["pacs.004"])
+    doc, root = _root(ns, "PmtRtr")
+    _build_group_header(root, ns, msg.group_header, is_pacs=True)
+    for tx in msg.transactions:
+        txinf = _sub(root, ns, "TxInf")
+        if tx.return_id:
+            _sub(txinf, ns, "RtrId", tx.return_id)
+        if msg.original_message_id or msg.original_message_name_id:
+            ogi = _sub(txinf, ns, "OrgnlGrpInf")
+            if msg.original_message_id:
+                _sub(ogi, ns, "OrgnlMsgId", msg.original_message_id)
+            if msg.original_message_name_id:
+                _sub(ogi, ns, "OrgnlMsgNmId", msg.original_message_name_id)
+        if tx.original_end_to_end_id:
+            _sub(txinf, ns, "OrgnlEndToEndId", tx.original_end_to_end_id)
+        if tx.original_tx_id:
+            _sub(txinf, ns, "OrgnlTxId", tx.original_tx_id)
+        if tx.original_uetr:
+            _sub(txinf, ns, "OrgnlUETR", tx.original_uetr)
+        if tx.original_interbank_amount is not None:
+            _build_amt(txinf, ns, "OrgnlIntrBkSttlmAmt", tx.original_interbank_amount)
+        _build_amt(txinf, ns, "RtrdIntrBkSttlmAmt", tx.returned_interbank_amount)
+        if tx.interbank_settlement_date:
+            _sub(txinf, ns, "IntrBkSttlmDt", tx.interbank_settlement_date)
+        if tx.return_reason_code or tx.additional_info:
+            rsn = _sub(txinf, ns, "RtrRsnInf")
+            if tx.return_reason_code:
+                _sub(_sub(rsn, ns, "Rsn"), ns, "Cd", tx.return_reason_code)
+            for info in tx.additional_info:
+                _sub(rsn, ns, "AddtlInf", info)
+    return _serialize(doc)
+
+
+def parse_pacs004(xml: str, version: str | None = None) -> PaymentReturn:
+    ns = urn_for(version or DEFAULT_VERSIONS["pacs.004"])
+    root = _root_or_raise(xml, ns, "PmtRtr")
+    gh = _parse_group_header(root, ns)
+    orig_msg_id: str | None = None
+    orig_msg_nm: str | None = None
+    txs = []
+    for txinf in _findall(root, ns, "TxInf"):
+        if orig_msg_id is None:
+            orig_msg_id = _text(txinf, ns, "OrgnlGrpInf/OrgnlMsgId")
+            orig_msg_nm = _text(txinf, ns, "OrgnlGrpInf/OrgnlMsgNmId")
+        rtrd = _parse_amount(_find(txinf, ns, "RtrdIntrBkSttlmAmt"))
+        if rtrd is None:
+            raise Iso20022CodecError("pacs.004 TxInf missing RtrdIntrBkSttlmAmt")
+        rsn = _find(txinf, ns, "RtrRsnInf")
+        txs.append(
+            PaymentReturnTransaction(
+                returned_interbank_amount=rtrd,
+                return_id=_text(txinf, ns, "RtrId"),
+                original_end_to_end_id=_text(txinf, ns, "OrgnlEndToEndId"),
+                original_tx_id=_text(txinf, ns, "OrgnlTxId"),
+                original_uetr=_text(txinf, ns, "OrgnlUETR"),
+                original_interbank_amount=_parse_amount(_find(txinf, ns, "OrgnlIntrBkSttlmAmt")),
+                interbank_settlement_date=_text(txinf, ns, "IntrBkSttlmDt"),
+                return_reason_code=_text(txinf, ns, "RtrRsnInf/Rsn/Cd"),
+                additional_info=_addtl_info(rsn, ns),
+            )
+        )
+    return PaymentReturn(
+        group_header=gh,
+        transactions=tuple(txs),
+        original_message_id=orig_msg_id,
+        original_message_name_id=orig_msg_nm,
+    )

--- a/py/kotoba_iso20022/kotoba_iso20022/conformance.py
+++ b/py/kotoba_iso20022/kotoba_iso20022/conformance.py
@@ -1,0 +1,205 @@
+"""CBPR+ Usage-Guideline conformance checks (the rulebook over the grammar).
+
+The codec in :mod:`kotoba_iso20022.codec` implements the *base ISO 20022*
+message grammar. SWIFT's **CBPR+** programme layers a Usage Guideline of
+additional constraints on top of that grammar — a base-schema-valid
+``pacs.008`` can still be a non-conformant CBPR+ message. This module is the
+cleanroom implementation of those published rules, so a kawase corridor can
+check an inbound/outbound message before it ever reaches the wire.
+
+Rules implemented (each carries a stable ``rule_id``), from the public
+CBPR+ Usage Guidelines for ``pacs.008.001.08`` and the BAH:
+
+- ``CBPR-001`` GrpHdr/NbOfTxs must equal the actual CdtTrfTxInf count.
+- ``CBPR-002`` UETR is mandatory on every transaction.
+- ``CBPR-003`` UETR must be a lowercase UUIDv4.
+- ``CBPR-004`` IntrBkSttlmAmt mandatory, with a valid ISO 4217 amount.
+- ``CBPR-005`` ChrgBr ∈ {DEBT, CRED, SHAR} (SLEV is SEPA, not CBPR+).
+- ``CBPR-006`` DbtrAgt and CdtrAgt each require a valid BICFI.
+- ``CBPR-007`` if an Agent BICFI is present, its Name is not allowed.
+- ``CBPR-008`` CtrlSum, if present, must equal the sum of settlement amounts.
+- ``CBPR-009`` Debtor and Creditor names are mandatory.
+- ``CBPR-010`` BAH MsgDefIdr must match the message definition.
+- ``CBPR-011`` BAH BizSvc should be a ``swift.cbprplus.*`` service (warning).
+
+This is a *non-adjudicating* deterministic checker: it reports findings, it
+does not move money, sign, or transact (kawase G2/G13 stay with the gated
+ingress cell). No proprietary SWIFT validator is used.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Literal
+
+from .model import (
+    Agent,
+    BusinessApplicationHeader,
+    CreditTransferTransaction,
+    FIToFICustomerCreditTransfer,
+)
+from .validate import (
+    Iso20022ValidationError,
+    is_uetr,
+    validate_amount,
+    validate_bic,
+)
+
+__all__ = (
+    "Severity",
+    "ConformanceIssue",
+    "CbprConformanceError",
+    "CBPR_CHARGE_BEARERS",
+    "check_cbpr_pacs008",
+    "check_cbpr_bah",
+    "assert_cbpr_pacs008",
+)
+
+Severity = Literal["error", "warning"]
+
+# CBPR+ permits only these charge-bearer codes (SLEV is SEPA-only).
+CBPR_CHARGE_BEARERS: frozenset[str] = frozenset({"DEBT", "CRED", "SHAR"})
+
+
+@dataclass(frozen=True)
+class ConformanceIssue:
+    """One CBPR+ finding. ``location`` points at the offending element."""
+
+    rule_id: str
+    severity: Severity
+    location: str
+    message: str
+
+
+class CbprConformanceError(ValueError):
+    """Raised by :func:`assert_cbpr_pacs008` when error-level issues exist."""
+
+    def __init__(self, issues: list[ConformanceIssue]) -> None:
+        self.issues = issues
+        super().__init__(
+            f"{len(issues)} CBPR+ error(s): "
+            + "; ".join(f"{i.rule_id}@{i.location}: {i.message}" for i in issues)
+        )
+
+
+def _agent_issues(agent: Agent | None, where: str) -> list[ConformanceIssue]:
+    out: list[ConformanceIssue] = []
+    if agent is None or not agent.bicfi:
+        out.append(ConformanceIssue("CBPR-006", "error", where, "Agent BICFI required"))
+        return out
+    try:
+        validate_bic(agent.bicfi)
+    except Iso20022ValidationError as exc:
+        out.append(ConformanceIssue("CBPR-006", "error", where, str(exc)))
+    if agent.name:
+        out.append(
+            ConformanceIssue(
+                "CBPR-007", "error", where, "Agent Name not allowed when BICFI present"
+            )
+        )
+    return out
+
+
+def _tx_issues(tx: CreditTransferTransaction, idx: int) -> list[ConformanceIssue]:
+    loc = f"CdtTrfTxInf[{idx}]"
+    out: list[ConformanceIssue] = []
+
+    if not tx.uetr:
+        out.append(ConformanceIssue("CBPR-002", "error", f"{loc}/PmtId", "UETR is mandatory"))
+    elif not is_uetr(tx.uetr):
+        out.append(
+            ConformanceIssue("CBPR-003", "error", f"{loc}/PmtId/UETR", "UETR must be UUIDv4")
+        )
+
+    if tx.interbank_amount is None:
+        out.append(ConformanceIssue("CBPR-004", "error", loc, "IntrBkSttlmAmt required"))
+    else:
+        try:
+            validate_amount(tx.interbank_amount.value, tx.interbank_amount.currency)
+        except Iso20022ValidationError as exc:
+            out.append(ConformanceIssue("CBPR-004", "error", f"{loc}/IntrBkSttlmAmt", str(exc)))
+
+    if tx.charge_bearer is not None and tx.charge_bearer not in CBPR_CHARGE_BEARERS:
+        out.append(
+            ConformanceIssue(
+                "CBPR-005", "error", f"{loc}/ChrgBr",
+                f"ChrgBr {tx.charge_bearer!r} not in CBPR+ {sorted(CBPR_CHARGE_BEARERS)}",
+            )
+        )
+
+    out += _agent_issues(tx.debtor_agent, f"{loc}/DbtrAgt")
+    out += _agent_issues(tx.creditor_agent, f"{loc}/CdtrAgt")
+
+    if tx.debtor is None or not tx.debtor.name:
+        out.append(ConformanceIssue("CBPR-009", "error", f"{loc}/Dbtr", "Debtor name required"))
+    if tx.creditor is None or not tx.creditor.name:
+        out.append(ConformanceIssue("CBPR-009", "error", f"{loc}/Cdtr", "Creditor name required"))
+
+    return out
+
+
+def check_cbpr_pacs008(msg: FIToFICustomerCreditTransfer) -> list[ConformanceIssue]:
+    """Return all CBPR+ Usage-Guideline findings for a pacs.008 message."""
+    out: list[ConformanceIssue] = []
+
+    actual = len(msg.transactions)
+    if msg.group_header.number_of_txs != actual:
+        out.append(
+            ConformanceIssue(
+                "CBPR-001", "error", "GrpHdr/NbOfTxs",
+                f"NbOfTxs={msg.group_header.number_of_txs} != {actual} transactions",
+            )
+        )
+
+    for idx, tx in enumerate(msg.transactions):
+        out += _tx_issues(tx, idx)
+
+    if msg.group_header.control_sum is not None:
+        total = sum(
+            (tx.interbank_amount.value for tx in msg.transactions if tx.interbank_amount),
+            Decimal("0"),
+        )
+        if total != msg.group_header.control_sum:
+            out.append(
+                ConformanceIssue(
+                    "CBPR-008", "error", "GrpHdr/CtrlSum",
+                    f"CtrlSum={msg.group_header.control_sum} != sum {total}",
+                )
+            )
+
+    return out
+
+
+def check_cbpr_bah(
+    bah: BusinessApplicationHeader, msg_definition: str | None = None
+) -> list[ConformanceIssue]:
+    """Return CBPR+ findings for a Business Application Header."""
+    out: list[ConformanceIssue] = []
+    for bic, where in ((bah.from_bic, "AppHdr/Fr"), (bah.to_bic, "AppHdr/To")):
+        try:
+            validate_bic(bic)
+        except Iso20022ValidationError as exc:
+            out.append(ConformanceIssue("CBPR-006", "error", where, str(exc)))
+    if msg_definition is not None and bah.message_definition != msg_definition:
+        out.append(
+            ConformanceIssue(
+                "CBPR-010", "error", "AppHdr/MsgDefIdr",
+                f"MsgDefIdr {bah.message_definition!r} != {msg_definition!r}",
+            )
+        )
+    if not (bah.business_service or "").startswith("swift.cbprplus."):
+        out.append(
+            ConformanceIssue(
+                "CBPR-011", "warning", "AppHdr/BizSvc",
+                "BizSvc should be a swift.cbprplus.* service for CBPR+",
+            )
+        )
+    return out
+
+
+def assert_cbpr_pacs008(msg: FIToFICustomerCreditTransfer) -> None:
+    """Raise :class:`CbprConformanceError` if any error-level issue exists."""
+    errors = [i for i in check_cbpr_pacs008(msg) if i.severity == "error"]
+    if errors:
+        raise CbprConformanceError(errors)

--- a/py/kotoba_iso20022/kotoba_iso20022/datoms.py
+++ b/py/kotoba_iso20022/kotoba_iso20022/datoms.py
@@ -1,0 +1,199 @@
+"""ISO 20022 message → kotoba EAVT Datom mapping (ingress/interop wire).
+
+Per CLAUDE.md the kotoba Datom log is first-class canonical state and the
+AT-Protocol MST is "ingress/interop wire". This module is the *traditional
+finance* analogue of that wire: it lands an inbound ISO 20022 message as a
+set of append-only EAVT facts so a real-world bank transfer becomes
+auditable kotoba history (Wellbecoming ``as-of``, no mutation, no deletion).
+
+A Datom here is the 4-tuple ``(entity, attribute, value, op)`` with ``op``
+always ``True`` (assertion) — retraction is never emitted for an ingress
+record, mirroring kawase-yui G11 (no reverse / no unwind). Entities are
+content-addressable handles derived from the message's own immutable
+identifiers (UETR / EndToEndId / MsgId), NOT random ids, so re-ingesting
+the same message is idempotent.
+
+This is pure mapping: it does not write to kotoba, touch a chain, or move
+money. The caller (a kawase-yui ingress cell, gated) is responsible for
+the actual transact under G2/G13.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .model import (
+    BankToCustomerDebitCreditNotification,
+    BankToCustomerStatement,
+    CreditTransferTransaction,
+    CustomerCreditTransferInitiation,
+    FIToFICustomerCreditTransfer,
+    FIToFIPaymentStatusReport,
+    PaymentReturn,
+    StatementEntry,
+)
+
+__all__ = ("Datom", "NS", "to_datoms", "tx_entity_of")
+
+NS = "com.etzhayyim.iso20022"
+
+
+def tx_entity_of(tx: CreditTransferTransaction) -> str:
+    """Public content-addressable entity handle for a transaction.
+
+    Keyed on the most stable immutable reference (UETR → TxId →
+    EndToEndId), so the same transaction always maps to the same kotoba
+    entity across pain.001 / pacs.008 / camt ingress and pacs.002 status.
+    """
+    ref = tx.uetr or tx.tx_id or tx.end_to_end_id
+    return f"{NS}/tx:{ref}"
+
+AnyMessage = (
+    CustomerCreditTransferInitiation
+    | FIToFICustomerCreditTransfer
+    | FIToFIPaymentStatusReport
+    | BankToCustomerStatement
+    | BankToCustomerDebitCreditNotification
+    | PaymentReturn
+)
+
+
+@dataclass(frozen=True)
+class Datom:
+    """A single append-only EAVT assertion."""
+
+    entity: str
+    attribute: str
+    value: str
+    op: bool = True  # assertion; ingress never retracts (kawase-yui G11)
+
+    def as_tuple(self) -> tuple[str, str, str, bool]:
+        return (self.entity, self.attribute, self.value, self.op)
+
+
+def _tx_entity(tx: CreditTransferTransaction) -> str:
+    """Stable content-addressable entity handle for a transaction."""
+    return tx_entity_of(tx)
+
+
+def _tx_datoms(entity: str, tx: CreditTransferTransaction) -> list[Datom]:
+    out: list[Datom] = [Datom(entity, f"{NS}.tx/endToEndId", tx.end_to_end_id)]
+    if tx.uetr:
+        out.append(Datom(entity, f"{NS}.tx/uetr", tx.uetr))
+    if tx.tx_id:
+        out.append(Datom(entity, f"{NS}.tx/txId", tx.tx_id))
+    amt = tx.interbank_amount or tx.instructed_amount
+    if amt is not None:
+        out.append(Datom(entity, f"{NS}.tx/amount", str(amt.value)))
+        out.append(Datom(entity, f"{NS}.tx/currency", amt.currency))
+    if tx.interbank_settlement_date:
+        out.append(Datom(entity, f"{NS}.tx/settlementDate", tx.interbank_settlement_date))
+    if tx.charge_bearer:
+        out.append(Datom(entity, f"{NS}.tx/chargeBearer", tx.charge_bearer))
+    if tx.debtor:
+        out.append(Datom(entity, f"{NS}.tx/debtorName", tx.debtor.name))
+    if tx.debtor_account and tx.debtor_account.iban:
+        out.append(Datom(entity, f"{NS}.tx/debtorIban", tx.debtor_account.iban))
+    if tx.debtor_agent and tx.debtor_agent.bicfi:
+        out.append(Datom(entity, f"{NS}.tx/debtorAgentBic", tx.debtor_agent.bicfi))
+    if tx.creditor:
+        out.append(Datom(entity, f"{NS}.tx/creditorName", tx.creditor.name))
+    if tx.creditor_account and tx.creditor_account.iban:
+        out.append(Datom(entity, f"{NS}.tx/creditorIban", tx.creditor_account.iban))
+    if tx.creditor_agent and tx.creditor_agent.bicfi:
+        out.append(Datom(entity, f"{NS}.tx/creditorAgentBic", tx.creditor_agent.bicfi))
+    if tx.remittance_info:
+        for i, line in enumerate(tx.remittance_info.unstructured):
+            out.append(Datom(entity, f"{NS}.tx/remittance[{i}]", line))
+    return out
+
+
+def to_datoms(msg: AnyMessage) -> list[Datom]:
+    """Map an ISO 20022 message to append-only kotoba EAVT Datoms."""
+    gh = msg.group_header
+    msg_entity = f"{NS}/msg:{gh.message_id}"
+    out: list[Datom] = [
+        Datom(msg_entity, f"{NS}.msg/messageId", gh.message_id),
+        Datom(msg_entity, f"{NS}.msg/creationDateTime", gh.creation_datetime),
+    ]
+
+    if isinstance(msg, CustomerCreditTransferInitiation):
+        out.append(Datom(msg_entity, f"{NS}.msg/definition", "pain.001"))
+        for pmt in msg.payments:
+            for tx in pmt.transactions:
+                ent = _tx_entity(tx)
+                out.append(Datom(msg_entity, f"{NS}.msg/hasTx", ent))
+                out.extend(_tx_datoms(ent, tx))
+    elif isinstance(msg, FIToFICustomerCreditTransfer):
+        out.append(Datom(msg_entity, f"{NS}.msg/definition", "pacs.008"))
+        for tx in msg.transactions:
+            ent = _tx_entity(tx)
+            out.append(Datom(msg_entity, f"{NS}.msg/hasTx", ent))
+            out.extend(_tx_datoms(ent, tx))
+    elif isinstance(msg, FIToFIPaymentStatusReport):
+        out.append(Datom(msg_entity, f"{NS}.msg/definition", "pacs.002"))
+        out.append(Datom(msg_entity, f"{NS}.msg/originalMessageId", msg.original_message_id))
+        for sts in msg.statuses:
+            ref = (
+                sts.original_uetr or sts.original_tx_id
+                or sts.original_end_to_end_id or sts.status_id
+            )
+            ent = f"{NS}/tx:{ref}"
+            out.append(Datom(ent, f"{NS}.tx/status", sts.transaction_status))
+            if sts.status_reason_code:
+                out.append(Datom(ent, f"{NS}.tx/statusReason", sts.status_reason_code))
+    elif isinstance(msg, BankToCustomerStatement):
+        out.append(Datom(msg_entity, f"{NS}.msg/definition", "camt.053"))
+        for stmt in msg.statements:
+            for entry in stmt.entries:
+                out.extend(_entry_datoms(msg_entity, entry, "camt.053"))
+    elif isinstance(msg, BankToCustomerDebitCreditNotification):
+        out.append(Datom(msg_entity, f"{NS}.msg/definition", "camt.054"))
+        for ntf in msg.notifications:
+            for entry in ntf.entries:
+                out.extend(_entry_datoms(msg_entity, entry, "camt.054"))
+    elif isinstance(msg, PaymentReturn):
+        out.append(Datom(msg_entity, f"{NS}.msg/definition", "pacs.004"))
+        for rtx in msg.transactions:
+            oref = rtx.original_uetr or rtx.original_tx_id or rtx.original_end_to_end_id
+            if oref is None:
+                continue
+            ent = f"{NS}/tx:{oref}"
+            # the return lands on the SAME entity as the original transfer
+            out.append(Datom(ent, f"{NS}.tx/status", "RTND"))
+            ramt = rtx.returned_interbank_amount
+            out.append(Datom(ent, f"{NS}.tx/returnedAmount", str(ramt.value)))
+            out.append(Datom(ent, f"{NS}.tx/returnedCurrency", ramt.currency))
+            if rtx.return_reason_code:
+                out.append(Datom(ent, f"{NS}.tx/returnReason", rtx.return_reason_code))
+    else:  # pragma: no cover - exhaustive by construction
+        raise TypeError(f"unsupported message type: {type(msg)!r}")
+
+    return out
+
+
+def _entry_datoms(msg_entity: str, entry: StatementEntry, definition: str) -> list[Datom]:
+    """Map a camt Ntry to reconciliation Datoms.
+
+    When the entry carries an EndToEndId it lands on the SAME content-
+    addressed transaction entity as the original pain.001/pacs.008 ingress,
+    so a statement/notification *reconciles* against the earlier message
+    (the off-ramp closing the loop) rather than creating a parallel record.
+    Entries without an EndToEndId get their own AcctSvcrRef-keyed entity.
+    """
+    ref = entry.end_to_end_id or entry.account_servicer_reference
+    ent = f"{NS}/tx:{ref}" if ref else msg_entity
+    out: list[Datom] = [
+        Datom(ent, f"{NS}.entry/amount", str(entry.amount.value)),
+        Datom(ent, f"{NS}.entry/currency", entry.amount.currency),
+        Datom(ent, f"{NS}.entry/creditDebit", entry.credit_debit),
+        Datom(ent, f"{NS}.entry/status", entry.status),
+        Datom(ent, f"{NS}.entry/reportedBy", definition),
+    ]
+    if entry.booking_date:
+        out.append(Datom(ent, f"{NS}.entry/bookingDate", entry.booking_date))
+    if entry.value_date:
+        out.append(Datom(ent, f"{NS}.entry/valueDate", entry.value_date))
+    if entry.account_servicer_reference:
+        out.append(Datom(ent, f"{NS}.entry/acctSvcrRef", entry.account_servicer_reference))
+    return out

--- a/py/kotoba_iso20022/kotoba_iso20022/helpers.py
+++ b/py/kotoba_iso20022/kotoba_iso20022/helpers.py
@@ -1,0 +1,73 @@
+"""Maturity helpers for constructing conformant ISO 20022 messages.
+
+Small, well-tested conveniences that remove the two most common ways a
+hand-built message fails CBPR+ conformance: a miscounted ``NbOfTxs`` and a
+mismatched ``CtrlSum`` (both flagged by ``conformance.CBPR-001``/``008``).
+Also a UETR generator so callers don't have to wire UUIDv4 themselves.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from decimal import Decimal
+
+from .model import CreditTransferTransaction, GroupHeader, Party, SettlementMethod
+
+__all__ = ("new_uetr", "control_sum_of", "pacs008_group_header", "pain001_group_header")
+
+
+def new_uetr() -> str:
+    """Generate a fresh CBPR+ UETR (lowercase UUIDv4)."""
+    return str(uuid.uuid4())
+
+
+def control_sum_of(transactions: Sequence[CreditTransferTransaction]) -> Decimal:
+    """Sum the settlement (or instructed) amounts of ``transactions``.
+
+    Uses ``interbank_amount`` when present (pacs.008), else
+    ``instructed_amount`` (pain.001). Transactions with neither contribute
+    zero. Mixed currencies are summed numerically as-is — callers should
+    only pass a single-currency batch (CBPR+ CtrlSum is single-currency).
+    """
+    total = Decimal("0")
+    for tx in transactions:
+        amt = tx.interbank_amount or tx.instructed_amount
+        if amt is not None:
+            total += amt.value
+    return total
+
+
+def pacs008_group_header(
+    message_id: str,
+    creation_datetime: str,
+    transactions: Sequence[CreditTransferTransaction],
+    *,
+    settlement_method: SettlementMethod = "CLRG",
+) -> GroupHeader:
+    """Build a pacs.008 ``GrpHdr`` with ``NbOfTxs``/``CtrlSum`` derived from
+    the transactions, so the result satisfies CBPR-001 and CBPR-008."""
+    return GroupHeader(
+        message_id=message_id,
+        creation_datetime=creation_datetime,
+        number_of_txs=len(transactions),
+        control_sum=control_sum_of(transactions),
+        settlement_method=settlement_method,
+    )
+
+
+def pain001_group_header(
+    message_id: str,
+    creation_datetime: str,
+    transactions: Sequence[CreditTransferTransaction],
+    *,
+    initiating_party: Party | None = None,
+) -> GroupHeader:
+    """Build a pain.001 ``GrpHdr`` with derived ``NbOfTxs``/``CtrlSum``."""
+    return GroupHeader(
+        message_id=message_id,
+        creation_datetime=creation_datetime,
+        number_of_txs=len(transactions),
+        control_sum=control_sum_of(transactions),
+        initiating_party=initiating_party,
+    )

--- a/py/kotoba_iso20022/kotoba_iso20022/model.py
+++ b/py/kotoba_iso20022/kotoba_iso20022/model.py
@@ -1,0 +1,372 @@
+"""ISO 20022 payment-message domain model (frozen dataclasses).
+
+A cleanroom object model of the three message definitions kawase-yui needs
+at its interop/ingress boundary (CLAUDE.md: "MST = ingress/interop wire" —
+here the wire is the global ISO 20022 banking network):
+
+- **pain.001** — ``CustomerCreditTransferInitiation`` (a party instructs
+  its agent to make a credit transfer; the *ingress* of a real-world
+  transfer into the kotoba Datom log).
+- **pacs.008** — ``FIToFICustomerCreditTransfer`` (the inter-bank leg; the
+  message SWIFT CBPR+ carries between financial institutions).
+- **pacs.002** — ``FIToFIPaymentStatusReport`` (per-hop acceptance /
+  rejection / pending acknowledgement).
+
+The element names mirror the official ISO 20022 message components
+(``GrpHdr`` / ``CdtTrfTxInf`` / ``PmtId`` / ``IntrBkSttlmAmt`` …) so the
+codec in :mod:`kotoba_iso20022.codec` is a faithful, auditable mapping.
+
+These dataclasses are pure data — building/parsing XML lives in the codec,
+validation in :mod:`kotoba_iso20022.validate`, and the kotoba EAVT mapping
+in :mod:`kotoba_iso20022.datoms`. Nothing here touches a network, a chain,
+or money movement; it is format datafication only.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Literal
+
+__all__ = (
+    "PostalAddress",
+    "Party",
+    "Account",
+    "Agent",
+    "Amount",
+    "RemittanceInfo",
+    "CreditTransferTransaction",
+    "GroupHeader",
+    "PaymentInstruction",
+    "CustomerCreditTransferInitiation",
+    "FIToFICustomerCreditTransfer",
+    "TransactionStatus",
+    "FIToFIPaymentStatusReport",
+    "ChargeBearer",
+    "SettlementMethod",
+    "TxStatusCode",
+    "CreditDebitCode",
+    "BalanceType",
+    "EntryStatus",
+    "CashBalance",
+    "StatementEntry",
+    "AccountStatement",
+    "BankToCustomerStatement",
+    "AccountNotification",
+    "BankToCustomerDebitCreditNotification",
+    "BusinessApplicationHeader",
+    "OriginalPaymentStatus",
+    "CustomerPaymentStatusReport",
+    "PaymentReturnTransaction",
+    "PaymentReturn",
+)
+
+# ISO 20022 external code subsets actually used by the messages here.
+ChargeBearer = Literal["DEBT", "CRED", "SHAR", "SLEV"]
+SettlementMethod = Literal["INDA", "INGA", "COVE", "CLRG"]
+# pacs.002 TransactionIndividualStatus (ISO external code set).
+TxStatusCode = Literal["ACCP", "ACSP", "ACSC", "ACWC", "ACWP", "RJCT", "PDNG"]
+# camt.05x CreditDebitCode + balance-type + entry-status code sets.
+CreditDebitCode = Literal["CRDT", "DBIT"]
+BalanceType = Literal["OPBD", "CLBD", "PRCD", "CLAV", "FWAV", "ITBD"]
+EntryStatus = Literal["BOOK", "PDNG", "INFO"]
+
+
+@dataclass(frozen=True)
+class PostalAddress:
+    """``PstlAdr`` — minimal structured address."""
+
+    country: str | None = None  # ISO 3166-1 alpha-2
+    address_lines: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Party:
+    """``Dbtr`` / ``Cdtr`` / ``InitgPty`` — an identified party."""
+
+    name: str
+    postal_address: PostalAddress | None = None
+    # ``Id`` — org BIC/LEI or private id; kept opaque at this layer.
+    identifier: str | None = None
+
+
+@dataclass(frozen=True)
+class Account:
+    """``DbtrAcct`` / ``CdtrAcct`` — IBAN-or-other account identification."""
+
+    iban: str | None = None
+    other_id: str | None = None
+    currency: str | None = None  # ISO 4217
+
+    def __post_init__(self) -> None:
+        if not self.iban and not self.other_id:
+            raise ValueError("Account needs either iban or other_id")
+
+
+@dataclass(frozen=True)
+class Agent:
+    """``DbtrAgt`` / ``CdtrAgt`` — a financial institution (``FinInstnId``)."""
+
+    bicfi: str | None = None  # ISO 9362 BIC
+    name: str | None = None
+    clearing_member_id: str | None = None  # ClrSysMmbId/MmbId
+
+    def __post_init__(self) -> None:
+        if not self.bicfi and not self.clearing_member_id:
+            raise ValueError("Agent needs bicfi or clearing_member_id")
+
+
+@dataclass(frozen=True)
+class Amount:
+    """``ActiveCurrencyAndAmount`` — value + ISO 4217 currency."""
+
+    value: Decimal
+    currency: str
+
+
+@dataclass(frozen=True)
+class RemittanceInfo:
+    """``RmtInf`` — unstructured remittance lines (``Ustrd``)."""
+
+    unstructured: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class CreditTransferTransaction:
+    """``CdtTrfTxInf`` — one credit-transfer transaction.
+
+    Shared shape across pain.001 and pacs.008. ``interbank_amount`` /
+    ``interbank_settlement_date`` / ``charge_bearer`` / ``tx_id`` are the
+    pacs.008 inter-bank fields; ``instructed_amount`` is the pain.001
+    customer-instruction field. A given message populates the subset its
+    definition requires (the codec enforces which).
+    """
+
+    end_to_end_id: str
+    instruction_id: str | None = None
+    tx_id: str | None = None          # pacs.008 TxId
+    uetr: str | None = None           # UUIDv4 end-to-end reference
+    instructed_amount: Amount | None = None      # pain.001 InstdAmt
+    interbank_amount: Amount | None = None        # pacs.008 IntrBkSttlmAmt
+    interbank_settlement_date: str | None = None  # IntrBkSttlmDt (ISO date)
+    charge_bearer: ChargeBearer | None = None
+    debtor: Party | None = None
+    debtor_account: Account | None = None
+    debtor_agent: Agent | None = None
+    creditor_agent: Agent | None = None
+    creditor: Party | None = None
+    creditor_account: Account | None = None
+    remittance_info: RemittanceInfo | None = None
+
+
+@dataclass(frozen=True)
+class GroupHeader:
+    """``GrpHdr`` — message-level header common to all three definitions."""
+
+    message_id: str
+    creation_datetime: str  # ISO 8601 (CreDtTm)
+    number_of_txs: int
+    control_sum: Decimal | None = None
+    initiating_party: Party | None = None        # pain.001 InitgPty
+    settlement_method: SettlementMethod | None = None  # pacs.008 SttlmInf
+
+
+@dataclass(frozen=True)
+class PaymentInstruction:
+    """``PmtInf`` — a pain.001 payment-information block (PmtMtd=TRF)."""
+
+    payment_info_id: str
+    requested_execution_date: str  # ReqdExctnDt (ISO date)
+    debtor: Party
+    debtor_account: Account
+    debtor_agent: Agent
+    transactions: tuple[CreditTransferTransaction, ...]
+    payment_method: Literal["TRF"] = "TRF"
+
+
+@dataclass(frozen=True)
+class CustomerCreditTransferInitiation:
+    """pain.001 — ``CstmrCdtTrfInitn``."""
+
+    group_header: GroupHeader
+    payments: tuple[PaymentInstruction, ...]
+
+
+@dataclass(frozen=True)
+class FIToFICustomerCreditTransfer:
+    """pacs.008 — ``FIToFICstmrCdtTrf``."""
+
+    group_header: GroupHeader
+    transactions: tuple[CreditTransferTransaction, ...]
+
+
+@dataclass(frozen=True)
+class TransactionStatus:
+    """``TxInfAndSts`` — one transaction's status inside pacs.002."""
+
+    status_id: str
+    original_end_to_end_id: str | None = None
+    original_tx_id: str | None = None
+    original_uetr: str | None = None
+    transaction_status: TxStatusCode = "ACSP"
+    status_reason_code: str | None = None  # StsRsnInf/Rsn/Cd
+    additional_info: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class FIToFIPaymentStatusReport:
+    """pacs.002 — ``FIToFIPmtStsRpt``."""
+
+    group_header: GroupHeader
+    original_message_id: str
+    original_message_name_id: str  # e.g. "pacs.008.001.08"
+    statuses: tuple[TransactionStatus, ...] = field(default_factory=tuple)
+
+
+# --------------------------------------------------------------------------
+# camt.053 / camt.054 — account reporting (reconciliation / off-ramp side)
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CashBalance:
+    """``Bal`` — a statement balance (opening / closing / available …)."""
+
+    balance_type: BalanceType  # Tp/CdOrPrtry/Cd
+    amount: Amount
+    credit_debit: CreditDebitCode  # CdtDbtInd
+    date: str  # Dt/Dt (ISO date)
+
+
+@dataclass(frozen=True)
+class StatementEntry:
+    """``Ntry`` — one booked/pending entry, shared by camt.053 and camt.054."""
+
+    amount: Amount
+    credit_debit: CreditDebitCode  # CdtDbtInd
+    status: EntryStatus  # Sts (BOOK / PDNG / INFO)
+    booking_date: str | None = None  # BookgDt/Dt
+    value_date: str | None = None  # ValDt/Dt
+    account_servicer_reference: str | None = None  # AcctSvcrRef
+    bank_transaction_code: str | None = None  # BkTxCd/Domn/Cd (kept opaque)
+    end_to_end_id: str | None = None  # NtryDtls/TxDtls/Refs/EndToEndId
+    remittance_info: RemittanceInfo | None = None
+
+
+@dataclass(frozen=True)
+class AccountStatement:
+    """``Stmt`` — one account statement within camt.053."""
+
+    statement_id: str
+    creation_datetime: str
+    account: Account
+    balances: tuple[CashBalance, ...] = ()
+    entries: tuple[StatementEntry, ...] = ()
+
+
+@dataclass(frozen=True)
+class BankToCustomerStatement:
+    """camt.053 — ``BkToCstmrStmt``."""
+
+    group_header: GroupHeader
+    statements: tuple[AccountStatement, ...]
+
+
+@dataclass(frozen=True)
+class AccountNotification:
+    """``Ntfctn`` — one account notification within camt.054."""
+
+    notification_id: str
+    creation_datetime: str
+    account: Account
+    entries: tuple[StatementEntry, ...] = ()
+
+
+@dataclass(frozen=True)
+class BankToCustomerDebitCreditNotification:
+    """camt.054 — ``BkToCstmrDbtCdtNtfctn``."""
+
+    group_header: GroupHeader
+    notifications: tuple[AccountNotification, ...]
+
+
+# --------------------------------------------------------------------------
+# head.001 — Business Application Header (mandatory wrapper for CBPR+)
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BusinessApplicationHeader:
+    """head.001 — ``AppHdr``.
+
+    The BAH that SWIFT CBPR+ mandates around every business message: it
+    names the sending/receiving institutions, the message identity, and the
+    definition the payload conforms to. ``message_definition`` MUST match
+    the wrapped Document's message definition (a CBPR+ conformance rule the
+    envelope codec enforces).
+    """
+
+    from_bic: str  # Fr/FIId/FinInstnId/BICFI
+    to_bic: str  # To/FIId/FinInstnId/BICFI
+    business_message_id: str  # BizMsgIdr
+    message_definition: str  # MsgDefIdr, e.g. "pacs.008.001.08"
+    creation_datetime: str  # CreDt
+    business_service: str | None = None  # BizSvc, e.g. "swift.cbprplus.02"
+
+
+# --------------------------------------------------------------------------
+# pain.002 — CustomerPaymentStatusReport (pain-side ack)
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OriginalPaymentStatus:
+    """``OrgnlPmtInfAndSts`` — statuses grouped by original PmtInfId."""
+
+    original_payment_info_id: str
+    statuses: tuple[TransactionStatus, ...] = ()
+
+
+@dataclass(frozen=True)
+class CustomerPaymentStatusReport:
+    """pain.002 — ``CstmrPmtStsRpt``."""
+
+    group_header: GroupHeader
+    original_message_id: str
+    original_message_name_id: str  # e.g. "pain.001.001.09"
+    payment_statuses: tuple[OriginalPaymentStatus, ...] = ()
+
+
+# --------------------------------------------------------------------------
+# pacs.004 — PaymentReturn (a settled transfer sent back; reversal loop)
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PaymentReturnTransaction:
+    """``TxInf`` — one returned transaction inside pacs.004.
+
+    Carries the *original* references (so the return reconciles onto the
+    same transaction entity as the original pacs.008/pacs.009) plus the
+    returned amount and an ``ExternalReturnReason`` code.
+    """
+
+    returned_interbank_amount: Amount  # RtrdIntrBkSttlmAmt
+    return_id: str | None = None  # RtrId
+    original_end_to_end_id: str | None = None
+    original_tx_id: str | None = None
+    original_uetr: str | None = None
+    original_interbank_amount: Amount | None = None  # OrgnlIntrBkSttlmAmt
+    interbank_settlement_date: str | None = None
+    return_reason_code: str | None = None  # RtrRsnInf/Rsn/Cd
+    additional_info: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PaymentReturn:
+    """pacs.004 — ``PmtRtr``."""
+
+    group_header: GroupHeader
+    transactions: tuple[PaymentReturnTransaction, ...]
+    original_message_id: str | None = None  # OrgnlGrpInf/OrgnlMsgId
+    original_message_name_id: str | None = None  # e.g. "pacs.008.001.08"

--- a/py/kotoba_iso20022/kotoba_iso20022/validate.py
+++ b/py/kotoba_iso20022/kotoba_iso20022/validate.py
@@ -1,0 +1,269 @@
+"""Cleanroom validators for the open identifier standards ISO 20022 reuses.
+
+Every routine here is implemented purely from the *published* algorithm in
+the relevant open ISO standard — no proprietary SWIFT SDK, no vendor
+reference code (Charter Rider §2(c)/§2(e); the same cleanroom discipline
+warifu applied to ISO 8583 in ``50-infra/warifu-gateway``).
+
+Standards implemented:
+
+- **IBAN** — ISO 13616 (check digits = ISO 7064 MOD 97-10).
+- **BIC**  — ISO 9362 (8- or 11-character business identifier code).
+- **Currency** — ISO 4217 alphabetic code shape + active-code membership.
+- **Amount** — ISO 20022 ``ActiveCurrencyAndAmount`` lexical constraints
+  (total digits ≤ 18, fraction digits ≤ 5, non-negative).
+
+These are *facts of an open standard*, not copyrightable expression, so a
+clean reimplementation is charter-clean.
+"""
+
+from __future__ import annotations
+
+import re
+from decimal import Decimal, InvalidOperation
+
+__all__ = (
+    "InvalidIban",
+    "InvalidBic",
+    "InvalidCurrency",
+    "InvalidAmount",
+    "InvalidUetr",
+    "validate_iban",
+    "validate_bic",
+    "validate_currency",
+    "validate_amount",
+    "validate_uetr",
+    "is_uetr",
+    "iban_check_digits",
+    "ISO4217_ACTIVE",
+)
+
+
+class Iso20022ValidationError(ValueError):
+    """Base class for every validator failure in this module."""
+
+
+class InvalidIban(Iso20022ValidationError):
+    """IBAN fails ISO 13616 structure or ISO 7064 MOD 97-10 check."""
+
+
+class InvalidBic(Iso20022ValidationError):
+    """BIC fails ISO 9362 structure."""
+
+
+class InvalidCurrency(Iso20022ValidationError):
+    """Currency code fails ISO 4217 shape or active-membership check."""
+
+
+class InvalidAmount(Iso20022ValidationError):
+    """Amount violates ISO 20022 ActiveCurrencyAndAmount constraints."""
+
+
+class InvalidUetr(Iso20022ValidationError):
+    """UETR is not a lowercase UUIDv4 (CBPR+ requirement)."""
+
+
+# --------------------------------------------------------------------------
+# ISO 13616 — IBAN
+# --------------------------------------------------------------------------
+
+# ISO 13616 fixed national IBAN lengths, from the official SWIFT IBAN
+# Registry. An unknown country code is structure-checked but length-skipped
+# (a soft pass) so the codec never hard-rejects a valid-but-unlisted country.
+# `0` marks a country that does not participate in IBAN (e.g. JP/US).
+IBAN_LENGTHS: dict[str, int] = {
+    "AD": 24, "AE": 23, "AL": 28, "AT": 20, "AZ": 28, "BA": 20, "BE": 16,
+    "BG": 22, "BH": 22, "BR": 29, "BY": 28, "CH": 21, "CR": 22, "CY": 28,
+    "CZ": 24, "DE": 22, "DK": 18, "DO": 28, "EE": 20, "EG": 29, "ES": 24,
+    "FI": 18, "FO": 18, "FR": 27, "GB": 22, "GE": 22, "GI": 23, "GL": 18,
+    "GR": 27, "GT": 28, "HR": 21, "HU": 28, "IE": 22, "IL": 23, "IQ": 23,
+    "IS": 26, "IT": 27, "JO": 30, "KW": 30, "KZ": 20, "LB": 28, "LC": 32,
+    "LI": 21, "LT": 20, "LU": 20, "LV": 21, "LY": 25, "MC": 27, "MD": 24,
+    "ME": 22, "MK": 19, "MR": 27, "MT": 31, "MU": 30, "NL": 18, "NO": 15,
+    "PK": 24, "PL": 28, "PS": 29, "PT": 25, "QA": 29, "RO": 24, "RS": 22,
+    "SA": 24, "SC": 31, "SE": 24, "SI": 19, "SK": 24, "SM": 27, "ST": 25,
+    "SV": 28, "TL": 23, "TN": 24, "TR": 26, "UA": 29, "VA": 22, "VG": 24,
+    "XK": 20,
+    "JP": 0, "US": 0,  # do not participate in IBAN
+}
+
+_IBAN_RE = re.compile(r"^[A-Z]{2}[0-9]{2}[A-Z0-9]{10,30}$")
+
+
+def _iban_mod97(rearranged: str) -> int:
+    """ISO 7064 MOD 97-10 over the letter-expanded IBAN string.
+
+    Letters A..Z expand to 10..35; the integer is reduced mod 97 in
+    chunks to avoid building an arbitrarily large int.
+    """
+    total = 0
+    for ch in rearranged:
+        if ch.isdigit():
+            total = (total * 10 + (ord(ch) - 48)) % 97
+        else:  # 'A'..'Z' -> 10..35, two decimal digits
+            total = (total * 100 + (ord(ch) - 55)) % 97
+    return total
+
+
+def normalize_iban(iban: str) -> str:
+    """Strip spaces and uppercase — the canonical electronic IBAN form."""
+    return re.sub(r"\s+", "", iban).upper()
+
+
+def iban_check_digits(country: str, bban: str) -> str:
+    """Compute the ISO 13616 two-digit check for ``country`` + ``bban``.
+
+    Useful for constructing test vectors and for emitting outbound IBANs.
+    """
+    country = country.upper()
+    bban = bban.upper()
+    rearranged = bban + country + "00"
+    remainder = _iban_mod97(rearranged)
+    check = 98 - remainder
+    return f"{check:02d}"
+
+
+def validate_iban(iban: str) -> str:
+    """Validate ``iban`` and return its normalized electronic form.
+
+    Raises :class:`InvalidIban` on any structural or checksum failure.
+    """
+    norm = normalize_iban(iban)
+    if not _IBAN_RE.match(norm):
+        raise InvalidIban(f"IBAN structure invalid (ISO 13616): {iban!r}")
+    country = norm[:2]
+    expected = IBAN_LENGTHS.get(country)
+    if expected == 0:
+        raise InvalidIban(f"country {country} does not participate in IBAN")
+    if expected is not None and len(norm) != expected:
+        raise InvalidIban(
+            f"IBAN length {len(norm)} != {expected} for {country} (ISO 13616)"
+        )
+    rearranged = norm[4:] + norm[:4]
+    if _iban_mod97(rearranged) != 1:
+        raise InvalidIban(f"IBAN MOD 97-10 check failed (ISO 7064): {iban!r}")
+    return norm
+
+
+# --------------------------------------------------------------------------
+# ISO 9362 — BIC
+# --------------------------------------------------------------------------
+
+# 4 alpha institution + 2 alpha ISO-3166 country + 2 alnum location
+# (+ optional 3 alnum branch). A location ending in '0' is a test BIC;
+# '1' is a passive participant; '2' a reverse-billing connection.
+_BIC_RE = re.compile(r"^[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}([A-Z0-9]{3})?$")
+
+
+def validate_bic(bic: str) -> str:
+    """Validate an ISO 9362 BIC (BICFI), returning its uppercase form."""
+    norm = bic.strip().upper()
+    if len(norm) not in (8, 11):
+        raise InvalidBic(f"BIC must be 8 or 11 chars (ISO 9362): {bic!r}")
+    if not _BIC_RE.match(norm):
+        raise InvalidBic(f"BIC structure invalid (ISO 9362): {bic!r}")
+    return norm
+
+
+# --------------------------------------------------------------------------
+# ISO 4217 — currency
+# --------------------------------------------------------------------------
+
+# Active ISO 4217 alphabetic codes. Scoped to the kawase-yui settlement
+# corridor (USD/EUR/JPY/GBP/CHF/KRW) plus common reach currencies; the
+# shape check below is the structural gate, this set the membership gate.
+ISO4217_ACTIVE: frozenset[str] = frozenset(
+    {
+        "USD", "EUR", "JPY", "GBP", "CHF", "KRW", "CAD", "AUD", "NZD",
+        "SEK", "NOK", "DKK", "PLN", "CZK", "HUF", "SGD", "HKD", "CNY",
+        "INR", "BRL", "MXN", "ZAR", "AED", "SAR", "TRY", "THB", "IDR",
+        "PHP", "MYR", "TWD", "ILS",
+    }
+)
+
+_CCY_RE = re.compile(r"^[A-Z]{3}$")
+
+
+def validate_currency(ccy: str, *, require_active: bool = True) -> str:
+    """Validate an ISO 4217 alphabetic currency code."""
+    norm = ccy.strip().upper()
+    if not _CCY_RE.match(norm):
+        raise InvalidCurrency(f"currency must be 3 letters (ISO 4217): {ccy!r}")
+    if require_active and norm not in ISO4217_ACTIVE:
+        raise InvalidCurrency(f"currency {norm} not in active ISO 4217 set")
+    return norm
+
+
+# --------------------------------------------------------------------------
+# ISO 20022 — ActiveCurrencyAndAmount lexical constraints
+# --------------------------------------------------------------------------
+
+# ISO 20022 currency-amount fraction digits per ISO 4217 minor unit. Default
+# 2; the exceptions are the codec's amount-formatting authority.
+CCY_FRACTION_DIGITS: dict[str, int] = {
+    "JPY": 0, "KRW": 0, "CLP": 0, "ISK": 0, "HUF": 2,
+    "BHD": 3, "KWD": 3, "OMR": 3, "TND": 3,
+}
+
+_MAX_TOTAL_DIGITS = 18
+_MAX_FRACTION_DIGITS = 5
+
+
+def validate_amount(value: Decimal | str, ccy: str) -> Decimal:
+    """Validate an ISO 20022 ``ActiveCurrencyAndAmount`` value for ``ccy``.
+
+    Enforces: non-negative, total significant digits ≤ 18, fraction digits
+    ≤ 5 and ≤ the ISO 4217 minor-unit digits for the currency.
+    """
+    norm_ccy = validate_currency(ccy, require_active=False)
+    try:
+        dec = Decimal(value)
+    except (InvalidOperation, ValueError, TypeError) as exc:
+        raise InvalidAmount(f"amount not a decimal: {value!r}") from exc
+    if dec.is_nan() or dec.is_infinite():
+        raise InvalidAmount(f"amount not finite: {value!r}")
+    if dec < 0:
+        raise InvalidAmount(f"amount must be non-negative: {value!r}")
+    sign, digits, exponent = dec.as_tuple()
+    # exponent is a special str ('n'/'N'/'F') only for NaN/Infinity, both
+    # already rejected above; narrow to int for the arithmetic below.
+    assert isinstance(exponent, int)
+    frac = -exponent if exponent < 0 else 0
+    if frac > _MAX_FRACTION_DIGITS:
+        raise InvalidAmount(
+            f"fraction digits {frac} > {_MAX_FRACTION_DIGITS} (ISO 20022)"
+        )
+    allowed_frac = CCY_FRACTION_DIGITS.get(norm_ccy, 2)
+    if frac > allowed_frac:
+        raise InvalidAmount(
+            f"{norm_ccy} permits {allowed_frac} fraction digits, got {frac}"
+        )
+    if len(digits) > _MAX_TOTAL_DIGITS:
+        raise InvalidAmount(
+            f"total digits {len(digits)} > {_MAX_TOTAL_DIGITS} (ISO 20022)"
+        )
+    return dec
+
+
+# --------------------------------------------------------------------------
+# UETR — Unique End-to-End Transaction Reference (CBPR+ requires UUIDv4)
+# --------------------------------------------------------------------------
+
+# UUID version 4, lowercase: 8-4-4-4-12 hex with version nibble '4' and
+# variant nibble in {8,9,a,b}. CBPR+ mandates the UETR be a UUIDv4 and it
+# must remain unchanged across the entire payment chain.
+_UETR_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+
+
+def is_uetr(uetr: str) -> bool:
+    """Return whether ``uetr`` is a lowercase UUIDv4 (CBPR+ UETR)."""
+    return bool(_UETR_RE.match(uetr))
+
+
+def validate_uetr(uetr: str) -> str:
+    """Validate a CBPR+ UETR (lowercase UUIDv4), returning it unchanged."""
+    if not is_uetr(uetr):
+        raise InvalidUetr(f"UETR must be a lowercase UUIDv4 (CBPR+): {uetr!r}")
+    return uetr

--- a/py/kotoba_iso20022/pyproject.toml
+++ b/py/kotoba_iso20022/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "kotoba-iso20022"
+version = "0.1.0"
+description = "Cleanroom ISO 20022 payment-message codec (pain.001 / pacs.008 / pacs.002) for the kawase-yui interop/ingress wire — built purely from the open published standard, no proprietary SWIFT SDK. Format datafication only: no network, no chain, no money movement, no Travel-Rule KYC (Adherent SBT remains the KYC per kawase-yui G10)."
+requires-python = ">=3.11"
+license = { text = "Apache-2.0" }
+authors = [{ name = "etzhayyim", email = "council@etzhayyim.com" }]
+dependencies = []
+
+[project.optional-dependencies]
+test = ["pytest>=8"]
+cov = ["pytest>=8", "coverage>=7"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["kotoba_iso20022"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "B", "UP", "SIM", "I", "C4", "PIE", "RET"]
+
+[tool.ruff.lint.per-file-ignores]
+# test fixtures favour wide, aligned literal rows
+"tests/*" = ["E501"]
+
+[tool.coverage.run]
+source = ["kotoba_iso20022"]
+branch = true
+
+[tool.coverage.report]
+show_missing = true
+exclude_also = [
+  "raise NotImplementedError",
+  "if __name__ == .__main__.:",
+  "pragma: no cover",
+]

--- a/py/kotoba_iso20022/tests/test_bah.py
+++ b/py/kotoba_iso20022/tests/test_bah.py
@@ -1,0 +1,142 @@
+"""Tests for head.001 BAH + CBPR+ business-message envelope + pain.002."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from decimal import Decimal
+
+import pytest
+
+from kotoba_iso20022 import (
+    Iso20022CodecError,
+    build_bah,
+    build_business_message,
+    build_pacs008,
+    build_pain002,
+    parse_bah,
+    parse_business_message,
+    parse_pacs008,
+    parse_pain002,
+    urn_for,
+)
+from kotoba_iso20022.bah import DEFAULT_BAH_VERSION
+from kotoba_iso20022.model import (
+    Amount,
+    BusinessApplicationHeader,
+    CreditTransferTransaction,
+    FIToFICustomerCreditTransfer,
+    GroupHeader,
+    OriginalPaymentStatus,
+    TransactionStatus,
+)
+
+
+def _bah(msgdef: str = "pacs.008.001.08") -> BusinessApplicationHeader:
+    return BusinessApplicationHeader(
+        from_bic="DEUTDEFF",
+        to_bic="NWBKGB2L",
+        business_message_id="BMID-2026-0608-1",
+        message_definition=msgdef,
+        creation_datetime="2026-06-08T09:30:00Z",
+        business_service="swift.cbprplus.02",
+    )
+
+
+def _pacs008_xml() -> str:
+    tx = CreditTransferTransaction(
+        end_to_end_id="E2E-0001", interbank_amount=Amount(Decimal("1000.00"), "EUR")
+    )
+    msg = FIToFICustomerCreditTransfer(
+        group_header=GroupHeader("M", "2026-06-08T09:30:00Z", 1, settlement_method="CLRG"),
+        transactions=(tx,),
+    )
+    return build_pacs008(msg)
+
+
+class TestBah:
+    def test_roundtrip(self) -> None:
+        back = parse_bah(build_bah(_bah()))
+        assert back.from_bic == "DEUTDEFF"
+        assert back.to_bic == "NWBKGB2L"
+        assert back.message_definition == "pacs.008.001.08"
+        assert back.business_service == "swift.cbprplus.02"
+
+    def test_official_namespace(self) -> None:
+        root = ET.fromstring(build_bah(_bah()))
+        assert root.tag == f"{{{urn_for(DEFAULT_BAH_VERSION)}}}AppHdr"
+
+    def test_invalid_bic_rejected(self) -> None:
+        from kotoba_iso20022.validate import InvalidBic
+        with pytest.raises(InvalidBic):
+            build_bah(_bah().__class__(
+                from_bic="BAD", to_bic="NWBKGB2L", business_message_id="x",
+                message_definition="pacs.008.001.08", creation_datetime="2026-06-08T09:30:00Z",
+            ))
+
+
+class TestBusinessMessageEnvelope:
+    def test_roundtrip_pairs_header_and_document(self) -> None:
+        env = build_business_message(_bah(), _pacs008_xml())
+        header, doc_xml = parse_business_message(env)
+        assert header.business_message_id == "BMID-2026-0608-1"
+        # the inner document still parses as a real pacs.008
+        msg = parse_pacs008(doc_xml)
+        assert msg.transactions[0].end_to_end_id == "E2E-0001"
+
+    def test_cbpr_msgdef_mismatch_rejected_on_build(self) -> None:
+        # BAH says pain.001 but the document is pacs.008 → CBPR+ violation
+        with pytest.raises(Iso20022CodecError):
+            build_business_message(_bah(msgdef="pain.001.001.09"), _pacs008_xml())
+
+    def test_cbpr_msgdef_mismatch_rejected_on_parse(self) -> None:
+        env = build_business_message(
+            _bah(msgdef="pain.001.001.09"), _pacs008_xml(), enforce_msgdef_match=False
+        )
+        with pytest.raises(Iso20022CodecError):
+            parse_business_message(env)
+
+    def test_envelope_has_apphdr_and_document_siblings(self) -> None:
+        env = build_business_message(_bah(), _pacs008_xml())
+        root = ET.fromstring(env)
+        assert root.tag == "Envelope"
+        children = list(root)
+        assert children[0].tag.endswith("}AppHdr")
+        assert children[1].tag.endswith("}Document")
+
+
+class TestPain002:
+    def test_roundtrip(self) -> None:
+        msg = parse_pain002(
+            build_pain002(
+                _pain002_message()
+            )
+        )
+        assert msg.original_message_name_id == "pain.001.001.09"
+        pstat = msg.payment_statuses[0]
+        assert pstat.original_payment_info_id == "PMT-0001"
+        assert pstat.statuses[0].transaction_status == "RJCT"
+        assert pstat.statuses[0].status_reason_code == "AC04"
+
+
+def _pain002_message():
+    from kotoba_iso20022.model import CustomerPaymentStatusReport
+
+    return CustomerPaymentStatusReport(
+        group_header=GroupHeader("STS-1", "2026-06-08T10:00:00Z", 0),
+        original_message_id="MSG-2026-0608-0001",
+        original_message_name_id="pain.001.001.09",
+        payment_statuses=(
+            OriginalPaymentStatus(
+                original_payment_info_id="PMT-0001",
+                statuses=(
+                    TransactionStatus(
+                        status_id="S1",
+                        original_end_to_end_id="E2E-0001",
+                        transaction_status="RJCT",
+                        status_reason_code="AC04",
+                        additional_info=("account closed",),
+                    ),
+                ),
+            ),
+        ),
+    )

--- a/py/kotoba_iso20022/tests/test_bridge.py
+++ b/py/kotoba_iso20022/tests/test_bridge.py
@@ -1,0 +1,157 @@
+"""Tests for the ISO 20022 → kawase ingressAttestation bridge.
+
+Also checks each produced record against the actual Lexicon JSON
+(required fields + no-float discipline).
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from kotoba_iso20022 import RECORD_TYPE, ingress_attestations
+from kotoba_iso20022.model import (
+    Account,
+    AccountNotification,
+    Agent,
+    Amount,
+    BankToCustomerDebitCreditNotification,
+    CreditTransferTransaction,
+    FIToFICustomerCreditTransfer,
+    FIToFIPaymentStatusReport,
+    GroupHeader,
+    Party,
+    RemittanceInfo,
+    StatementEntry,
+    TransactionStatus,
+)
+
+GOOD_UETR = "dced6a36-9e4b-4e2a-8b9f-2f3a4b5c6d7e"
+
+# Load the Lexicon's required fields once, from the canonical schema file.
+# kotoba_iso20022 is engine-core (a charter-clean ISO 20022 codec) but its
+# Datom/Lexicon bridge is verified against an etzhayyim Lexicon that lives in
+# the monorepo, NOT in a standalone kotoba checkout. Path resolves to the
+# monorepo root (tests/ -> kotoba_iso20022/ -> py/ -> kotoba/ -> 40-engine/ ->
+# monorepo root = parents[5]); the load degrades to a per-test skip when the
+# Lexicon is absent (upstream CI on a bare kotoba clone).
+_LEXICON_PATH = (
+    Path(__file__).resolve().parents[5]
+    / "00-contracts/lexicons/com/etzhayyim/iso20022/ingressAttestation.json"
+)
+_LEXICON = json.loads(_LEXICON_PATH.read_text()) if _LEXICON_PATH.exists() else None
+_REQUIRED = _LEXICON["defs"]["main"]["record"]["required"] if _LEXICON else []
+
+
+def _assert_lexicon_shape(rec: dict) -> None:
+    if _LEXICON is None:
+        pytest.skip(
+            "monorepo Lexicon absent (standalone kotoba checkout): "
+            "00-contracts/lexicons/com/etzhayyim/iso20022/ingressAttestation.json"
+        )
+    assert rec["$type"] == RECORD_TYPE
+    for field in _REQUIRED:
+        assert field in rec, f"missing required field {field}"
+    # No floats anywhere (amount must be string, not float).
+    assert isinstance(rec["amount"], str)
+    for v in rec.values():
+        assert not isinstance(v, float)
+
+
+def _pacs008() -> FIToFICustomerCreditTransfer:
+    tx = CreditTransferTransaction(
+        end_to_end_id="E2E-0001",
+        uetr=GOOD_UETR,
+        interbank_amount=Amount(Decimal("1000.00"), "EUR"),
+        debtor=Party("Alice Cohen"),
+        debtor_agent=Agent(bicfi="DEUTDEFF"),
+        creditor=Party("Bob Levi"),
+        creditor_agent=Agent(bicfi="NWBKGB2L"),
+    )
+    return FIToFICustomerCreditTransfer(
+        group_header=GroupHeader("MSG-1", "2026-06-08T09:30:00Z", 1, settlement_method="CLRG"),
+        transactions=(tx,),
+    )
+
+
+class TestPacs008Bridge:
+    def test_one_record_per_tx_with_lexicon_shape(self) -> None:
+        recs = ingress_attestations(
+            _pacs008(), ingested_at="2026-06-08T23:00:00Z", cbpr_conformant=True
+        )
+        assert len(recs) == 1
+        rec = recs[0]
+        _assert_lexicon_shape(rec)
+        assert rec["messageDefinition"] == "pacs.008.001.08"
+        assert rec["endToEndId"] == "E2E-0001"
+        assert rec["uetr"] == GOOD_UETR
+        assert rec["amount"] == "1000.00"
+        assert rec["currency"] == "EUR"
+        assert rec["reportedBy"] == "pacs.008"
+        assert rec["debtorAgentBic"] == "DEUTDEFF"
+        assert rec["creditorAgentBic"] == "NWBKGB2L"
+        assert rec["cbprConformant"] is True
+
+    def test_party_names_omitted_by_default(self) -> None:
+        rec = ingress_attestations(_pacs008(), ingested_at="2026-06-08T23:00:00Z")[0]
+        assert "debtorName" not in rec
+        assert "creditorName" not in rec
+
+    def test_party_names_opt_in(self) -> None:
+        rec = ingress_attestations(
+            _pacs008(), ingested_at="2026-06-08T23:00:00Z", include_party_names=True
+        )[0]
+        assert rec["debtorName"] == "Alice Cohen"
+        assert rec["creditorName"] == "Bob Levi"
+
+    def test_linked_deposit_cid_for_reconciliation(self) -> None:
+        rec = ingress_attestations(
+            _pacs008(), ingested_at="2026-06-08T23:00:00Z",
+            linked_deposit_cid="bafyreideposit",
+        )[0]
+        assert rec["linkedDepositCid"] == "bafyreideposit"
+
+    def test_tx_entity_matches_datom_entity(self) -> None:
+        from kotoba_iso20022 import to_datoms
+        rec = ingress_attestations(_pacs008(), ingested_at="2026-06-08T23:00:00Z")[0]
+        datom_entities = {d.entity for d in to_datoms(_pacs008())}
+        assert rec["txEntity"] in datom_entities
+
+
+class TestCamt054Bridge:
+    def test_entry_records(self) -> None:
+        entry = StatementEntry(
+            amount=Amount(Decimal("1000.00"), "EUR"),
+            credit_debit="CRDT",
+            status="BOOK",
+            end_to_end_id="E2E-0001",
+            remittance_info=RemittanceInfo(unstructured=("on-ramp",)),
+        )
+        msg = BankToCustomerDebitCreditNotification(
+            group_header=GroupHeader("CAMT-1", "2026-06-08T23:00:00Z", 0),
+            notifications=(
+                AccountNotification("N", "2026-06-08T23:05:00Z",
+                                    Account(iban="DE89370400440532013000"), (entry,)),
+            ),
+        )
+        rec = ingress_attestations(msg, ingested_at="2026-06-08T23:10:00Z")[0]
+        _assert_lexicon_shape(rec)
+        assert rec["reportedBy"] == "camt.054"
+        assert rec["creditDebit"] == "CRDT"
+        assert rec["status"] == "BOOK"
+        # reconciles onto the same entity a prior pacs.008 ingress used
+        assert rec["txEntity"] == "com.etzhayyim.iso20022/tx:E2E-0001"
+
+
+def test_status_report_rejected() -> None:
+    report = FIToFIPaymentStatusReport(
+        group_header=GroupHeader("STS-1", "2026-06-08T09:31:00Z", 0),
+        original_message_id="MSG-1",
+        original_message_name_id="pacs.008.001.08",
+        statuses=(TransactionStatus(status_id="S1", transaction_status="ACSC"),),
+    )
+    with pytest.raises(TypeError):
+        ingress_attestations(report, ingested_at="2026-06-08T23:10:00Z")

--- a/py/kotoba_iso20022/tests/test_camt.py
+++ b/py/kotoba_iso20022/tests/test_camt.py
@@ -1,0 +1,148 @@
+"""Round-trip + reconciliation tests for camt.053 / camt.054."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from decimal import Decimal
+
+import pytest
+
+from kotoba_iso20022 import (
+    DEFAULT_VERSIONS,
+    Iso20022CodecError,
+    build_camt053,
+    build_camt054,
+    parse_camt053,
+    parse_camt054,
+    to_datoms,
+    urn_for,
+)
+from kotoba_iso20022.datoms import NS
+from kotoba_iso20022.model import (
+    Account,
+    AccountNotification,
+    AccountStatement,
+    Amount,
+    BankToCustomerDebitCreditNotification,
+    BankToCustomerStatement,
+    CashBalance,
+    CreditTransferTransaction,
+    FIToFICustomerCreditTransfer,
+    GroupHeader,
+    RemittanceInfo,
+    StatementEntry,
+)
+
+_GH = GroupHeader(message_id="CAMT-1", creation_datetime="2026-06-08T23:00:00Z", number_of_txs=0)
+_ACCT = Account(iban="DE89370400440532013000", currency="EUR")
+
+
+def _entry() -> StatementEntry:
+    return StatementEntry(
+        amount=Amount(Decimal("1000.00"), "EUR"),
+        credit_debit="CRDT",
+        status="BOOK",
+        booking_date="2026-06-08",
+        value_date="2026-06-09",
+        account_servicer_reference="ACCTSVCR-77",
+        end_to_end_id="E2E-0001",
+        remittance_info=RemittanceInfo(unstructured=("kawase-yui on-ramp",)),
+    )
+
+
+class TestCamt053:
+    def test_roundtrip(self) -> None:
+        msg = BankToCustomerStatement(
+            group_header=_GH,
+            statements=(
+                AccountStatement(
+                    statement_id="STMT-1",
+                    creation_datetime="2026-06-08T23:00:00Z",
+                    account=_ACCT,
+                    balances=(
+                        CashBalance("OPBD", Amount(Decimal("0.00"), "EUR"), "CRDT", "2026-06-08"),
+                        CashBalance("CLBD", Amount(Decimal("1000.00"), "EUR"), "CRDT", "2026-06-08"),
+                    ),
+                    entries=(_entry(),),
+                ),
+            ),
+        )
+        back = parse_camt053(build_camt053(msg))
+        stmt = back.statements[0]
+        assert stmt.account.iban == "DE89370400440532013000"
+        assert len(stmt.balances) == 2
+        assert stmt.balances[1].balance_type == "CLBD"
+        assert stmt.balances[1].amount == Amount(Decimal("1000.00"), "EUR")
+        e = stmt.entries[0]
+        assert e.credit_debit == "CRDT"
+        assert e.status == "BOOK"
+        assert e.value_date == "2026-06-09"
+        assert e.end_to_end_id == "E2E-0001"
+        assert e.remittance_info.unstructured == ("kawase-yui on-ramp",)
+
+    def test_official_namespace(self) -> None:
+        msg = BankToCustomerStatement(
+            group_header=_GH,
+            statements=(
+                AccountStatement("S", "2026-06-08T23:00:00Z", _ACCT, (), (_entry(),)),
+            ),
+        )
+        root = ET.fromstring(build_camt053(msg))
+        assert root.tag == f"{{{urn_for(DEFAULT_VERSIONS['camt.053'])}}}Document"
+
+
+class TestCamt054:
+    def test_roundtrip(self) -> None:
+        msg = BankToCustomerDebitCreditNotification(
+            group_header=_GH,
+            notifications=(
+                AccountNotification(
+                    notification_id="NTF-1",
+                    creation_datetime="2026-06-08T23:05:00Z",
+                    account=_ACCT,
+                    entries=(_entry(),),
+                ),
+            ),
+        )
+        back = parse_camt054(build_camt054(msg))
+        ntf = back.notifications[0]
+        assert ntf.notification_id == "NTF-1"
+        assert ntf.entries[0].end_to_end_id == "E2E-0001"
+
+    def test_bad_namespace_raises(self) -> None:
+        msg = BankToCustomerDebitCreditNotification(
+            group_header=_GH,
+            notifications=(AccountNotification("N", "2026-06-08T23:05:00Z", _ACCT, (_entry(),)),),
+        )
+        xml = build_camt054(msg, version="camt.054.001.08")
+        with pytest.raises(Iso20022CodecError):
+            parse_camt054(xml, version="camt.054.001.10")
+
+
+def test_camt054_entry_reconciles_against_pacs008_ingress() -> None:
+    # An inbound pacs.008 lands first as ingress, keyed by EndToEndId.
+    pacs = FIToFICustomerCreditTransfer(
+        group_header=GroupHeader("M", "2026-06-08T09:30:00Z", 1, settlement_method="CLRG"),
+        transactions=(
+            CreditTransferTransaction(
+                end_to_end_id="E2E-0001",
+                interbank_amount=Amount(Decimal("1000.00"), "EUR"),
+            ),
+        ),
+    )
+    # Later a camt.054 credit notification arrives for the same EndToEndId.
+    camt = BankToCustomerDebitCreditNotification(
+        group_header=_GH,
+        notifications=(AccountNotification("N", "2026-06-08T23:05:00Z", _ACCT, (_entry(),)),),
+    )
+    ingress_entity = f"{NS}/tx:E2E-0001"
+    pacs_datoms = to_datoms(pacs)
+    camt_datoms = to_datoms(camt)
+    # Both reference the SAME content-addressed transaction entity.
+    assert any(d.entity == ingress_entity for d in pacs_datoms)
+    assert any(d.entity == ingress_entity for d in camt_datoms)
+    # The camt side asserts the booked-entry reconciliation facts.
+    camt_facts = {(d.attribute, d.value) for d in camt_datoms if d.entity == ingress_entity}
+    assert (f"{NS}.entry/creditDebit", "CRDT") in camt_facts
+    assert (f"{NS}.entry/status", "BOOK") in camt_facts
+    assert (f"{NS}.entry/reportedBy", "camt.054") in camt_facts

--- a/py/kotoba_iso20022/tests/test_codec.py
+++ b/py/kotoba_iso20022/tests/test_codec.py
@@ -1,0 +1,233 @@
+"""Round-trip + structural tests for the ISO 20022 codec."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from decimal import Decimal
+
+import pytest
+
+from kotoba_iso20022 import (
+    DEFAULT_VERSIONS,
+    Iso20022CodecError,
+    build_pacs002,
+    build_pacs008,
+    build_pain001,
+    parse_pacs002,
+    parse_pacs008,
+    parse_pain001,
+    urn_for,
+)
+from kotoba_iso20022.model import (
+    Account,
+    Agent,
+    Amount,
+    CreditTransferTransaction,
+    CustomerCreditTransferInitiation,
+    FIToFICustomerCreditTransfer,
+    FIToFIPaymentStatusReport,
+    GroupHeader,
+    Party,
+    PaymentInstruction,
+    RemittanceInfo,
+    TransactionStatus,
+)
+
+
+def _alice_to_bob_tx(*, interbank: bool) -> CreditTransferTransaction:
+    amt = Amount(Decimal("1000.00"), "EUR")
+    return CreditTransferTransaction(
+        end_to_end_id="E2E-0001",
+        instruction_id="INSTR-0001",
+        tx_id="TX-0001" if interbank else None,
+        uetr="dced6a36-9e4b-4e2a-8b9f-2f3a4b5c6d7e",
+        instructed_amount=None if interbank else amt,
+        interbank_amount=amt if interbank else None,
+        interbank_settlement_date="2026-06-08" if interbank else None,
+        charge_bearer="SLEV" if interbank else None,
+        debtor=Party("Alice Cohen", identifier="DE-ALICE"),
+        debtor_account=Account(iban="DE89370400440532013000"),
+        debtor_agent=Agent(bicfi="DEUTDEFF"),
+        creditor_agent=Agent(bicfi="NWBKGB2L"),
+        creditor=Party("Bob Levi"),
+        creditor_account=Account(iban="GB29NWBK60161331926819"),
+        remittance_info=RemittanceInfo(unstructured=("kawase-yui on-ramp", "ref 42")),
+    )
+
+
+def _group_header(*, pacs: bool) -> GroupHeader:
+    return GroupHeader(
+        message_id="MSG-2026-0608-0001",
+        creation_datetime="2026-06-08T09:30:00Z",
+        number_of_txs=1,
+        control_sum=Decimal("1000.00"),
+        initiating_party=None if pacs else Party("etzhayyim kawase-yui"),
+        settlement_method="CLRG" if pacs else None,
+    )
+
+
+class TestPain001:
+    def test_roundtrip(self) -> None:
+        msg = CustomerCreditTransferInitiation(
+            group_header=_group_header(pacs=False),
+            payments=(
+                PaymentInstruction(
+                    payment_info_id="PMT-0001",
+                    requested_execution_date="2026-06-08",
+                    debtor=Party("Alice Cohen"),
+                    debtor_account=Account(iban="DE89370400440532013000"),
+                    debtor_agent=Agent(bicfi="DEUTDEFF"),
+                    transactions=(_alice_to_bob_tx(interbank=False),),
+                ),
+            ),
+        )
+        xml = build_pain001(msg)
+        back = parse_pain001(xml)
+        tx = back.payments[0].transactions[0]
+        assert back.group_header.message_id == "MSG-2026-0608-0001"
+        assert tx.end_to_end_id == "E2E-0001"
+        assert tx.instructed_amount == Amount(Decimal("1000.00"), "EUR")
+        assert tx.creditor_account.iban == "GB29NWBK60161331926819"
+        assert tx.remittance_info.unstructured == ("kawase-yui on-ramp", "ref 42")
+
+    def test_namespace_is_official_urn(self) -> None:
+        msg = CustomerCreditTransferInitiation(
+            group_header=_group_header(pacs=False),
+            payments=(
+                PaymentInstruction(
+                    payment_info_id="PMT-0001",
+                    requested_execution_date="2026-06-08",
+                    debtor=Party("Alice"),
+                    debtor_account=Account(iban="DE89370400440532013000"),
+                    debtor_agent=Agent(bicfi="DEUTDEFF"),
+                    transactions=(_alice_to_bob_tx(interbank=False),),
+                ),
+            ),
+        )
+        xml = build_pain001(msg)
+        root = ET.fromstring(xml)
+        assert root.tag == f"{{{urn_for(DEFAULT_VERSIONS['pain.001'])}}}Document"
+
+    def test_missing_amount_raises(self) -> None:
+        bad_tx = CreditTransferTransaction(end_to_end_id="E2E", instructed_amount=None)
+        msg = CustomerCreditTransferInitiation(
+            group_header=_group_header(pacs=False),
+            payments=(
+                PaymentInstruction(
+                    payment_info_id="P",
+                    requested_execution_date="2026-06-08",
+                    debtor=Party("A"),
+                    debtor_account=Account(iban="DE89370400440532013000"),
+                    debtor_agent=Agent(bicfi="DEUTDEFF"),
+                    transactions=(bad_tx,),
+                ),
+            ),
+        )
+        with pytest.raises(Iso20022CodecError):
+            build_pain001(msg)
+
+
+class TestPacs008:
+    def test_roundtrip(self) -> None:
+        msg = FIToFICustomerCreditTransfer(
+            group_header=_group_header(pacs=True),
+            transactions=(_alice_to_bob_tx(interbank=True),),
+        )
+        xml = build_pacs008(msg)
+        back = parse_pacs008(xml)
+        tx = back.transactions[0]
+        assert back.group_header.settlement_method == "CLRG"
+        assert tx.tx_id == "TX-0001"
+        assert tx.uetr == "dced6a36-9e4b-4e2a-8b9f-2f3a4b5c6d7e"
+        assert tx.interbank_amount == Amount(Decimal("1000.00"), "EUR")
+        assert tx.interbank_settlement_date == "2026-06-08"
+        assert tx.charge_bearer == "SLEV"
+        assert tx.debtor_agent.bicfi == "DEUTDEFF"
+        assert tx.creditor_agent.bicfi == "NWBKGB2L"
+
+    def test_jpy_amount_formats_without_fraction(self) -> None:
+        tx = CreditTransferTransaction(
+            end_to_end_id="E2E-JPY",
+            interbank_amount=Amount(Decimal("500000"), "JPY"),
+        )
+        msg = FIToFICustomerCreditTransfer(
+            group_header=_group_header(pacs=True), transactions=(tx,)
+        )
+        xml = build_pacs008(msg)
+        assert ">500000<" in xml
+        back = parse_pacs008(xml)
+        assert back.transactions[0].interbank_amount.value == Decimal("500000")
+
+    def test_missing_interbank_amount_raises(self) -> None:
+        tx = CreditTransferTransaction(end_to_end_id="E2E", interbank_amount=None)
+        msg = FIToFICustomerCreditTransfer(
+            group_header=_group_header(pacs=True), transactions=(tx,)
+        )
+        with pytest.raises(Iso20022CodecError):
+            build_pacs008(msg)
+
+    def test_wrong_namespace_parse_raises(self) -> None:
+        msg = FIToFICustomerCreditTransfer(
+            group_header=_group_header(pacs=True),
+            transactions=(_alice_to_bob_tx(interbank=True),),
+        )
+        xml = build_pacs008(msg, version="pacs.008.001.08")
+        with pytest.raises(Iso20022CodecError):
+            parse_pacs008(xml, version="pacs.008.001.10")
+
+
+class TestPacs002:
+    def test_roundtrip_accepted(self) -> None:
+        msg = FIToFIPaymentStatusReport(
+            group_header=GroupHeader(
+                message_id="STS-0001",
+                creation_datetime="2026-06-08T09:31:00Z",
+                number_of_txs=0,
+            ),
+            original_message_id="MSG-2026-0608-0001",
+            original_message_name_id="pacs.008.001.08",
+            statuses=(
+                TransactionStatus(
+                    status_id="STSID-1",
+                    original_end_to_end_id="E2E-0001",
+                    original_uetr="dced6a36-9e4b-4e2a-8b9f-2f3a4b5c6d7e",
+                    transaction_status="ACSC",
+                ),
+            ),
+        )
+        xml = build_pacs002(msg)
+        back = parse_pacs002(xml)
+        assert back.original_message_name_id == "pacs.008.001.08"
+        assert back.statuses[0].transaction_status == "ACSC"
+        assert back.statuses[0].original_end_to_end_id == "E2E-0001"
+
+    def test_roundtrip_rejected_with_reason(self) -> None:
+        msg = FIToFIPaymentStatusReport(
+            group_header=GroupHeader(
+                message_id="STS-0002",
+                creation_datetime="2026-06-08T09:32:00Z",
+                number_of_txs=0,
+            ),
+            original_message_id="MSG-2026-0608-0001",
+            original_message_name_id="pacs.008.001.08",
+            statuses=(
+                TransactionStatus(
+                    status_id="STSID-2",
+                    original_end_to_end_id="E2E-0001",
+                    transaction_status="RJCT",
+                    status_reason_code="AC04",
+                    additional_info=("account closed",),
+                ),
+            ),
+        )
+        xml = build_pacs002(msg)
+        back = parse_pacs002(xml)
+        sts = back.statuses[0]
+        assert sts.transaction_status == "RJCT"
+        assert sts.status_reason_code == "AC04"
+        assert sts.additional_info == ("account closed",)
+
+
+def test_parse_garbage_raises() -> None:
+    with pytest.raises(Iso20022CodecError):
+        parse_pacs008("<not-xml")

--- a/py/kotoba_iso20022/tests/test_codec_errors.py
+++ b/py/kotoba_iso20022/tests/test_codec_errors.py
@@ -1,0 +1,165 @@
+"""Malformed-input error paths + optional-element build branches for codec."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from kotoba_iso20022 import (
+    Iso20022CodecError,
+    build_camt053,
+    build_pacs002,
+    build_pain002,
+    parse_camt053,
+    parse_camt054,
+    parse_pacs002,
+    parse_pacs008,
+    parse_pain001,
+    parse_pain002,
+)
+from kotoba_iso20022.model import (
+    Account,
+    AccountStatement,
+    Amount,
+    BankToCustomerStatement,
+    CashBalance,
+    CustomerPaymentStatusReport,
+    FIToFIPaymentStatusReport,
+    GroupHeader,
+    OriginalPaymentStatus,
+    StatementEntry,
+    TransactionStatus,
+)
+
+
+def _doc(msgdef: str, body: str) -> str:
+    ns = f"urn:iso:std:iso:20022:tech:xsd:{msgdef}"
+    return f"<?xml version='1.0'?><Document xmlns='{ns}'>{body}</Document>"
+
+
+# --------------------------------------------------------------------------
+# parse error paths
+# --------------------------------------------------------------------------
+
+
+def test_missing_group_header() -> None:
+    xml = _doc("pacs.008.001.08", "<FIToFICstmrCdtTrf></FIToFICstmrCdtTrf>")
+    with pytest.raises(Iso20022CodecError, match="GrpHdr"):
+        parse_pacs008(xml)
+
+
+def test_amount_missing_ccy_attribute() -> None:
+    body = (
+        "<FIToFICstmrCdtTrf>"
+        "<GrpHdr><MsgId>M</MsgId><CreDtTm>t</CreDtTm><NbOfTxs>1</NbOfTxs>"
+        "<SttlmInf><SttlmMtd>CLRG</SttlmMtd></SttlmInf></GrpHdr>"
+        "<CdtTrfTxInf><PmtId><EndToEndId>E</EndToEndId></PmtId>"
+        "<IntrBkSttlmAmt>10.00</IntrBkSttlmAmt></CdtTrfTxInf>"
+        "</FIToFICstmrCdtTrf>"
+    )
+    with pytest.raises(Iso20022CodecError, match="Ccy"):
+        parse_pacs008(_doc("pacs.008.001.08", body))
+
+
+def test_pain001_pmtinf_missing_debtor() -> None:
+    body = (
+        "<CstmrCdtTrfInitn>"
+        "<GrpHdr><MsgId>M</MsgId><CreDtTm>t</CreDtTm><NbOfTxs>1</NbOfTxs></GrpHdr>"
+        "<PmtInf><PmtInfId>P</PmtInfId><ReqdExctnDt>2026-06-08</ReqdExctnDt></PmtInf>"
+        "</CstmrCdtTrfInitn>"
+    )
+    with pytest.raises(Iso20022CodecError, match="Dbtr"):
+        parse_pain001(_doc("pain.001.001.09", body))
+
+
+def test_camt053_stmt_missing_acct() -> None:
+    body = (
+        "<BkToCstmrStmt><GrpHdr><MsgId>M</MsgId><CreDtTm>t</CreDtTm></GrpHdr>"
+        "<Stmt><Id>S</Id><CreDtTm>t</CreDtTm></Stmt></BkToCstmrStmt>"
+    )
+    with pytest.raises(Iso20022CodecError, match="Acct"):
+        parse_camt053(_doc("camt.053.001.08", body))
+
+
+def test_camt053_balance_missing_amt() -> None:
+    body = (
+        "<BkToCstmrStmt><GrpHdr><MsgId>M</MsgId><CreDtTm>t</CreDtTm></GrpHdr>"
+        "<Stmt><Id>S</Id><CreDtTm>t</CreDtTm>"
+        "<Acct><Id><IBAN>DE89370400440532013000</IBAN></Id></Acct>"
+        "<Bal><Tp><CdOrPrtry><Cd>OPBD</Cd></CdOrPrtry></Tp>"
+        "<CdtDbtInd>CRDT</CdtDbtInd><Dt><Dt>2026-06-08</Dt></Dt></Bal>"
+        "</Stmt></BkToCstmrStmt>"
+    )
+    with pytest.raises(Iso20022CodecError, match="Bal missing Amt"):
+        parse_camt053(_doc("camt.053.001.08", body))
+
+
+def test_camt053_entry_missing_amt() -> None:
+    body = (
+        "<BkToCstmrStmt><GrpHdr><MsgId>M</MsgId><CreDtTm>t</CreDtTm></GrpHdr>"
+        "<Stmt><Id>S</Id><CreDtTm>t</CreDtTm>"
+        "<Acct><Id><IBAN>DE89370400440532013000</IBAN></Id></Acct>"
+        "<Ntry><CdtDbtInd>CRDT</CdtDbtInd><Sts>BOOK</Sts></Ntry>"
+        "</Stmt></BkToCstmrStmt>"
+    )
+    with pytest.raises(Iso20022CodecError, match="Ntry missing Amt"):
+        parse_camt053(_doc("camt.053.001.08", body))
+
+
+def test_camt054_ntfctn_missing_acct() -> None:
+    body = (
+        "<BkToCstmrDbtCdtNtfctn><GrpHdr><MsgId>M</MsgId><CreDtTm>t</CreDtTm></GrpHdr>"
+        "<Ntfctn><Id>N</Id><CreDtTm>t</CreDtTm></Ntfctn></BkToCstmrDbtCdtNtfctn>"
+    )
+    with pytest.raises(Iso20022CodecError, match="Acct"):
+        parse_camt054(_doc("camt.054.001.08", body))
+
+
+# --------------------------------------------------------------------------
+# optional-element build branches (OrgnlTxId, BkTxCd)
+# --------------------------------------------------------------------------
+
+
+def test_pacs002_with_original_tx_id() -> None:
+    msg = FIToFIPaymentStatusReport(
+        group_header=GroupHeader("STS", "t", 0),
+        original_message_id="M", original_message_name_id="pacs.008.001.08",
+        statuses=(TransactionStatus(status_id="S", original_tx_id="TX-9",
+                                    transaction_status="ACSC"),),
+    )
+    back = parse_pacs002(build_pacs002(msg))
+    assert back.statuses[0].original_tx_id == "TX-9"
+
+
+def test_pain002_with_original_tx_id() -> None:
+    msg = CustomerPaymentStatusReport(
+        group_header=GroupHeader("STS", "t", 0),
+        original_message_id="M", original_message_name_id="pain.001.001.09",
+        payment_statuses=(
+            OriginalPaymentStatus(
+                original_payment_info_id="P",
+                statuses=(TransactionStatus(status_id="S", original_tx_id="TX-7",
+                                            transaction_status="ACSP"),),
+            ),
+        ),
+    )
+    back = parse_pain002(build_pain002(msg))
+    assert back.payment_statuses[0].statuses[0].original_tx_id == "TX-7"
+
+
+def test_camt053_entry_with_bank_transaction_code() -> None:
+    entry = StatementEntry(
+        amount=Amount(Decimal("1.00"), "EUR"), credit_debit="CRDT", status="BOOK",
+        end_to_end_id="E", bank_transaction_code="PMNT",
+    )
+    msg = BankToCustomerStatement(
+        group_header=GroupHeader("CS", "t", 0),
+        statements=(AccountStatement("S", "t", Account(iban="DE89370400440532013000"),
+                                     (CashBalance("OPBD", Amount(Decimal("0"), "EUR"),
+                                                  "CRDT", "2026-06-08"),), (entry,)),),
+    )
+    xml = build_camt053(msg)
+    assert "<BkTxCd>" in xml
+    back = parse_camt053(xml)
+    assert back.statements[0].entries[0].bank_transaction_code == "PMNT"

--- a/py/kotoba_iso20022/tests/test_conformance.py
+++ b/py/kotoba_iso20022/tests/test_conformance.py
@@ -1,0 +1,132 @@
+"""Tests for the CBPR+ Usage-Guideline conformance checker."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from kotoba_iso20022 import (
+    CbprConformanceError,
+    assert_cbpr_pacs008,
+    check_cbpr_bah,
+    check_cbpr_pacs008,
+    validate_uetr,
+)
+from kotoba_iso20022.model import (
+    Agent,
+    Amount,
+    BusinessApplicationHeader,
+    CreditTransferTransaction,
+    FIToFICustomerCreditTransfer,
+    GroupHeader,
+    Party,
+)
+from kotoba_iso20022.validate import InvalidUetr, is_uetr
+
+GOOD_UETR = "dced6a36-9e4b-4e2a-8b9f-2f3a4b5c6d7e"
+
+
+def _good_tx(**over) -> CreditTransferTransaction:
+    base = {
+        "end_to_end_id": "E2E-1",
+        "uetr": GOOD_UETR,
+        "interbank_amount": Amount(Decimal("1000.00"), "EUR"),
+        "charge_bearer": "SHAR",
+        "debtor": Party("Alice Cohen"),
+        "debtor_agent": Agent(bicfi="DEUTDEFF"),
+        "creditor": Party("Bob Levi"),
+        "creditor_agent": Agent(bicfi="NWBKGB2L"),
+    }
+    base.update(over)
+    return CreditTransferTransaction(**base)
+
+
+def _msg(tx: CreditTransferTransaction, *, nb: int = 1, ctrl=None) -> FIToFICustomerCreditTransfer:
+    return FIToFICustomerCreditTransfer(
+        group_header=GroupHeader("M", "2026-06-08T09:30:00Z", nb, control_sum=ctrl,
+                                 settlement_method="CLRG"),
+        transactions=(tx,),
+    )
+
+
+class TestUetr:
+    def test_valid(self) -> None:
+        assert is_uetr(GOOD_UETR)
+        assert validate_uetr(GOOD_UETR) == GOOD_UETR
+
+    @pytest.mark.parametrize("bad", [
+        "DCED6A36-9E4B-4E2A-8B9F-2F3A4B5C6D7E",  # uppercase
+        "dced6a36-9e4b-1e2a-8b9f-2f3a4b5c6d7e",  # version nibble != 4
+        "dced6a36-9e4b-4e2a-7b9f-2f3a4b5c6d7e",  # variant nibble bad
+        "not-a-uuid",
+    ])
+    def test_invalid(self, bad: str) -> None:
+        assert not is_uetr(bad)
+        with pytest.raises(InvalidUetr):
+            validate_uetr(bad)
+
+
+class TestPacs008Conformance:
+    def test_clean_message_has_no_issues(self) -> None:
+        assert check_cbpr_pacs008(_msg(_good_tx(), ctrl=Decimal("1000.00"))) == []
+
+    def test_missing_uetr(self) -> None:
+        issues = check_cbpr_pacs008(_msg(_good_tx(uetr=None)))
+        assert any(i.rule_id == "CBPR-002" for i in issues)
+
+    def test_bad_uetr_format(self) -> None:
+        issues = check_cbpr_pacs008(_msg(_good_tx(uetr="not-a-uuid")))
+        assert any(i.rule_id == "CBPR-003" for i in issues)
+
+    def test_slev_charge_bearer_rejected(self) -> None:
+        # SLEV is SEPA, not CBPR+
+        issues = check_cbpr_pacs008(_msg(_good_tx(charge_bearer="SLEV")))
+        assert any(i.rule_id == "CBPR-005" for i in issues)
+
+    def test_missing_creditor_agent_bic(self) -> None:
+        issues = check_cbpr_pacs008(_msg(_good_tx(creditor_agent=None)))
+        assert any(i.rule_id == "CBPR-006" and "CdtrAgt" in i.location for i in issues)
+
+    def test_agent_name_with_bic_rejected(self) -> None:
+        issues = check_cbpr_pacs008(_msg(_good_tx(debtor_agent=Agent(bicfi="DEUTDEFF", name="DB"))))
+        assert any(i.rule_id == "CBPR-007" for i in issues)
+
+    def test_nboftxs_mismatch(self) -> None:
+        issues = check_cbpr_pacs008(_msg(_good_tx(), nb=5))
+        assert any(i.rule_id == "CBPR-001" for i in issues)
+
+    def test_control_sum_mismatch(self) -> None:
+        issues = check_cbpr_pacs008(_msg(_good_tx(), ctrl=Decimal("999.99")))
+        assert any(i.rule_id == "CBPR-008" for i in issues)
+
+    def test_missing_creditor_name(self) -> None:
+        issues = check_cbpr_pacs008(_msg(_good_tx(creditor=Party(""))))
+        assert any(i.rule_id == "CBPR-009" for i in issues)
+
+    def test_assert_raises_on_error(self) -> None:
+        with pytest.raises(CbprConformanceError):
+            assert_cbpr_pacs008(_msg(_good_tx(uetr=None)))
+
+    def test_assert_passes_clean(self) -> None:
+        assert_cbpr_pacs008(_msg(_good_tx(), ctrl=Decimal("1000.00")))  # no raise
+
+
+class TestBahConformance:
+    def test_clean(self) -> None:
+        bah = BusinessApplicationHeader(
+            from_bic="DEUTDEFF", to_bic="NWBKGB2L", business_message_id="B",
+            message_definition="pacs.008.001.08", creation_datetime="2026-06-08T09:30:00Z",
+            business_service="swift.cbprplus.02",
+        )
+        assert check_cbpr_bah(bah, "pacs.008.001.08") == []
+
+    def test_msgdef_mismatch_and_bizsvc_warning(self) -> None:
+        bah = BusinessApplicationHeader(
+            from_bic="DEUTDEFF", to_bic="NWBKGB2L", business_message_id="B",
+            message_definition="pain.001.001.09", creation_datetime="2026-06-08T09:30:00Z",
+            business_service=None,
+        )
+        issues = check_cbpr_bah(bah, "pacs.008.001.08")
+        assert any(i.rule_id == "CBPR-010" for i in issues)
+        assert any(i.rule_id == "CBPR-011" and i.severity == "warning" for i in issues)

--- a/py/kotoba_iso20022/tests/test_datoms.py
+++ b/py/kotoba_iso20022/tests/test_datoms.py
@@ -1,0 +1,92 @@
+"""Tests for the ISO 20022 → kotoba EAVT Datom ingress mapping."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from kotoba_iso20022 import to_datoms
+from kotoba_iso20022.datoms import NS
+from kotoba_iso20022.model import (
+    Account,
+    Agent,
+    Amount,
+    CreditTransferTransaction,
+    FIToFICustomerCreditTransfer,
+    FIToFIPaymentStatusReport,
+    GroupHeader,
+    Party,
+    TransactionStatus,
+)
+
+
+def _pacs008() -> FIToFICustomerCreditTransfer:
+    tx = CreditTransferTransaction(
+        end_to_end_id="E2E-0001",
+        tx_id="TX-0001",
+        uetr="dced6a36-9e4b-4e2a-8b9f-2f3a4b5c6d7e",
+        interbank_amount=Amount(Decimal("1000.00"), "EUR"),
+        interbank_settlement_date="2026-06-08",
+        charge_bearer="SLEV",
+        debtor=Party("Alice Cohen"),
+        debtor_account=Account(iban="DE89370400440532013000"),
+        debtor_agent=Agent(bicfi="DEUTDEFF"),
+        creditor=Party("Bob Levi"),
+        creditor_account=Account(iban="GB29NWBK60161331926819"),
+        creditor_agent=Agent(bicfi="NWBKGB2L"),
+    )
+    return FIToFICustomerCreditTransfer(
+        group_header=GroupHeader(
+            message_id="MSG-1", creation_datetime="2026-06-08T09:30:00Z", number_of_txs=1
+        ),
+        transactions=(tx,),
+    )
+
+
+def test_entity_is_content_addressed_on_uetr() -> None:
+    datoms = to_datoms(_pacs008())
+    tx_entity = f"{NS}/tx:dced6a36-9e4b-4e2a-8b9f-2f3a4b5c6d7e"
+    assert any(d.entity == tx_entity for d in datoms)
+
+
+def test_all_ops_are_assertions() -> None:
+    # ingress never retracts (kawase-yui G11 mirror)
+    assert all(d.op is True for d in to_datoms(_pacs008()))
+
+
+def test_idempotent_entity_handles() -> None:
+    # re-mapping the same message yields identical (e, a, v) tuples
+    a = [d.as_tuple() for d in to_datoms(_pacs008())]
+    b = [d.as_tuple() for d in to_datoms(_pacs008())]
+    assert a == b
+
+
+def test_core_facts_present() -> None:
+    facts = {(d.attribute, d.value) for d in to_datoms(_pacs008())}
+    assert (f"{NS}.tx/amount", "1000.00") in facts
+    assert (f"{NS}.tx/currency", "EUR") in facts
+    assert (f"{NS}.tx/debtorIban", "DE89370400440532013000") in facts
+    assert (f"{NS}.tx/creditorAgentBic", "NWBKGB2L") in facts
+    assert (f"{NS}.msg/definition", "pacs.008") in facts
+
+
+def test_pacs002_status_lands_on_same_tx_entity() -> None:
+    report = FIToFIPaymentStatusReport(
+        group_header=GroupHeader(
+            message_id="STS-1", creation_datetime="2026-06-08T09:31:00Z", number_of_txs=0
+        ),
+        original_message_id="MSG-1",
+        original_message_name_id="pacs.008.001.08",
+        statuses=(
+            TransactionStatus(
+                status_id="S1",
+                original_uetr="dced6a36-9e4b-4e2a-8b9f-2f3a4b5c6d7e",
+                transaction_status="ACSC",
+            ),
+        ),
+    )
+    datoms = to_datoms(report)
+    tx_entity = f"{NS}/tx:dced6a36-9e4b-4e2a-8b9f-2f3a4b5c6d7e"
+    assert any(
+        d.entity == tx_entity and d.attribute == f"{NS}.tx/status" and d.value == "ACSC"
+        for d in datoms
+    )

--- a/py/kotoba_iso20022/tests/test_edges.py
+++ b/py/kotoba_iso20022/tests/test_edges.py
@@ -1,0 +1,373 @@
+"""Edge-case + error-path coverage across all modules."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from kotoba_iso20022 import (
+    Iso20022CodecError,
+    build_pacs008,
+    build_pain001,
+    control_sum_of,
+    ingress_attestations,
+    new_uetr,
+    pacs008_group_header,
+    pain001_group_header,
+    parse_pacs008,
+    parse_pain001,
+    to_datoms,
+)
+from kotoba_iso20022.bah import (
+    build_business_message,
+    parse_bah,
+    parse_business_message,
+)
+from kotoba_iso20022.conformance import check_cbpr_bah, check_cbpr_pacs008
+from kotoba_iso20022.datoms import NS
+from kotoba_iso20022.model import (
+    Account,
+    AccountStatement,
+    Agent,
+    Amount,
+    BankToCustomerStatement,
+    BusinessApplicationHeader,
+    CashBalance,
+    CreditTransferTransaction,
+    CustomerCreditTransferInitiation,
+    FIToFICustomerCreditTransfer,
+    GroupHeader,
+    Party,
+    PaymentInstruction,
+    PostalAddress,
+    StatementEntry,
+)
+from kotoba_iso20022.validate import is_uetr
+
+# --------------------------------------------------------------------------
+# model __post_init__ validation
+# --------------------------------------------------------------------------
+
+
+class TestModelValidation:
+    def test_account_requires_an_id(self) -> None:
+        with pytest.raises(ValueError):
+            Account()
+
+    def test_agent_requires_bic_or_member_id(self) -> None:
+        with pytest.raises(ValueError):
+            Agent()
+
+    def test_account_other_id_ok(self) -> None:
+        assert Account(other_id="123").other_id == "123"
+
+    def test_agent_clearing_member_ok(self) -> None:
+        assert Agent(clearing_member_id="USABA021000021").clearing_member_id
+
+
+# --------------------------------------------------------------------------
+# codec optional branches (other_id account, clearing member, postal address)
+# --------------------------------------------------------------------------
+
+
+class TestCodecOptionalBranches:
+    def test_pacs008_with_other_id_and_clearing_member_and_address(self) -> None:
+        tx = CreditTransferTransaction(
+            end_to_end_id="E2E",
+            interbank_amount=Amount(Decimal("10.00"), "USD"),
+            debtor=Party("Acme", postal_address=PostalAddress("US", ("1 Main St",)),
+                         identifier="LEI123"),
+            debtor_account=Account(other_id="ACCT-1", currency="USD"),
+            debtor_agent=Agent(clearing_member_id="021000021"),
+            creditor_agent=Agent(bicfi="NWBKGB2L", name="NatWest"),
+            creditor=Party("Bob"),
+            creditor_account=Account(other_id="C-1"),
+        )
+        msg = FIToFICustomerCreditTransfer(
+            group_header=pacs008_group_header("M", "2026-06-08T09:30:00Z", (tx,)),
+            transactions=(tx,),
+        )
+        back = parse_pacs008(build_pacs008(msg))
+        rtx = back.transactions[0]
+        assert rtx.debtor.postal_address.country == "US"
+        assert rtx.debtor.identifier == "LEI123"
+        assert rtx.debtor_account.other_id == "ACCT-1"
+        assert rtx.debtor_agent.clearing_member_id == "021000021"
+        assert rtx.creditor_agent.name == "NatWest"
+
+    def test_pain001_multiple_transactions_roundtrip(self) -> None:
+        txs = tuple(
+            CreditTransferTransaction(
+                end_to_end_id=f"E2E-{i}",
+                instructed_amount=Amount(Decimal("10.00"), "EUR"),
+                creditor=Party(f"C{i}"),
+                creditor_account=Account(iban="GB29NWBK60161331926819"),
+            )
+            for i in range(3)
+        )
+        msg = CustomerCreditTransferInitiation(
+            group_header=pain001_group_header("M", "2026-06-08T09:30:00Z", txs,
+                                              initiating_party=Party("Org")),
+            payments=(
+                PaymentInstruction(
+                    payment_info_id="P", requested_execution_date="2026-06-08",
+                    debtor=Party("Alice"),
+                    debtor_account=Account(iban="DE89370400440532013000"),
+                    debtor_agent=Agent(bicfi="DEUTDEFF"),
+                    transactions=txs,
+                ),
+            ),
+        )
+        back = parse_pain001(build_pain001(msg))
+        assert len(back.payments[0].transactions) == 3
+        assert back.group_header.control_sum == Decimal("30.00")
+
+
+# --------------------------------------------------------------------------
+# datoms: pain.001 + camt.053 paths
+# --------------------------------------------------------------------------
+
+
+class TestDatomsPaths:
+    def test_pain001_datoms(self) -> None:
+        tx = CreditTransferTransaction(
+            end_to_end_id="E2E-P", instructed_amount=Amount(Decimal("5.00"), "EUR")
+        )
+        msg = CustomerCreditTransferInitiation(
+            group_header=GroupHeader("MP", "2026-06-08T09:30:00Z", 1),
+            payments=(
+                PaymentInstruction(
+                    payment_info_id="P", requested_execution_date="2026-06-08",
+                    debtor=Party("Alice"),
+                    debtor_account=Account(iban="DE89370400440532013000"),
+                    debtor_agent=Agent(bicfi="DEUTDEFF"),
+                    transactions=(tx,),
+                ),
+            ),
+        )
+        facts = {(d.attribute, d.value) for d in to_datoms(msg)}
+        assert (f"{NS}.msg/definition", "pain.001") in facts
+        assert (f"{NS}.tx/amount", "5.00") in facts
+
+    def test_camt053_datoms(self) -> None:
+        entry = StatementEntry(
+            amount=Amount(Decimal("7.00"), "EUR"), credit_debit="DBIT", status="BOOK",
+            account_servicer_reference="SVCR-9", value_date="2026-06-09",
+        )
+        msg = BankToCustomerStatement(
+            group_header=GroupHeader("CS", "2026-06-08T23:00:00Z", 0),
+            statements=(
+                AccountStatement("S", "2026-06-08T23:00:00Z",
+                                 Account(iban="DE89370400440532013000"),
+                                 (CashBalance("OPBD", Amount(Decimal("0"), "EUR"), "CRDT",
+                                              "2026-06-08"),),
+                                 (entry,)),
+            ),
+        )
+        facts = {(d.attribute, d.value) for d in to_datoms(msg)}
+        assert (f"{NS}.msg/definition", "camt.053") in facts
+        assert (f"{NS}.entry/reportedBy", "camt.053") in facts
+        assert (f"{NS}.entry/creditDebit", "DBIT") in facts
+
+
+# --------------------------------------------------------------------------
+# bridge: pain.001 path + entry without ref skipped
+# --------------------------------------------------------------------------
+
+
+class TestBridgeEdges:
+    def test_pain001_bridge(self) -> None:
+        tx = CreditTransferTransaction(
+            end_to_end_id="E2E-P", uetr=new_uetr(),
+            instructed_amount=Amount(Decimal("5.00"), "EUR"),
+        )
+        msg = CustomerCreditTransferInitiation(
+            group_header=GroupHeader("MP", "2026-06-08T09:30:00Z", 1),
+            payments=(
+                PaymentInstruction(
+                    payment_info_id="P", requested_execution_date="2026-06-08",
+                    debtor=Party("Alice"),
+                    debtor_account=Account(iban="DE89370400440532013000"),
+                    debtor_agent=Agent(bicfi="DEUTDEFF"),
+                    transactions=(tx,),
+                ),
+            ),
+        )
+        recs = ingress_attestations(msg, ingested_at="2026-06-08T23:00:00Z")
+        assert recs[0]["reportedBy"] == "pain.001"
+        assert recs[0]["amount"] == "5.00"
+
+    def test_entry_without_ref_is_skipped(self) -> None:
+        from kotoba_iso20022.model import AccountNotification, BankToCustomerDebitCreditNotification
+        entry = StatementEntry(amount=Amount(Decimal("1"), "EUR"), credit_debit="CRDT",
+                               status="BOOK")  # no end_to_end_id, no acct_svcr_ref
+        msg = BankToCustomerDebitCreditNotification(
+            group_header=GroupHeader("C", "2026-06-08T23:00:00Z", 0),
+            notifications=(AccountNotification("N", "2026-06-08T23:00:00Z",
+                                               Account(iban="DE89370400440532013000"), (entry,)),),
+        )
+        assert ingress_attestations(msg, ingested_at="2026-06-08T23:00:00Z") == []
+
+
+# --------------------------------------------------------------------------
+# bah error paths
+# --------------------------------------------------------------------------
+
+
+def _bah() -> BusinessApplicationHeader:
+    return BusinessApplicationHeader(
+        from_bic="DEUTDEFF", to_bic="NWBKGB2L", business_message_id="B",
+        message_definition="pacs.008.001.08", creation_datetime="2026-06-08T09:30:00Z",
+    )
+
+
+class TestBahErrors:
+    def test_parse_bad_xml(self) -> None:
+        with pytest.raises(Iso20022CodecError):
+            parse_bah("<nope")
+
+    def test_parse_wrong_root(self) -> None:
+        with pytest.raises(Iso20022CodecError):
+            parse_bah("<Document xmlns='urn:iso:std:iso:20022:tech:xsd:head.001.001.02'/>")
+
+    def test_parse_missing_bic(self) -> None:
+        ns = "urn:iso:std:iso:20022:tech:xsd:head.001.001.02"
+        xml = f"<AppHdr xmlns='{ns}'><BizMsgIdr>B</BizMsgIdr></AppHdr>"
+        with pytest.raises(Iso20022CodecError):
+            parse_bah(xml)
+
+    def test_envelope_payload_not_document(self) -> None:
+        with pytest.raises(Iso20022CodecError):
+            build_business_message(_bah(), "<NotDocument/>")
+
+    def test_envelope_non_iso_namespace(self) -> None:
+        with pytest.raises(Iso20022CodecError):
+            build_business_message(_bah(), "<Document xmlns='http://example.com'/>")
+
+    def test_parse_envelope_missing_parts(self) -> None:
+        with pytest.raises(Iso20022CodecError):
+            parse_business_message("<Envelope/>")
+
+    def test_parse_envelope_bad_xml(self) -> None:
+        with pytest.raises(Iso20022CodecError):
+            parse_business_message("<Envelope")
+
+
+# --------------------------------------------------------------------------
+# conformance: invalid (not just missing) agent BIC + bah BIC
+# --------------------------------------------------------------------------
+
+
+class TestConformanceInvalidBic:
+    def test_invalid_agent_bic(self) -> None:
+        tx = CreditTransferTransaction(
+            end_to_end_id="E", uetr=new_uetr(),
+            interbank_amount=Amount(Decimal("1.00"), "EUR"),
+            charge_bearer="SHAR",
+            debtor=Party("A"), debtor_agent=Agent(bicfi="BADBIC!!"),
+            creditor=Party("B"), creditor_agent=Agent(bicfi="NWBKGB2L"),
+        )
+        msg = FIToFICustomerCreditTransfer(
+            group_header=pacs008_group_header("M", "2026-06-08T09:30:00Z", (tx,)),
+            transactions=(tx,),
+        )
+        assert any(i.rule_id == "CBPR-006" for i in check_cbpr_pacs008(msg))
+
+    def test_bah_invalid_bic(self) -> None:
+        bah = BusinessApplicationHeader(
+            from_bic="BAD", to_bic="NWBKGB2L", business_message_id="B",
+            message_definition="pacs.008.001.08", creation_datetime="2026-06-08T09:30:00Z",
+            business_service="swift.cbprplus.02",
+        )
+        assert any(i.rule_id == "CBPR-006" for i in check_cbpr_bah(bah))
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+
+
+class TestAmountValidationEdges:
+    def test_non_decimal_string(self) -> None:
+        from kotoba_iso20022 import validate_amount
+        from kotoba_iso20022.validate import InvalidAmount
+        with pytest.raises(InvalidAmount):
+            validate_amount("not-a-number", "USD")
+
+    def test_nan(self) -> None:
+        from kotoba_iso20022 import validate_amount
+        from kotoba_iso20022.validate import InvalidAmount
+        with pytest.raises(InvalidAmount):
+            validate_amount(Decimal("NaN"), "USD")
+
+    def test_infinity(self) -> None:
+        from kotoba_iso20022 import validate_amount
+        from kotoba_iso20022.validate import InvalidAmount
+        with pytest.raises(InvalidAmount):
+            validate_amount(Decimal("Infinity"), "USD")
+
+
+class TestCamt053Bridge:
+    def test_statement_entries_bridged(self) -> None:
+        entry = StatementEntry(
+            amount=Amount(Decimal("9.00"), "EUR"), credit_debit="CRDT", status="BOOK",
+            end_to_end_id="E2E-S",
+        )
+        msg = BankToCustomerStatement(
+            group_header=GroupHeader("CS", "2026-06-08T23:00:00Z", 0),
+            statements=(
+                AccountStatement("S", "2026-06-08T23:00:00Z",
+                                 Account(iban="DE89370400440532013000"), (), (entry,)),
+            ),
+        )
+        recs = ingress_attestations(msg, ingested_at="2026-06-08T23:10:00Z")
+        assert recs[0]["reportedBy"] == "camt.053"
+        assert recs[0]["amount"] == "9.00"
+
+
+class TestConformanceMissingFields:
+    def test_missing_amount_and_debtor(self) -> None:
+        tx = CreditTransferTransaction(
+            end_to_end_id="E", uetr=new_uetr(),
+            interbank_amount=None,            # CBPR-004
+            creditor=Party("B"), creditor_agent=Agent(bicfi="NWBKGB2L"),
+            debtor=None, debtor_agent=None,   # CBPR-006 + CBPR-009
+        )
+        msg = FIToFICustomerCreditTransfer(
+            group_header=GroupHeader("M", "2026-06-08T09:30:00Z", 1, settlement_method="CLRG"),
+            transactions=(tx,),
+        )
+        ids = {i.rule_id for i in check_cbpr_pacs008(msg)}
+        assert {"CBPR-004", "CBPR-006", "CBPR-009"} <= ids
+
+
+class TestHelpers:
+    def test_new_uetr_is_valid(self) -> None:
+        assert is_uetr(new_uetr())
+
+    def test_new_uetr_unique(self) -> None:
+        assert new_uetr() != new_uetr()
+
+    def test_control_sum(self) -> None:
+        txs = (
+            CreditTransferTransaction(end_to_end_id="1", interbank_amount=Amount(Decimal("1.50"), "EUR")),
+            CreditTransferTransaction(end_to_end_id="2", instructed_amount=Amount(Decimal("2.50"), "EUR")),
+            CreditTransferTransaction(end_to_end_id="3"),  # no amount → 0
+        )
+        assert control_sum_of(txs) == Decimal("4.00")
+
+    def test_generated_pacs008_header_is_cbpr_clean(self) -> None:
+        tx = CreditTransferTransaction(
+            end_to_end_id="E", uetr=new_uetr(),
+            interbank_amount=Amount(Decimal("1000.00"), "EUR"), charge_bearer="SHAR",
+            debtor=Party("A"), debtor_agent=Agent(bicfi="DEUTDEFF"),
+            creditor=Party("B"), creditor_agent=Agent(bicfi="NWBKGB2L"),
+        )
+        msg = FIToFICustomerCreditTransfer(
+            group_header=pacs008_group_header("M", "2026-06-08T09:30:00Z", (tx,)),
+            transactions=(tx,),
+        )
+        # NbOfTxs + CtrlSum derived → no CBPR-001/008 findings
+        ids = {i.rule_id for i in check_cbpr_pacs008(msg)}
+        assert "CBPR-001" not in ids and "CBPR-008" not in ids

--- a/py/kotoba_iso20022/tests/test_pacs004.py
+++ b/py/kotoba_iso20022/tests/test_pacs004.py
@@ -1,0 +1,133 @@
+"""pacs.004 PaymentReturn — round-trip + reversal reconciliation."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from decimal import Decimal
+
+import pytest
+
+from kotoba_iso20022 import (
+    DEFAULT_VERSIONS,
+    Iso20022CodecError,
+    build_pacs004,
+    parse_pacs004,
+    to_datoms,
+    urn_for,
+)
+from kotoba_iso20022.datoms import NS
+from kotoba_iso20022.model import (
+    Amount,
+    CreditTransferTransaction,
+    FIToFICustomerCreditTransfer,
+    GroupHeader,
+    PaymentReturn,
+    PaymentReturnTransaction,
+)
+
+GOOD_UETR = "dced6a36-9e4b-4e2a-8b9f-2f3a4b5c6d7e"
+
+
+def _return() -> PaymentReturn:
+    tx = PaymentReturnTransaction(
+        returned_interbank_amount=Amount(Decimal("1000.00"), "EUR"),
+        return_id="RTR-1",
+        original_end_to_end_id="E2E-0001",
+        original_tx_id="TX-0001",
+        original_uetr=GOOD_UETR,
+        original_interbank_amount=Amount(Decimal("1000.00"), "EUR"),
+        interbank_settlement_date="2026-06-10",
+        return_reason_code="AC04",  # account closed
+        additional_info=("beneficiary account closed",),
+    )
+    return PaymentReturn(
+        group_header=GroupHeader("RTN-1", "2026-06-10T09:00:00Z", 1, settlement_method="CLRG"),
+        transactions=(tx,),
+        original_message_id="MSG-2026-0608-0001",
+        original_message_name_id="pacs.008.001.08",
+    )
+
+
+class TestRoundTrip:
+    def test_roundtrip(self) -> None:
+        back = parse_pacs004(build_pacs004(_return()))
+        assert back.original_message_name_id == "pacs.008.001.08"
+        tx = back.transactions[0]
+        assert tx.return_id == "RTR-1"
+        assert tx.original_uetr == GOOD_UETR
+        assert tx.original_end_to_end_id == "E2E-0001"
+        assert tx.returned_interbank_amount == Amount(Decimal("1000.00"), "EUR")
+        assert tx.original_interbank_amount == Amount(Decimal("1000.00"), "EUR")
+        assert tx.return_reason_code == "AC04"
+        assert tx.additional_info == ("beneficiary account closed",)
+        assert tx.interbank_settlement_date == "2026-06-10"
+
+    def test_official_namespace(self) -> None:
+        root = ET.fromstring(build_pacs004(_return()))
+        assert root.tag == f"{{{urn_for(DEFAULT_VERSIONS['pacs.004'])}}}Document"
+
+    def test_minimal_return(self) -> None:
+        msg = PaymentReturn(
+            group_header=GroupHeader("R", "t", 1, settlement_method="CLRG"),
+            transactions=(
+                PaymentReturnTransaction(
+                    returned_interbank_amount=Amount(Decimal("5.00"), "USD"),
+                    original_end_to_end_id="E2E-X",
+                ),
+            ),
+        )
+        back = parse_pacs004(build_pacs004(msg))
+        assert back.transactions[0].returned_interbank_amount.value == Decimal("5.00")
+        assert back.original_message_id is None
+
+    def test_missing_returned_amount_raises(self) -> None:
+        body = (
+            "<PmtRtr><GrpHdr><MsgId>M</MsgId><CreDtTm>t</CreDtTm><NbOfTxs>1</NbOfTxs>"
+            "<SttlmInf><SttlmMtd>CLRG</SttlmMtd></SttlmInf></GrpHdr>"
+            "<TxInf><OrgnlEndToEndId>E</OrgnlEndToEndId></TxInf></PmtRtr>"
+        )
+        ns = urn_for(DEFAULT_VERSIONS["pacs.004"])
+        with pytest.raises(Iso20022CodecError, match="RtrdIntrBkSttlmAmt"):
+            parse_pacs004(f"<Document xmlns='{ns}'>{body}</Document>")
+
+
+class TestReversalReconciliation:
+    def test_return_lands_on_original_transfer_entity(self) -> None:
+        # original transfer ingress
+        pacs008 = FIToFICustomerCreditTransfer(
+            group_header=GroupHeader("M", "2026-06-08T09:30:00Z", 1, settlement_method="CLRG"),
+            transactions=(
+                CreditTransferTransaction(
+                    end_to_end_id="E2E-0001", uetr=GOOD_UETR,
+                    interbank_amount=Amount(Decimal("1000.00"), "EUR"),
+                ),
+            ),
+        )
+        entity = f"{NS}/tx:{GOOD_UETR}"
+        assert any(d.entity == entity for d in to_datoms(pacs008))
+
+        # the return lands on the SAME entity, asserting RTND + reason
+        rd = to_datoms(_return())
+        facts = {(d.attribute, d.value) for d in rd if d.entity == entity}
+        assert (f"{NS}.tx/status", "RTND") in facts
+        assert (f"{NS}.tx/returnReason", "AC04") in facts
+        assert (f"{NS}.tx/returnedAmount", "1000.00") in facts
+        assert (f"{NS}.tx/returnedCurrency", "EUR") in facts
+
+    def test_definition_fact(self) -> None:
+        facts = {(d.attribute, d.value) for d in to_datoms(_return())}
+        assert (f"{NS}.msg/definition", "pacs.004") in facts
+
+    def test_return_without_original_refs_emits_no_tx_facts(self) -> None:
+        msg = PaymentReturn(
+            group_header=GroupHeader("R", "t", 1, settlement_method="CLRG"),
+            transactions=(
+                PaymentReturnTransaction(
+                    returned_interbank_amount=Amount(Decimal("1.00"), "EUR"),
+                ),  # no original_uetr/tx_id/end_to_end_id
+            ),
+        )
+        datoms = to_datoms(msg)
+        # only the message-level facts; no per-tx entity facts
+        assert all(not d.entity.startswith(f"{NS}/tx:") for d in datoms)
+        assert any(d.attribute == f"{NS}.msg/definition" and d.value == "pacs.004" for d in datoms)

--- a/py/kotoba_iso20022/tests/test_property.py
+++ b/py/kotoba_iso20022/tests/test_property.py
@@ -1,0 +1,253 @@
+"""Property-based round-trip idempotence + golden-output regression lock.
+
+A correct codec is a *stable fixed point*: ``build(parse(build(m))) ==
+build(m)``. These tests generate many structurally-varied valid messages
+from a fixed seed (deterministic, dependency-free) and assert that property,
+catching serialization bugs that hand-written examples miss. A golden test
+additionally pins the exact wire bytes so an accidental format change is
+caught as a regression.
+"""
+
+from __future__ import annotations
+
+import random
+from decimal import Decimal
+
+import pytest
+
+from kotoba_iso20022 import (
+    build_camt054,
+    build_pacs008,
+    build_pain001,
+    pacs008_group_header,
+    pain001_group_header,
+    parse_camt054,
+    parse_pacs008,
+    parse_pain001,
+)
+from kotoba_iso20022.model import (
+    Account,
+    AccountNotification,
+    Agent,
+    Amount,
+    BankToCustomerDebitCreditNotification,
+    CreditTransferTransaction,
+    CustomerCreditTransferInitiation,
+    FIToFICustomerCreditTransfer,
+    GroupHeader,
+    Party,
+    PaymentInstruction,
+    RemittanceInfo,
+    StatementEntry,
+)
+from kotoba_iso20022.validate import iban_check_digits
+
+_CCYS = [("EUR", 2), ("USD", 2), ("JPY", 0), ("GBP", 2)]
+_BICS = ["DEUTDEFF", "NWBKGB2L", "BOFAUS3N", "BNPAFRPP", "CHASUS33", "DEUTDEFF500"]
+_NAMES = ["Alice Cohen", "Bob Levi", "Acme GmbH", "Société Générale Client", "李雷"]
+
+
+def _iban(rng: random.Random) -> str:
+    country, length = rng.choice([("DE", 22), ("GB", 22), ("FR", 27), ("NL", 18)])
+    bban = "".join(rng.choice("0123456789") for _ in range(length - 4))
+    return country + iban_check_digits(country, bban) + bban
+
+
+def _uetr(rng: random.Random) -> str:
+    h = "0123456789abcdef"
+    def p(n: int) -> str:
+        return "".join(rng.choice(h) for _ in range(n))
+    return f"{p(8)}-{p(4)}-4{p(3)}-{rng.choice('89ab')}{p(3)}-{p(12)}"
+
+
+def _amount(rng: random.Random) -> Amount:
+    ccy, dp = rng.choice(_CCYS)
+    units = rng.randint(1, 10_000_000)
+    value = Decimal(units) / (10 ** dp) if dp else Decimal(units)
+    return Amount(value.quantize(Decimal(1).scaleb(-dp)) if dp else value, ccy)
+
+
+def _party(rng: random.Random) -> Party:
+    return Party(rng.choice(_NAMES))
+
+
+def _gen_pacs008(rng: random.Random) -> FIToFICustomerCreditTransfer:
+    n = rng.randint(1, 4)
+    txs = []
+    for i in range(n):
+        tx = CreditTransferTransaction(
+            end_to_end_id=f"E2E-{rng.randint(0, 1_000_000)}",
+            instruction_id=f"INSTR-{i}" if rng.random() < 0.5 else None,
+            tx_id=f"TX-{i}" if rng.random() < 0.5 else None,
+            uetr=_uetr(rng),
+            interbank_amount=_amount(rng),
+            interbank_settlement_date="2026-06-08" if rng.random() < 0.7 else None,
+            charge_bearer=rng.choice(["DEBT", "CRED", "SHAR"]) if rng.random() < 0.7 else None,
+            debtor=_party(rng),
+            debtor_account=Account(iban=_iban(rng)) if rng.random() < 0.6 else None,
+            debtor_agent=Agent(bicfi=rng.choice(_BICS)),
+            creditor_agent=Agent(bicfi=rng.choice(_BICS)),
+            creditor=_party(rng),
+            creditor_account=Account(iban=_iban(rng)) if rng.random() < 0.6 else None,
+            remittance_info=RemittanceInfo(tuple(
+                f"line {k}" for k in range(rng.randint(1, 3))
+            )) if rng.random() < 0.5 else None,
+        )
+        txs.append(tx)
+    return FIToFICustomerCreditTransfer(
+        group_header=pacs008_group_header(f"MSG-{rng.randint(0, 10**6)}",
+                                          "2026-06-08T09:30:00Z", tuple(txs)),
+        transactions=tuple(txs),
+    )
+
+
+def _gen_pain001(rng: random.Random) -> CustomerCreditTransferInitiation:
+    n = rng.randint(1, 4)
+    txs = tuple(
+        CreditTransferTransaction(
+            end_to_end_id=f"E2E-{rng.randint(0, 10**6)}",
+            uetr=_uetr(rng) if rng.random() < 0.5 else None,
+            instructed_amount=_amount(rng),
+            creditor=_party(rng),
+            creditor_account=Account(iban=_iban(rng)) if rng.random() < 0.6 else None,
+            remittance_info=RemittanceInfo(("ref",)) if rng.random() < 0.4 else None,
+        )
+        for _ in range(n)
+    )
+    return CustomerCreditTransferInitiation(
+        group_header=pain001_group_header(f"MSG-{rng.randint(0, 10**6)}",
+                                          "2026-06-08T09:30:00Z", txs,
+                                          initiating_party=_party(rng)),
+        payments=(
+            PaymentInstruction(
+                payment_info_id=f"P-{rng.randint(0, 10**6)}",
+                requested_execution_date="2026-06-08",
+                debtor=_party(rng),
+                debtor_account=Account(iban=_iban(rng)),
+                debtor_agent=Agent(bicfi=rng.choice(_BICS)),
+                transactions=txs,
+            ),
+        ),
+    )
+
+
+def _gen_camt054(rng: random.Random) -> BankToCustomerDebitCreditNotification:
+    entries = tuple(
+        StatementEntry(
+            amount=_amount(rng),
+            credit_debit=rng.choice(["CRDT", "DBIT"]),
+            status=rng.choice(["BOOK", "PDNG", "INFO"]),
+            booking_date="2026-06-08" if rng.random() < 0.6 else None,
+            value_date="2026-06-09" if rng.random() < 0.6 else None,
+            account_servicer_reference=f"SVCR-{rng.randint(0, 10**6)}" if rng.random() < 0.5 else None,
+            end_to_end_id=f"E2E-{rng.randint(0, 10**6)}" if rng.random() < 0.7 else None,
+            bank_transaction_code="PMNT" if rng.random() < 0.3 else None,
+        )
+        for _ in range(rng.randint(1, 3))
+    )
+    return BankToCustomerDebitCreditNotification(
+        group_header=GroupHeader(f"C-{rng.randint(0, 10**6)}", "2026-06-08T23:00:00Z", 0),
+        notifications=(
+            AccountNotification(f"N-{rng.randint(0, 10**6)}", "2026-06-08T23:05:00Z",
+                                Account(iban=_iban(rng)), entries),
+        ),
+    )
+
+
+_GENERATORS = [
+    (_gen_pacs008, build_pacs008, parse_pacs008),
+    (_gen_pain001, build_pain001, parse_pain001),
+    (_gen_camt054, build_camt054, parse_camt054),
+]
+
+
+@pytest.mark.parametrize("gen,build,parse", _GENERATORS)
+def test_serialization_is_idempotent(gen, build, parse) -> None:
+    rng = random.Random(20260608)
+    for _ in range(150):
+        msg = gen(rng)
+        xml1 = build(msg)
+        xml2 = build(parse(xml1))
+        assert xml1 == xml2, "codec is not a stable round-trip fixed point"
+
+
+@pytest.mark.parametrize("gen,build,parse", _GENERATORS)
+def test_parse_preserves_structure(gen, build, parse) -> None:
+    rng = random.Random(42)
+    for _ in range(100):
+        msg = gen(rng)
+        back = parse(build(msg))
+        # rebuild matches — structural equality via the wire form
+        assert build(back) == build(msg)
+
+
+# --------------------------------------------------------------------------
+# golden output — pins the exact wire bytes (regression lock)
+# --------------------------------------------------------------------------
+
+_GOLDEN_PACS008 = (
+    "<?xml version='1.0' encoding='utf-8'?>\n"
+    '<Document xmlns="urn:iso:std:iso:20022:tech:xsd:pacs.008.001.08">\n'
+    "  <FIToFICstmrCdtTrf>\n"
+    "    <GrpHdr>\n"
+    "      <MsgId>MSG-GOLD</MsgId>\n"
+    "      <CreDtTm>2026-06-08T09:30:00Z</CreDtTm>\n"
+    "      <NbOfTxs>1</NbOfTxs>\n"
+    "      <CtrlSum>1234.56</CtrlSum>\n"
+    "      <SttlmInf>\n"
+    "        <SttlmMtd>CLRG</SttlmMtd>\n"
+    "      </SttlmInf>\n"
+    "    </GrpHdr>\n"
+    "    <CdtTrfTxInf>\n"
+    "      <PmtId>\n"
+    "        <EndToEndId>E2E-GOLD</EndToEndId>\n"
+    "        <UETR>dced6a36-9e4b-4e2a-8b9f-2f3a4b5c6d7e</UETR>\n"
+    "      </PmtId>\n"
+    '      <IntrBkSttlmAmt Ccy="EUR">1234.56</IntrBkSttlmAmt>\n'
+    "      <IntrBkSttlmDt>2026-06-08</IntrBkSttlmDt>\n"
+    "      <ChrgBr>SHAR</ChrgBr>\n"
+    "      <Dbtr>\n"
+    "        <Nm>Alice</Nm>\n"
+    "      </Dbtr>\n"
+    "      <DbtrAcct>\n"
+    "        <Id>\n"
+    "          <IBAN>DE89370400440532013000</IBAN>\n"
+    "        </Id>\n"
+    "      </DbtrAcct>\n"
+    "      <DbtrAgt>\n"
+    "        <FinInstnId>\n"
+    "          <BICFI>DEUTDEFF</BICFI>\n"
+    "        </FinInstnId>\n"
+    "      </DbtrAgt>\n"
+    "      <CdtrAgt>\n"
+    "        <FinInstnId>\n"
+    "          <BICFI>NWBKGB2L</BICFI>\n"
+    "        </FinInstnId>\n"
+    "      </CdtrAgt>\n"
+    "      <Cdtr>\n"
+    "        <Nm>Bob</Nm>\n"
+    "      </Cdtr>\n"
+    "      <CdtrAcct>\n"
+    "        <Id>\n"
+    "          <IBAN>GB29NWBK60161331926819</IBAN>\n"
+    "        </Id>\n"
+    "      </CdtrAcct>\n"
+    "    </CdtTrfTxInf>\n"
+    "  </FIToFICstmrCdtTrf>\n"
+    "</Document>"
+)
+
+
+def test_golden_pacs008_exact_bytes() -> None:
+    tx = CreditTransferTransaction(
+        end_to_end_id="E2E-GOLD", uetr="dced6a36-9e4b-4e2a-8b9f-2f3a4b5c6d7e",
+        interbank_amount=Amount(Decimal("1234.56"), "EUR"),
+        interbank_settlement_date="2026-06-08", charge_bearer="SHAR",
+        debtor=Party("Alice"), debtor_account=Account(iban="DE89370400440532013000"),
+        debtor_agent=Agent(bicfi="DEUTDEFF"), creditor_agent=Agent(bicfi="NWBKGB2L"),
+        creditor=Party("Bob"), creditor_account=Account(iban="GB29NWBK60161331926819"),
+    )
+    gh = GroupHeader("MSG-GOLD", "2026-06-08T09:30:00Z", 1,
+                     control_sum=Decimal("1234.56"), settlement_method="CLRG")
+    out = build_pacs008(FIToFICustomerCreditTransfer(group_header=gh, transactions=(tx,)))
+    assert out == _GOLDEN_PACS008

--- a/py/kotoba_iso20022/tests/test_robustness.py
+++ b/py/kotoba_iso20022/tests/test_robustness.py
@@ -1,0 +1,124 @@
+"""Breadth/robustness tests: full IBAN registry, cross-currency round-trips.
+
+These exercise the codec/validators across the *range* of valid inputs,
+not just one happy path — the maturity complement to the edge-case suite.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from kotoba_iso20022 import build_pacs008, pacs008_group_header, parse_pacs008
+from kotoba_iso20022.model import (
+    Agent,
+    Amount,
+    CreditTransferTransaction,
+    FIToFICustomerCreditTransfer,
+    Party,
+)
+from kotoba_iso20022.validate import (
+    IBAN_LENGTHS,
+    iban_check_digits,
+    validate_amount,
+    validate_iban,
+)
+
+# --------------------------------------------------------------------------
+# Full ISO 13616 registry: a valid IBAN can be constructed + validated for
+# every listed participating country.
+# --------------------------------------------------------------------------
+
+_PARTICIPATING = [c for c, n in IBAN_LENGTHS.items() if n > 0]
+
+
+@pytest.mark.parametrize("country", _PARTICIPATING)
+def test_constructed_iban_validates(country: str) -> None:
+    length = IBAN_LENGTHS[country]
+    # numeric BBAN of the right width (digits are valid BBAN chars everywhere)
+    bban = ("1234567890" * 4)[: length - 4]
+    check = iban_check_digits(country, bban)
+    iban = country + check + bban
+    assert validate_iban(iban) == iban
+    assert len(iban) == length
+
+
+def test_registry_is_substantial() -> None:
+    # guard against an accidental truncation of the registry
+    assert len(_PARTICIPATING) >= 75
+
+
+def test_unlisted_country_soft_passes_structure() -> None:
+    # a structurally-valid IBAN for a country not in the registry is accepted
+    # on structure + checksum (length check skipped), never hard-rejected
+    bban = "ABCD1234567890123456"
+    check = iban_check_digits("ZZ", bban)
+    assert validate_iban("ZZ" + check + bban)
+
+
+# --------------------------------------------------------------------------
+# Cross-currency round-trips with correct ISO 4217 minor-unit formatting.
+# --------------------------------------------------------------------------
+
+_CURRENCY_CASES = [
+    ("USD", "1000.00"),
+    ("EUR", "0.01"),
+    ("GBP", "999999.99"),
+    ("CHF", "12.50"),
+    ("JPY", "500000"),      # 0 fraction digits
+    ("KRW", "1000000"),     # 0 fraction digits
+    ("BHD", "1.234"),       # 3 fraction digits
+    ("KWD", "0.500"),       # 3 fraction digits
+]
+
+
+@pytest.mark.parametrize("ccy,amount", _CURRENCY_CASES)
+def test_pacs008_amount_roundtrip(ccy: str, amount: str) -> None:
+    tx = CreditTransferTransaction(
+        end_to_end_id="E2E",
+        interbank_amount=Amount(Decimal(amount), ccy),
+        debtor=Party("A"), debtor_agent=Agent(bicfi="DEUTDEFF"),
+        creditor=Party("B"), creditor_agent=Agent(bicfi="NWBKGB2L"),
+    )
+    msg = FIToFICustomerCreditTransfer(
+        group_header=pacs008_group_header("M", "2026-06-08T09:30:00Z", (tx,)),
+        transactions=(tx,),
+    )
+    back = parse_pacs008(build_pacs008(msg))
+    rt = back.transactions[0].interbank_amount
+    assert rt.currency == ccy
+    assert rt.value == Decimal(amount)
+
+
+@pytest.mark.parametrize("ccy,amount", _CURRENCY_CASES)
+def test_amounts_validate(ccy: str, amount: str) -> None:
+    assert validate_amount(amount, ccy) == Decimal(amount)
+
+
+def test_max_total_digits_boundary() -> None:
+    # exactly 18 significant digits is allowed; 19 is rejected
+    assert validate_amount("123456789012345.67", "USD")  # 17 digits, ok
+    from kotoba_iso20022.validate import InvalidAmount
+    with pytest.raises(InvalidAmount):
+        validate_amount("12345678901234567.89", "USD")  # 19 digits
+
+
+def test_many_transactions_in_one_message() -> None:
+    txs = tuple(
+        CreditTransferTransaction(
+            end_to_end_id=f"E2E-{i}",
+            interbank_amount=Amount(Decimal("1.00"), "EUR"),
+            debtor=Party("A"), debtor_agent=Agent(bicfi="DEUTDEFF"),
+            creditor=Party(f"C{i}"), creditor_agent=Agent(bicfi="NWBKGB2L"),
+        )
+        for i in range(25)
+    )
+    msg = FIToFICustomerCreditTransfer(
+        group_header=pacs008_group_header("M", "2026-06-08T09:30:00Z", txs),
+        transactions=txs,
+    )
+    back = parse_pacs008(build_pacs008(msg))
+    assert len(back.transactions) == 25
+    assert back.group_header.control_sum == Decimal("25.00")
+    assert {t.end_to_end_id for t in back.transactions} == {f"E2E-{i}" for i in range(25)}

--- a/py/kotoba_iso20022/tests/test_validate.py
+++ b/py/kotoba_iso20022/tests/test_validate.py
@@ -1,0 +1,109 @@
+"""Tests for the cleanroom open-standard validators."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from kotoba_iso20022.validate import (
+    InvalidAmount,
+    InvalidBic,
+    InvalidCurrency,
+    InvalidIban,
+    iban_check_digits,
+    validate_amount,
+    validate_bic,
+    validate_currency,
+    validate_iban,
+)
+
+
+class TestIban:
+    # Published ISO 13616 example IBANs (registry test vectors).
+    VALID = [
+        "DE89 3704 0044 0532 0130 00",
+        "GB29 NWBK 6016 1331 9268 19",
+        "FR14 2004 1010 0505 0001 3M02 606",
+        "CH93 0076 2011 6238 5295 7",
+        "BE68 5390 0754 7034",
+    ]
+
+    @pytest.mark.parametrize("iban", VALID)
+    def test_valid(self, iban: str) -> None:
+        out = validate_iban(iban)
+        assert " " not in out and out == out.upper()
+
+    def test_bad_checksum(self) -> None:
+        # flip a digit in the German example
+        with pytest.raises(InvalidIban):
+            validate_iban("DE90 3704 0044 0532 0130 00")
+
+    def test_wrong_length(self) -> None:
+        with pytest.raises(InvalidIban):
+            validate_iban("DE89 3704 0044 0532 0130")
+
+    def test_bad_structure(self) -> None:
+        with pytest.raises(InvalidIban):
+            validate_iban("XX")
+
+    def test_jp_has_no_iban(self) -> None:
+        with pytest.raises(InvalidIban):
+            validate_iban("JP00 0000 0000 0000 0000 00")
+
+    def test_check_digits_roundtrip(self) -> None:
+        # DE BBAN from the canonical example
+        cd = iban_check_digits("DE", "370400440532013000")
+        assert cd == "89"
+        assert validate_iban("DE" + cd + "370400440532013000")
+
+
+class TestBic:
+    @pytest.mark.parametrize("bic", ["DEUTDEFF", "DEUTDEFF500", "NWBKGB2L", "BOFAUS3N"])
+    def test_valid(self, bic: str) -> None:
+        assert validate_bic(bic) == bic.upper()
+
+    @pytest.mark.parametrize("bic", ["DEUT", "DEUTDEFF5", "1234DEFF", "deutde"])
+    def test_invalid(self, bic: str) -> None:
+        with pytest.raises(InvalidBic):
+            validate_bic(bic)
+
+
+class TestCurrency:
+    def test_valid_active(self) -> None:
+        assert validate_currency("usd") == "USD"
+
+    def test_shape_only(self) -> None:
+        assert validate_currency("XYZ", require_active=False) == "XYZ"
+
+    def test_inactive_rejected(self) -> None:
+        with pytest.raises(InvalidCurrency):
+            validate_currency("XYZ")
+
+    def test_bad_shape(self) -> None:
+        with pytest.raises(InvalidCurrency):
+            validate_currency("US")
+
+
+class TestAmount:
+    def test_eur_two_dp(self) -> None:
+        assert validate_amount("100.00", "EUR") == Decimal("100.00")
+
+    def test_jpy_zero_dp(self) -> None:
+        assert validate_amount("1000", "JPY") == Decimal("1000")
+
+    def test_jpy_rejects_fraction(self) -> None:
+        with pytest.raises(InvalidAmount):
+            validate_amount("1000.50", "JPY")
+
+    def test_too_many_fraction_digits(self) -> None:
+        with pytest.raises(InvalidAmount):
+            validate_amount("1.000000", "USD")
+
+    def test_negative_rejected(self) -> None:
+        with pytest.raises(InvalidAmount):
+            validate_amount("-1.00", "USD")
+
+    def test_total_digits_cap(self) -> None:
+        with pytest.raises(InvalidAmount):
+            validate_amount("1234567890123456789", "USD")


### PR DESCRIPTION
Adds the `kotoba_iso20022` cleanroom ISO 20022 payment-message codec at `py/kotoba_iso20022/`, a sibling of `py/kotoba_langgraph/` + `py/kotoba_murakumo/`.

## What
A dependency-free, charter-clean reimplementation of the ISO 20022 message definitions (`pain.001` / `pacs.008` / `pacs.002` / `camt` / `pacs.004`), built purely from the **open published** standard — no proprietary SWIFT SDK, no vendor schema files at runtime (`dependencies = []`).

This is the traditional-finance analogue of the substrate rule *"AT-Protocol MST = ingress/interop wire"*: a generic, reusable codec that translates the global ISO 20022 banking wire ⇄ the canonical kotoba EAVT Datom log. It is **engine core**, not actor logic — the codec carries no per-actor or charter-bound behaviour (format datafication only: no network, no chain, no money movement, no Travel-Rule KYC).

## Monorepo-context test input
The Datom/Lexicon bridge test verifies record shape against an etzhayyim Lexicon that lives in the monorepo, so `test_bridge` resolves to the monorepo root (`parents[5]`) and **degrades to a per-test skip** when that Lexicon is absent (standalone kotoba checkout). Stray tracked `.coverage` artifact dropped.

## Tests
231 pass in the monorepo context; 229 pass / 2 bridge-shape tests skip in a standalone checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
