### PR TITLE
feat: HLC clock + causal cross-graph firehose — ADR-001 five-axis redesign (phase 1)

### DIFF
--- a/crates/kotoba-datomic/src/distributed.rs
+++ b/crates/kotoba-datomic/src/distributed.rs
@@ -77,10 +77,36 @@ pub struct DistributedDatomCommit {
     pub author: String,
     pub seq: u64,
     pub ts: u64,
+    /// Hybrid Logical Clock (ms·2^16 + counter) — monotonic per node, never goes
+    /// backwards under wall-clock skew. The causal/total ordering key for the
+    /// cross-graph firehose and the merge tiebreak (ADR-001). `#[serde(default)]`
+    /// so pre-HLC commits still decode (hlc = 0).
+    #[serde(default)]
+    pub hlc: u64,
     /// Covering ProllyTree roots: eavt/aevt/avet/vaet/tea.
     pub index_roots: HashMap<String, KotobaCid>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cacao_proof_cid: Option<KotobaCid>,
+}
+
+/// Process Hybrid Logical Clock. Packs `physical_ms << 16 | counter`; advances to
+/// `max(physical, last+1)` so it is monotonic even if the wall clock jumps back.
+/// The cross-graph ordering key + merge tiebreak (ADR-001). Single-node variant
+/// (a multi-node deployment also merges observed peer HLCs on read — later phase).
+pub(crate) fn next_hlc(phys_ms: u64) -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static HLC: AtomicU64 = AtomicU64::new(0);
+    let phys = phys_ms << 16;
+    loop {
+        let last = HLC.load(Ordering::Relaxed);
+        let next = if phys > last { phys } else { last + 1 };
+        if HLC
+            .compare_exchange_weak(last, next, Ordering::Relaxed, Ordering::Relaxed)
+            .is_ok()
+        {
+            return next;
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2746,10 +2772,11 @@ impl DistributedDatomCommit {
         index_roots: HashMap<String, KotobaCid>,
         cacao_proof_cid: Option<KotobaCid>,
     ) -> Result<Self, DistributedCommitError> {
-        let ts = std::time::SystemTime::now()
+        let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs();
+            .unwrap_or_default();
+        let ts = now.as_secs();
+        let hlc = next_hlc(now.as_millis() as u64);
         let mut commit = Self {
             cid: KotobaCid::default(),
             graph,
@@ -2758,6 +2785,7 @@ impl DistributedDatomCommit {
             author,
             seq,
             ts,
+            hlc,
             index_roots,
             cacao_proof_cid,
         };
@@ -8648,5 +8676,30 @@ mod tests {
         // idempotent
         let again = gc_history(&c2.cid, 1, &store).unwrap();
         assert_eq!(again.deleted_blocks, 0);
+    }
+
+    #[test]
+    fn next_hlc_is_monotonic_under_clock_skew() {
+        // Advancing physical time bumps the high bits.
+        let a = next_hlc(1_000);
+        let b = next_hlc(2_000);
+        assert!(b > a, "HLC must advance with physical time");
+        // A wall-clock JUMP BACKWARDS must NOT produce a smaller HLC.
+        let c = next_hlc(500);
+        assert!(c > b, "HLC must stay monotonic when the clock goes backwards");
+        // Same-millisecond calls still strictly increase (logical counter).
+        let d = next_hlc(2_000);
+        let e = next_hlc(2_000);
+        assert!(e > d, "HLC must strictly increase within the same millisecond");
+    }
+
+    #[test]
+    fn seal_stamps_a_nonzero_hlc() {
+        let graph = KotobaCid::from_bytes(b"hlc-seal");
+        let c = DistributedDatomCommit::seal(
+            graph.clone(), KotobaCid::from_bytes(b"tx"), None,
+            "did:key:t".into(), 1, std::collections::HashMap::new(), None,
+        ).unwrap();
+        assert!(c.hlc > 0, "seal must stamp a Hybrid Logical Clock");
     }
 }

--- a/crates/kotoba-server/src/firehose.rs
+++ b/crates/kotoba-server/src/firehose.rs
@@ -119,6 +119,10 @@ async fn gate(
 pub struct FirehoseEvent {
     pub seq: u64,
     pub ts: u64,
+    /// Hybrid Logical Clock of the source commit (ADR-001) — the skew-resistant
+    /// cross-graph ordering key. 0 for journal-sourced (non-datomic) events.
+    #[serde(default)]
+    pub hlc: u64,
     pub topic: String,
     pub cid: String,
     pub payload: serde_json::Value,
@@ -134,6 +138,7 @@ impl FirehoseEvent {
         graph_cid: &KotobaCid,
         seq: u64,
         ts: u64,
+        hlc: u64,
     ) -> Self {
         let quad = crate::xrpc::datom_to_projection_quad(datom, graph_cid);
         let topic = if datom.added {
@@ -158,6 +163,7 @@ impl FirehoseEvent {
         FirehoseEvent {
             seq,
             ts,
+            hlc,
             topic,
             cid,
             payload,
@@ -172,6 +178,7 @@ impl FirehoseEvent {
         FirehoseEvent {
             seq: e.seq,
             ts: e.ts,
+            hlc: 0, // journal (non-datomic) events carry no commit HLC
             topic: e.topic.clone(),
             cid: e.cid.to_multibase(),
             payload,
@@ -354,6 +361,7 @@ fn firehose_events_from_commitdag(
                 &graph_cid,
                 seq,
                 entry.commit.ts,
+                entry.commit.hlc,
             ));
         }
     }
@@ -406,11 +414,12 @@ pub struct AllGraphsParams {
 
 /// Merge every registered graph's CommitDag change feed into one whole-node feed.
 ///
-/// Ordering is `(commit.ts, graph, per-graph seq)`. NOTE: `commit.ts` is whole
-/// seconds, so cross-graph order is timestamp-*approximate* — within a single
-/// graph it is exact. The returned `seq` is a global 1-based index over the
-/// merged order; it is stable for append-only growth (new commits sort to the
-/// tail) and serves as the resume cursor.
+/// Ordering is `(commit.hlc, graph, per-graph seq)` (ADR-001). The Hybrid Logical
+/// Clock is monotonic per node and skew-resistant, so cross-graph order is stable
+/// and not at the mercy of wall-clock jumps; within a single graph it is exact.
+/// The returned `seq` is a global 1-based index over the merged order; it is
+/// stable for append-only growth (new commits sort to the tail) and serves as the
+/// resume cursor.
 fn firehose_events_all_graphs(
     state: &KotobaState,
 ) -> Result<Vec<FirehoseEvent>, (StatusCode, String)> {
@@ -421,7 +430,7 @@ fn firehose_events_all_graphs(
         };
         let per_graph = firehose_events_from_commitdag(state, graph_mb)?;
         for ev in per_graph {
-            merged.push((ev.ts, graph_mb.to_string(), ev.seq, ev));
+            merged.push((ev.hlc, graph_mb.to_string(), ev.seq, ev));
         }
     }
     // (ts, graph, per-graph seq) — deterministic merge across graphs.

--- a/docs/ADR-001-five-axis-distributed-redesign.md
+++ b/docs/ADR-001-five-axis-distributed-redesign.md
@@ -1,0 +1,81 @@
+# ADR-001 — Five-axis distributed redesign (authority / ordering / availability / conflict / transport)
+
+Status: **accepted (phased)** · 2026-06
+
+## Context
+
+After the journal deletion (#57) kotoba's durable substrate is the **CommitDag**
+(per-graph ProllyTree commits, content-addressed, IPNS head) plus each
+subsystem's own content-addressed store (signal → Shelf, realtime → block-store
+snapshots). The live surface is an in-memory **LiveBus** (gossipsub-style,
+ephemeral). That is coherent as a *sovereign single-writer* design, but five
+distributed-systems axes were only handled implicitly. This ADR makes the target
+explicit and sequences the work.
+
+### Where we are (audited against the code)
+
+| axis | current behaviour | gap |
+|---|---|---|
+| **authority** | one `owner` DID per graph (= IPNS controller); writes need owner Bearer or a CACAO/VP `datom:transact` capability whose recovered issuer == owner; IPNS head is signature-required | no independent **validation** (no "shared physics"); no multi-writer |
+| **ordering** | in-graph **total order** (linear `prev` + `seq`, CAS-serialised); cross-graph order is **wall-clock `ts` (1 s)** | "CommitDag" is really a chain (single parent); cross-graph order is skew-prone, not causal |
+| **availability** | content-addressed in FsBlockStore → CAR-on-B2 → kubo → DHT (opt-in); de-facto holder = owner node + B2 | no declared replication responsibility; single-holder by default |
+| **conflict** | `expected_parent` CAS → `StaleParent` (**reject**) | no merge; the ProllyTree's order-independence (Fireproof-style CRDT) is unused |
+| **transport** | datomic live (LiveBus) loss is recoverable from the CommitDag; **non-datomic is live-only** | non-datomic event *stream* is unrecoverable on transport loss (only the payload is, by CID) |
+
+## Decision — the target (A + B unified)
+
+Adopt a **multi-writer, causally-ordered, merge-on-conflict, replicated,
+transport-independent** content-addressed model, while preserving the
+sovereign-single-writer mode as a special case (one authorized writer ⇒ no
+merges ever happen).
+
+| axis | target | mechanism |
+|---|---|---|
+| **authority** | owner-rooted, **delegatable + validated** | keep CACAO `datom:transact` capability chains; add a per-graph **validation hook** (`:db.validate/*` rules + optional WASM validator) run on every transact — the "shared physics". Multiple writers = multiple capability holders. |
+| **ordering** | **causal** (not wall-clock, not global-total) | **Hybrid Logical Clock (HLC)** on every commit + optional `caused_by: [commitCID]` cross-graph causal refs. Cross-graph firehose orders by HLC. In-graph stays total. |
+| **availability** | **declared responsibility** | per-graph `replication = { min_replicas, pin_peers }`; the DHT NeighborhoodBlockStore enforces the replication factor (pin contract), default-on. |
+| **conflict** | **merge** (CRDT), reject only on validation failure | the CommitDag becomes a **true multi-parent DAG**: concurrent writes don't `StaleParent`, they create a **merge commit** whose ProllyTree is the join of both states. Datom resolution: cardinality-one = **LWW by (HLC, writerDID)**; cardinality-many = **OR-set** (assert/retract by `(e,a,v)` with HLC tiebreak). Deterministic ⇒ same DAG ⇒ same root CID on every replica. |
+| **transport** | recoverable for **all** topics | datomic already replays from the CommitDag; give each non-datomic topic a cheap **pointer-chain** (append-only CID-pointer commits — no ProllyTree rebuild) so the stream is cursor-replayable without re-introducing the heavy journal. |
+
+### Why the ProllyTree substrate makes B cheap
+ProllyTrees are history-independent: the same datom set yields the same Merkle
+root regardless of insert order (this is exactly what Fireproof exploits). So a
+merge is `ProllyTree::diff` + a deterministic per-`(e,a,v)` resolution, then a
+rebuild — and because the result is canonical, every replica converges to an
+identical root CID without coordination. The commit DAG is the Merkle clock.
+
+### Merge semantics (the load-bearing decision)
+A datom is `(e, a, v, tx, op)`. On merging two heads H1, H2 with common
+ancestor A:
+- compute `Δ1 = diff(A,H1)`, `Δ2 = diff(A,H2)`;
+- union the asserted set, apply retracts;
+- for the same `(e,a)` under a **cardinality-one** attribute, keep the datom with
+  the greater `(hlc, writer_did)` (LWW, total + deterministic);
+- under **cardinality-many**, keep the OR-set (an assert and a later retract of
+  the same `(e,a,v)` resolve by `(hlc, writer_did)`);
+- the merge commit's `parents = [H1, H2]`, `hlc = max(hlc1,hlc2)+1`.
+Validation runs on the merged result; if it fails, the *later* writer's commit is
+rejected (the only place "reject" survives).
+
+## Phasing (each phase is an independently shippable, verified PR)
+
+1. **HLC clock** — add `hlc` to commits; cross-graph firehose orders by HLC
+   instead of wall-clock `ts`. Foundation for both causal ordering and the merge
+   tiebreak. *(this PR)*
+2. **Multi-parent DAG + Merkle-CRDT merge** — `parents: Vec<KotobaCid>`;
+   `StaleParent` → auto-merge with the resolution above; convergence test
+   (two writers, independent commits, identical root CID after merge).
+3. **Validation hook** — `:db.validate/*` + optional WASM validator on transact
+   and on merge results.
+4. **Declared replication** — per-graph replication policy enforced by the DHT
+   tier (pin contract); availability surfaced in `node.status`.
+5. **Non-datomic pointer-chains** — cursor-replayable streams for signal /
+   realtime / kse without the journal.
+
+## Consequences
+- Commit block format changes (new fields) — content-addressed CIDs change.
+  Acceptable at dev stage; `#[serde(default)]` keeps old commits readable.
+- Sovereign single-writer deployments are unaffected in behaviour (no concurrent
+  writes ⇒ no merge commits ⇒ identical to today, just HLC-stamped).
+- Multi-writer becomes possible without a global consensus/ledger — agent-centric
+  like Holochain, convergent like a Merkle-CRDT like Fireproof.


### PR DESCRIPTION
Phase 1 of the **five-axis distributed redesign** (`docs/ADR-001`): authority / ordering / availability / conflict / transport. This lands the shared foundation both halves of the target need — a **Hybrid Logical Clock**.

## ADR-001 (included)
Audits the current design against the five axes and sets the A+B target:
- **authority**: owner-rooted + capability delegation + **validation hook** (phase 3)
- **ordering**: **causal via HLC** (this PR) + optional `caused_by` refs
- **availability**: **declared replication** policy enforced by the DHT tier (phase 4)
- **conflict**: **merge** — CommitDag becomes a true multi-parent DAG with Merkle-CRDT resolution (LWW-by-(hlc,writer) for card-one, OR-set for card-many) (phase 2)
- **transport**: datomic already replays from the CommitDag; **non-datomic pointer-chains** for cursor-replay (phase 5)

## This PR (phase 1)
- `DistributedDatomCommit.hlc` — stamped in `seal()` from a process HLC (`physical_ms<<16 | counter`, advanced to `max(physical, last+1)`; never regresses under clock skew). `#[serde(default)]` keeps pre-HLC commits decodable.
- `sync.eventsAllGraphs` orders by `(hlc, graph, seq)` instead of wall-clock `ts` — fixes the skew-prone cross-graph ordering flagged in the audit. `FirehoseEvent.hlc` carries it (0 for journal/non-datomic events). In-graph order unchanged.

## Verification
- `next_hlc` monotonic across a **backwards** wall-clock jump and within the same ms; `seal` stamps `hlc > 0`.
- Live two-graph load → `sync.eventsAllGraphs`: 423 events, **every event `hlc > 0`**, **non-decreasing across graphs**.

Single-writer behaviour is otherwise unchanged (commits just gain a clock). Multi-writer merge arrives in phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)