### PR TITLE
feat(host-sdk): generalize blob helpers from Backblaze-B2 to provider-agnostic S3

### DIFF
--- a/crates/kotoba-kotodama/sdk/kotodama-host-sdk/package.json
+++ b/crates/kotoba-kotodama/sdk/kotodama-host-sdk/package.json
@@ -28,6 +28,7 @@
     "./write-outbox": "./src/write-outbox.ts",
     "./write-dispatch.generated": "./src/write-dispatch.generated.ts",
     "./b2": "./src/b2.ts",
+    "./s3": "./src/s3.ts",
     "./generated/tool-manifest/*": "./src/generated/tool-manifest/*.ts"
   },
   "scripts": {

--- a/crates/kotoba-kotodama/sdk/kotodama-host-sdk/src/b2.ts
+++ b/crates/kotoba-kotodama/sdk/kotodama-host-sdk/src/b2.ts
@@ -1,314 +1,43 @@
 /**
- * B2 (Backblaze B2 S3-compatible) blob fetch helpers — Cloudflare
- * Worker-friendly. No external SDK; all S3 SigV4 signing is done with
- * `crypto.subtle` (HMAC-SHA256). Response shape mirrors `R2Bucket` so
- * migration from `env.CDN_R2.get(...)` is mechanical.
+ * Backward-compatibility shim — `b2*` is now an alias of the generic,
+ * provider-agnostic S3 helpers in `./s3`. The blob layer is no longer
+ * hard-coded to Backblaze B2; B2 is just one S3-compatible endpoint among
+ * many (AWS S3 / R2 / MinIO / Linode / Vultr …). Configure via `S3_*`
+ * env vars; the legacy `B2_*` names are still honoured as a fallback
+ * (see `./s3`).
  *
- * ADR-0048 (B2 primary) + `[[conventions]] blob-storage-b2-only`. Use
- * for all new blob-using Workers; existing R2 callers migrate per the
- * `[[migrations]] blob-storage-r2-to-b2-code` recipe.
+ * Prefer importing from "@etzhayyim/kotodama-host-sdk/s3" in new code:
  *
- * Env shape (all Workers using these helpers):
+ *   import { s3Get, s3Put, s3Head, s3Delete } from "@etzhayyim/kotodama-host-sdk/s3";
  *
- *   B2_ENDPOINT             https://s3.us-east-005.backblazeb2.com
- *   B2_REGION               us-east-005
- *   B2_BUCKET               etzhayyim-{actor}
- *   B2_KEY_ID               (wrangler secret put B2_KEY_ID)
- *   B2_APPLICATION_KEY      (wrangler secret put B2_APPLICATION_KEY)
- *
- * Usage:
- *
- *   import { b2Get, b2Put, b2Head, b2Delete } from "@etzhayyim/kotodama-host-sdk";
- *   const obj = await b2Get(env, "bim/blobs/abc123");
- *   if (obj) {
- *     const buf = await obj.arrayBuffer();
- *     // ... parse ...
- *   }
- *   await b2Put(env, "bim/meshes/abc123", buf, { contentType: "model/gltf-binary" });
+ * Existing `b2Get` / `b2Put` / `b2Head` / `b2Delete` callers keep working
+ * unchanged.
  */
 
-export interface B2Env {
-  B2_ENDPOINT?: string;
-  B2_REGION?: string;
-  B2_BUCKET?: string;
-  B2_KEY_ID?: string;
-  B2_APPLICATION_KEY?: string;
-}
+import {
+  s3Get,
+  s3Put,
+  s3Head,
+  s3Delete,
+  type S3Env,
+  type S3GetResult,
+  type S3PutOptions,
+  type S3HeadResult,
+} from "./s3.js";
 
-export interface B2GetResult {
-  body: ReadableStream<Uint8Array>;
-  arrayBuffer(): Promise<ArrayBuffer>;
-  text(): Promise<string>;
-  json<T = unknown>(): Promise<T>;
-  size: number;
-  etag: string | null;
-  contentType: string | null;
-  /** Raw underlying Response — for streaming pass-through. */
-  response: Response;
-}
+// ── type aliases (legacy names) ────────────────────────────────────────
+export type B2Env = S3Env;
+export type B2GetResult = S3GetResult;
+export type B2PutOptions = S3PutOptions;
+export type B2HeadResult = S3HeadResult;
 
-export interface B2PutOptions {
-  contentType?: string;
-  cacheControl?: string;
-  metadata?: Record<string, string>;
-}
+// ── function aliases (legacy names) ────────────────────────────────────
+export const b2Get = s3Get;
+export const b2Put = s3Put;
+export const b2Head = s3Head;
+export const b2Delete = s3Delete;
 
-export interface B2HeadResult {
-  size: number;
-  etag: string | null;
-  contentType: string | null;
-}
-
-const REQUIRED: (keyof B2Env)[] = [
-  "B2_ENDPOINT", "B2_REGION", "B2_BUCKET", "B2_KEY_ID", "B2_APPLICATION_KEY",
-];
-
-function readEnv(env: B2Env): {
-  endpoint: string; region: string; bucket: string; keyId: string; appKey: string; host: string;
-} {
-  for (const k of REQUIRED) {
-    if (!env[k]) throw new Error(`b2: ${k} is not configured`);
-  }
-  const endpoint = env.B2_ENDPOINT!.replace(/\/$/, "");
-  const url = new URL(endpoint);
-  return {
-    endpoint,
-    region: env.B2_REGION!,
-    bucket: env.B2_BUCKET!,
-    keyId: env.B2_KEY_ID!,
-    appKey: env.B2_APPLICATION_KEY!,
-    host: url.host,
-  };
-}
-
-// ── S3 SigV4 signing (RFC 4231 HMAC-SHA256 via crypto.subtle) ──────────
-
-const ENC = new TextEncoder();
-
-async function hmac(key: ArrayBuffer | Uint8Array, message: string): Promise<ArrayBuffer> {
-  const cryptoKey = await crypto.subtle.importKey(
-    "raw",
-    key as BufferSource,
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"],
-  );
-  return crypto.subtle.sign("HMAC", cryptoKey, ENC.encode(message));
-}
-
-function bufToHex(buf: ArrayBuffer): string {
-  const view = new Uint8Array(buf);
-  let s = "";
-  for (let i = 0; i < view.length; i++) s += view[i].toString(16).padStart(2, "0");
-  return s;
-}
-
-async function sha256Hex(payload: ArrayBuffer | string): Promise<string> {
-  const data = typeof payload === "string" ? ENC.encode(payload) : new Uint8Array(payload);
-  return bufToHex(await crypto.subtle.digest("SHA-256", data));
-}
-
-function uriEncode(s: string, encodeSlash = false): string {
-  // S3 SigV4 — RFC 3986 unreserved + skip "/" inside path components.
-  return s.split("").map((c) => {
-    if (/[A-Za-z0-9\-_.~]/.test(c)) return c;
-    if (c === "/" && !encodeSlash) return c;
-    return encodeURIComponent(c).toUpperCase();
-  }).join("");
-}
-
-interface SignArgs {
-  method: "GET" | "PUT" | "HEAD" | "DELETE";
-  url: URL;
-  headers: Record<string, string>;
-  payload: ArrayBuffer | string;
-  region: string;
-  keyId: string;
-  appKey: string;
-  service?: string;  // default "s3"
-}
-
-async function signRequest(args: SignArgs): Promise<Record<string, string>> {
-  const service = args.service ?? "s3";
-  const now = new Date();
-  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, ""); // 20260425T101530Z
-  const dateStamp = amzDate.slice(0, 8);
-  const payloadHash = await sha256Hex(args.payload);
-
-  const canonicalHeadersObj: Record<string, string> = {
-    ...Object.fromEntries(
-      Object.entries(args.headers).map(([k, v]) => [k.toLowerCase().trim(), String(v).trim()]),
-    ),
-    host: args.url.host,
-    "x-amz-content-sha256": payloadHash,
-    "x-amz-date": amzDate,
-  };
-  const sortedHeaderNames = Object.keys(canonicalHeadersObj).sort();
-  const canonicalHeaders = sortedHeaderNames.map((n) => `${n}:${canonicalHeadersObj[n]}\n`).join("");
-  const signedHeaders = sortedHeaderNames.join(";");
-
-  const canonicalQuery = [...args.url.searchParams.entries()]
-    .map(([k, v]) => [uriEncode(k, true), uriEncode(v, true)] as const)
-    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
-    .map(([k, v]) => `${k}=${v}`)
-    .join("&");
-
-  const canonicalRequest = [
-    args.method,
-    uriEncode(args.url.pathname, false),
-    canonicalQuery,
-    canonicalHeaders,
-    signedHeaders,
-    payloadHash,
-  ].join("\n");
-
-  const credentialScope = `${dateStamp}/${args.region}/${service}/aws4_request`;
-  const stringToSign = [
-    "AWS4-HMAC-SHA256",
-    amzDate,
-    credentialScope,
-    await sha256Hex(canonicalRequest),
-  ].join("\n");
-
-  const kDate = await hmac(ENC.encode("AWS4" + args.appKey), dateStamp);
-  const kRegion = await hmac(kDate, args.region);
-  const kService = await hmac(kRegion, service);
-  const kSigning = await hmac(kService, "aws4_request");
-  const signature = bufToHex(await hmac(kSigning, stringToSign));
-
-  return {
-    ...args.headers,
-    Host: args.url.host,
-    "X-Amz-Content-Sha256": payloadHash,
-    "X-Amz-Date": amzDate,
-    Authorization: `AWS4-HMAC-SHA256 Credential=${args.keyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
-  };
-}
-
-// ── public helpers ─────────────────────────────────────────────────────
-
-function objectUrl(env: B2Env, key: string): { url: URL; cfg: ReturnType<typeof readEnv> } {
-  const cfg = readEnv(env);
-  const url = new URL(`${cfg.endpoint}/${cfg.bucket}/${key.replace(/^\/+/, "")}`);
-  return { url, cfg };
-}
-
-/**
- * GET an object. Returns `null` on 404 (mirrors `R2Bucket.get` shape).
- * Throws on other non-2xx responses.
- */
-export async function b2Get(env: B2Env, key: string): Promise<B2GetResult | null> {
-  const { url, cfg } = objectUrl(env, key);
-  const headers = await signRequest({
-    method: "GET", url, headers: {}, payload: "",
-    region: cfg.region, keyId: cfg.keyId, appKey: cfg.appKey,
-  });
-  const resp = await fetch(url.toString(), { method: "GET", headers });
-  if (resp.status === 404) return null;
-  if (!resp.ok) throw new Error(`b2Get ${key}: ${resp.status} ${await safeText(resp)}`);
-  return responseToGetResult(resp);
-}
-
-/**
- * HEAD an object. Returns `null` on 404 (mirrors `R2Bucket.head`).
- */
-export async function b2Head(env: B2Env, key: string): Promise<B2HeadResult | null> {
-  const { url, cfg } = objectUrl(env, key);
-  const headers = await signRequest({
-    method: "HEAD", url, headers: {}, payload: "",
-    region: cfg.region, keyId: cfg.keyId, appKey: cfg.appKey,
-  });
-  const resp = await fetch(url.toString(), { method: "HEAD", headers });
-  if (resp.status === 404) return null;
-  if (!resp.ok) throw new Error(`b2Head ${key}: ${resp.status} ${await safeText(resp)}`);
-  return {
-    size: Number(resp.headers.get("content-length") ?? "0"),
-    etag: resp.headers.get("etag"),
-    contentType: resp.headers.get("content-type"),
-  };
-}
-
-/**
- * PUT an object. Resolves the SHA-256 hash up front (S3 SigV4 requires
- * `x-amz-content-sha256` of the body, no streaming-unsigned). Returns
- * the etag returned by B2.
- */
-export async function b2Put(
-  env: B2Env,
-  key: string,
-  body: ArrayBuffer | Uint8Array | string,
-  opts: B2PutOptions = {},
-): Promise<{ etag: string | null }> {
-  const { url, cfg } = objectUrl(env, key);
-  const payload =
-    typeof body === "string"
-      ? ENC.encode(body).buffer as ArrayBuffer
-      : body instanceof Uint8Array
-        ? body.slice().buffer
-        : body;
-
-  const baseHeaders: Record<string, string> = {};
-  if (opts.contentType) baseHeaders["Content-Type"] = opts.contentType;
-  if (opts.cacheControl) baseHeaders["Cache-Control"] = opts.cacheControl;
-  if (opts.metadata) {
-    for (const [k, v] of Object.entries(opts.metadata)) {
-      baseHeaders[`x-amz-meta-${k.toLowerCase()}`] = v;
-    }
-  }
-
-  const headers = await signRequest({
-    method: "PUT", url, headers: baseHeaders, payload,
-    region: cfg.region, keyId: cfg.keyId, appKey: cfg.appKey,
-  });
-  const resp = await fetch(url.toString(), {
-    method: "PUT",
-    headers,
-    body: payload,
-  });
-  if (!resp.ok) throw new Error(`b2Put ${key}: ${resp.status} ${await safeText(resp)}`);
-  return { etag: resp.headers.get("etag") };
-}
-
-/**
- * DELETE an object. Idempotent — 404 is treated as success (the
- * caller's intent was "make sure this is gone").
- */
-export async function b2Delete(env: B2Env, key: string): Promise<void> {
-  const { url, cfg } = objectUrl(env, key);
-  const headers = await signRequest({
-    method: "DELETE", url, headers: {}, payload: "",
-    region: cfg.region, keyId: cfg.keyId, appKey: cfg.appKey,
-  });
-  const resp = await fetch(url.toString(), { method: "DELETE", headers });
-  if (resp.status === 404) return;
-  if (!resp.ok && resp.status !== 204) {
-    throw new Error(`b2Delete ${key}: ${resp.status} ${await safeText(resp)}`);
-  }
-}
-
-// ── helpers ────────────────────────────────────────────────────────────
-
-function responseToGetResult(resp: Response): B2GetResult {
-  // Tee the body so a caller can do .arrayBuffer() and still walk
-  // .response.body if they prefer streaming.
-  const [a, b] = resp.body!.tee();
-  return {
-    body: b,
-    arrayBuffer: () => new Response(a).arrayBuffer(),
-    text: () => new Response(a).text(),
-    json: <T = unknown>() => new Response(a).json() as Promise<T>,
-    size: Number(resp.headers.get("content-length") ?? "0"),
-    etag: resp.headers.get("etag"),
-    contentType: resp.headers.get("content-type"),
-    response: resp,
-  };
-}
-
-async function safeText(resp: Response): Promise<string> {
-  try {
-    const t = await resp.text();
-    return t.length > 300 ? t.slice(0, 300) + "…" : t;
-  } catch {
-    return "";
-  }
-}
+// Re-export the canonical names too, so a `./b2` importer can migrate
+// in place without changing the import path.
+export { s3Get, s3Put, s3Head, s3Delete };
+export type { S3Env, S3GetResult, S3PutOptions, S3HeadResult };

--- a/crates/kotoba-kotodama/sdk/kotodama-host-sdk/src/index.ts
+++ b/crates/kotoba-kotodama/sdk/kotodama-host-sdk/src/index.ts
@@ -385,6 +385,10 @@ export type { ConsentHelper, ConsentSubmitInput, ConsentRequestRecord, ConsentVe
 export { createAgentLifecycle } from "./agent-lifecycle.js";
 export type { AgentLifecycle, AgentSpawnConfig, AgentRecord, AgentEvent, AgentStatus } from "./agent-lifecycle.js";
 
+// Generic S3-compatible blob helpers (provider-agnostic; B2 = one endpoint).
+export { s3Get, s3Put, s3Head, s3Delete } from "./s3.js";
+export type { S3Env, S3GetResult, S3PutOptions, S3HeadResult } from "./s3.js";
+// Backward-compat aliases — `b2*` re-exports the same s3 implementation.
 export { b2Get, b2Put, b2Head, b2Delete } from "./b2.js";
 export type { B2Env, B2GetResult, B2PutOptions, B2HeadResult } from "./b2.js";
 

--- a/crates/kotoba-kotodama/sdk/kotodama-host-sdk/src/s3.ts
+++ b/crates/kotoba-kotodama/sdk/kotodama-host-sdk/src/s3.ts
@@ -1,0 +1,347 @@
+/**
+ * Generic S3-compatible blob helpers — Cloudflare Worker-friendly. No
+ * external SDK; all S3 SigV4 signing is done with `crypto.subtle`
+ * (HMAC-SHA256). Response shape mirrors `R2Bucket` so migration from
+ * `env.CDN_R2.get(...)` is mechanical.
+ *
+ * This is provider-agnostic: it speaks the AWS S3 SigV4 REST API, so it
+ * works against any S3-compatible endpoint (AWS S3, Backblaze B2,
+ * Cloudflare R2, MinIO, Linode/Vultr Object Storage, …). The endpoint,
+ * region and bucket are pure configuration — nothing is hard-coded to a
+ * single provider.
+ *
+ * Env shape (canonical):
+ *
+ *   S3_ENDPOINT             https://s3.<region>.example.com   (provider URL)
+ *   S3_REGION               us-east-1
+ *   S3_BUCKET               my-bucket
+ *   S3_ACCESS_KEY_ID        (wrangler secret put S3_ACCESS_KEY_ID)
+ *   S3_SECRET_ACCESS_KEY    (wrangler secret put S3_SECRET_ACCESS_KEY)
+ *   S3_SERVICE              (optional, default "s3")
+ *
+ * Legacy `B2_*` names are still honoured as a fallback so existing
+ * Backblaze-configured deployments keep working without a config change:
+ *
+ *   B2_ENDPOINT  → S3_ENDPOINT
+ *   B2_REGION    → S3_REGION
+ *   B2_BUCKET    → S3_BUCKET
+ *   B2_KEY_ID            → S3_ACCESS_KEY_ID
+ *   B2_APPLICATION_KEY   → S3_SECRET_ACCESS_KEY
+ *
+ * Usage:
+ *
+ *   import { s3Get, s3Put, s3Head, s3Delete } from "@etzhayyim/kotodama-host-sdk/s3";
+ *   const obj = await s3Get(env, "bim/blobs/abc123");
+ *   if (obj) {
+ *     const buf = await obj.arrayBuffer();
+ *     // ... parse ...
+ *   }
+ *   await s3Put(env, "bim/meshes/abc123", buf, { contentType: "model/gltf-binary" });
+ */
+
+export interface S3Env {
+  S3_ENDPOINT?: string;
+  S3_REGION?: string;
+  S3_BUCKET?: string;
+  S3_ACCESS_KEY_ID?: string;
+  S3_SECRET_ACCESS_KEY?: string;
+  S3_SERVICE?: string;
+
+  // ── legacy Backblaze names (honoured as fallback) ──────────────────
+  B2_ENDPOINT?: string;
+  B2_REGION?: string;
+  B2_BUCKET?: string;
+  B2_KEY_ID?: string;
+  B2_APPLICATION_KEY?: string;
+}
+
+export interface S3GetResult {
+  body: ReadableStream<Uint8Array>;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  text(): Promise<string>;
+  json<T = unknown>(): Promise<T>;
+  size: number;
+  etag: string | null;
+  contentType: string | null;
+  /** Raw underlying Response — for streaming pass-through. */
+  response: Response;
+}
+
+export interface S3PutOptions {
+  contentType?: string;
+  cacheControl?: string;
+  metadata?: Record<string, string>;
+}
+
+export interface S3HeadResult {
+  size: number;
+  etag: string | null;
+  contentType: string | null;
+}
+
+interface S3Config {
+  endpoint: string;
+  region: string;
+  bucket: string;
+  keyId: string;
+  secretKey: string;
+  service: string;
+  host: string;
+}
+
+function readEnv(env: S3Env): S3Config {
+  const endpointRaw = env.S3_ENDPOINT ?? env.B2_ENDPOINT;
+  const region = env.S3_REGION ?? env.B2_REGION;
+  const bucket = env.S3_BUCKET ?? env.B2_BUCKET;
+  const keyId = env.S3_ACCESS_KEY_ID ?? env.B2_KEY_ID;
+  const secretKey = env.S3_SECRET_ACCESS_KEY ?? env.B2_APPLICATION_KEY;
+
+  const missing: string[] = [];
+  if (!endpointRaw) missing.push("S3_ENDPOINT");
+  if (!region) missing.push("S3_REGION");
+  if (!bucket) missing.push("S3_BUCKET");
+  if (!keyId) missing.push("S3_ACCESS_KEY_ID");
+  if (!secretKey) missing.push("S3_SECRET_ACCESS_KEY");
+  if (missing.length) {
+    throw new Error(`s3: not configured — missing ${missing.join(", ")}`);
+  }
+
+  const endpoint = endpointRaw!.replace(/\/$/, "");
+  const url = new URL(endpoint);
+  return {
+    endpoint,
+    region: region!,
+    bucket: bucket!,
+    keyId: keyId!,
+    secretKey: secretKey!,
+    service: env.S3_SERVICE ?? "s3",
+    host: url.host,
+  };
+}
+
+// ── S3 SigV4 signing (RFC 4231 HMAC-SHA256 via crypto.subtle) ──────────
+
+const ENC = new TextEncoder();
+
+async function hmac(key: ArrayBuffer | Uint8Array, message: string): Promise<ArrayBuffer> {
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    key as BufferSource,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  return crypto.subtle.sign("HMAC", cryptoKey, ENC.encode(message));
+}
+
+function bufToHex(buf: ArrayBuffer): string {
+  const view = new Uint8Array(buf);
+  let s = "";
+  for (let i = 0; i < view.length; i++) s += view[i].toString(16).padStart(2, "0");
+  return s;
+}
+
+async function sha256Hex(payload: ArrayBuffer | string): Promise<string> {
+  const data = typeof payload === "string" ? ENC.encode(payload) : new Uint8Array(payload);
+  return bufToHex(await crypto.subtle.digest("SHA-256", data));
+}
+
+function uriEncode(s: string, encodeSlash = false): string {
+  // S3 SigV4 — RFC 3986 unreserved + skip "/" inside path components.
+  return s.split("").map((c) => {
+    if (/[A-Za-z0-9\-_.~]/.test(c)) return c;
+    if (c === "/" && !encodeSlash) return c;
+    return encodeURIComponent(c).toUpperCase();
+  }).join("");
+}
+
+interface SignArgs {
+  method: "GET" | "PUT" | "HEAD" | "DELETE";
+  url: URL;
+  headers: Record<string, string>;
+  payload: ArrayBuffer | string;
+  region: string;
+  keyId: string;
+  secretKey: string;
+  service: string;
+}
+
+async function signRequest(args: SignArgs): Promise<Record<string, string>> {
+  const service = args.service;
+  const now = new Date();
+  const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, ""); // 20260425T101530Z
+  const dateStamp = amzDate.slice(0, 8);
+  const payloadHash = await sha256Hex(args.payload);
+
+  const canonicalHeadersObj: Record<string, string> = {
+    ...Object.fromEntries(
+      Object.entries(args.headers).map(([k, v]) => [k.toLowerCase().trim(), String(v).trim()]),
+    ),
+    host: args.url.host,
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": amzDate,
+  };
+  const sortedHeaderNames = Object.keys(canonicalHeadersObj).sort();
+  const canonicalHeaders = sortedHeaderNames.map((n) => `${n}:${canonicalHeadersObj[n]}\n`).join("");
+  const signedHeaders = sortedHeaderNames.join(";");
+
+  const canonicalQuery = [...args.url.searchParams.entries()]
+    .map(([k, v]) => [uriEncode(k, true), uriEncode(v, true)] as const)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${k}=${v}`)
+    .join("&");
+
+  const canonicalRequest = [
+    args.method,
+    uriEncode(args.url.pathname, false),
+    canonicalQuery,
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+
+  const credentialScope = `${dateStamp}/${args.region}/${service}/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    amzDate,
+    credentialScope,
+    await sha256Hex(canonicalRequest),
+  ].join("\n");
+
+  const kDate = await hmac(ENC.encode("AWS4" + args.secretKey), dateStamp);
+  const kRegion = await hmac(kDate, args.region);
+  const kService = await hmac(kRegion, service);
+  const kSigning = await hmac(kService, "aws4_request");
+  const signature = bufToHex(await hmac(kSigning, stringToSign));
+
+  return {
+    ...args.headers,
+    Host: args.url.host,
+    "X-Amz-Content-Sha256": payloadHash,
+    "X-Amz-Date": amzDate,
+    Authorization: `AWS4-HMAC-SHA256 Credential=${args.keyId}/${credentialScope}, SignedHeaders=${signedHeaders}, Signature=${signature}`,
+  };
+}
+
+// ── public helpers ─────────────────────────────────────────────────────
+
+function objectUrl(env: S3Env, key: string): { url: URL; cfg: S3Config } {
+  const cfg = readEnv(env);
+  const url = new URL(`${cfg.endpoint}/${cfg.bucket}/${key.replace(/^\/+/, "")}`);
+  return { url, cfg };
+}
+
+async function sign(cfg: S3Config, method: SignArgs["method"], url: URL, headers: Record<string, string>, payload: ArrayBuffer | string): Promise<Record<string, string>> {
+  return signRequest({
+    method, url, headers, payload,
+    region: cfg.region, keyId: cfg.keyId, secretKey: cfg.secretKey, service: cfg.service,
+  });
+}
+
+/**
+ * GET an object. Returns `null` on 404 (mirrors `R2Bucket.get` shape).
+ * Throws on other non-2xx responses.
+ */
+export async function s3Get(env: S3Env, key: string): Promise<S3GetResult | null> {
+  const { url, cfg } = objectUrl(env, key);
+  const headers = await sign(cfg, "GET", url, {}, "");
+  const resp = await fetch(url.toString(), { method: "GET", headers });
+  if (resp.status === 404) return null;
+  if (!resp.ok) throw new Error(`s3Get ${key}: ${resp.status} ${await safeText(resp)}`);
+  return responseToGetResult(resp);
+}
+
+/**
+ * HEAD an object. Returns `null` on 404 (mirrors `R2Bucket.head`).
+ */
+export async function s3Head(env: S3Env, key: string): Promise<S3HeadResult | null> {
+  const { url, cfg } = objectUrl(env, key);
+  const headers = await sign(cfg, "HEAD", url, {}, "");
+  const resp = await fetch(url.toString(), { method: "HEAD", headers });
+  if (resp.status === 404) return null;
+  if (!resp.ok) throw new Error(`s3Head ${key}: ${resp.status} ${await safeText(resp)}`);
+  return {
+    size: Number(resp.headers.get("content-length") ?? "0"),
+    etag: resp.headers.get("etag"),
+    contentType: resp.headers.get("content-type"),
+  };
+}
+
+/**
+ * PUT an object. Resolves the SHA-256 hash up front (S3 SigV4 requires
+ * `x-amz-content-sha256` of the body, no streaming-unsigned). Returns
+ * the etag returned by the store.
+ */
+export async function s3Put(
+  env: S3Env,
+  key: string,
+  body: ArrayBuffer | Uint8Array | string,
+  opts: S3PutOptions = {},
+): Promise<{ etag: string | null }> {
+  const { url, cfg } = objectUrl(env, key);
+  const payload =
+    typeof body === "string"
+      ? ENC.encode(body).buffer as ArrayBuffer
+      : body instanceof Uint8Array
+        ? body.slice().buffer
+        : body;
+
+  const baseHeaders: Record<string, string> = {};
+  if (opts.contentType) baseHeaders["Content-Type"] = opts.contentType;
+  if (opts.cacheControl) baseHeaders["Cache-Control"] = opts.cacheControl;
+  if (opts.metadata) {
+    for (const [k, v] of Object.entries(opts.metadata)) {
+      baseHeaders[`x-amz-meta-${k.toLowerCase()}`] = v;
+    }
+  }
+
+  const headers = await sign(cfg, "PUT", url, baseHeaders, payload);
+  const resp = await fetch(url.toString(), {
+    method: "PUT",
+    headers,
+    body: payload,
+  });
+  if (!resp.ok) throw new Error(`s3Put ${key}: ${resp.status} ${await safeText(resp)}`);
+  return { etag: resp.headers.get("etag") };
+}
+
+/**
+ * DELETE an object. Idempotent — 404 is treated as success (the
+ * caller's intent was "make sure this is gone").
+ */
+export async function s3Delete(env: S3Env, key: string): Promise<void> {
+  const { url, cfg } = objectUrl(env, key);
+  const headers = await sign(cfg, "DELETE", url, {}, "");
+  const resp = await fetch(url.toString(), { method: "DELETE", headers });
+  if (resp.status === 404) return;
+  if (!resp.ok && resp.status !== 204) {
+    throw new Error(`s3Delete ${key}: ${resp.status} ${await safeText(resp)}`);
+  }
+}
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+function responseToGetResult(resp: Response): S3GetResult {
+  // Tee the body so a caller can do .arrayBuffer() and still walk
+  // .response.body if they prefer streaming.
+  const [a, b] = resp.body!.tee();
+  return {
+    body: b,
+    arrayBuffer: () => new Response(a).arrayBuffer(),
+    text: () => new Response(a).text(),
+    json: <T = unknown>() => new Response(a).json() as Promise<T>,
+    size: Number(resp.headers.get("content-length") ?? "0"),
+    etag: resp.headers.get("etag"),
+    contentType: resp.headers.get("content-type"),
+    response: resp,
+  };
+}
+
+async function safeText(resp: Response): Promise<string> {
+  try {
+    const t = await resp.text();
+    return t.length > 300 ? t.slice(0, 300) + "…" : t;
+  } catch {
+    return "";
+  }
+}

--- a/crates/kotoba-kotodama/sdk/kotodama-host-sdk/test/s3.node-check.ts
+++ b/crates/kotoba-kotodama/sdk/kotodama-host-sdk/test/s3.node-check.ts
@@ -1,0 +1,146 @@
+/**
+ * Standalone `node --test` verification for src/s3.ts — runs without the
+ * (currently uninstalled) vitest toolchain, using Node's built-in type
+ * stripping + node:test + node:assert. Mirrors test/s3.test.ts.
+ *
+ *   node --test test/s3.node-check.ts
+ *
+ * The SigV4 cross-check derives the expected signature INDEPENDENTLY with
+ * node:crypto, reading back the X-Amz-Date the implementation actually
+ * used (no clock stubbing needed).
+ */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHmac, createHash } from "node:crypto";
+import { s3Get, s3Put, s3Head, s3Delete, type S3Env } from "../src/s3.ts";
+
+// ── independent SigV4 reference ────────────────────────────────────────
+const sha256Hex = (s: string) => createHash("sha256").update(s, "utf8").digest("hex");
+const hmac = (key: Buffer | string, msg: string) => createHmac("sha256", key).update(msg, "utf8").digest();
+const uriEncode = (s: string, encodeSlash: boolean) =>
+  s.split("").map((c) =>
+    /[A-Za-z0-9\-_.~]/.test(c) ? c : c === "/" && !encodeSlash ? c : encodeURIComponent(c).toUpperCase(),
+  ).join("");
+
+function expectedSignature(o: {
+  method: string; endpoint: string; bucket: string; key: string;
+  region: string; service: string; secretKey: string; amzDate: string;
+}): string {
+  const url = new URL(`${o.endpoint}/${o.bucket}/${o.key}`);
+  const dateStamp = o.amzDate.slice(0, 8);
+  const payloadHash = sha256Hex("");
+  const headers: Record<string, string> = {
+    host: url.host, "x-amz-content-sha256": payloadHash, "x-amz-date": o.amzDate,
+  };
+  const names = Object.keys(headers).sort();
+  const canonicalHeaders = names.map((n) => `${n}:${headers[n]}\n`).join("");
+  const canonicalRequest = [
+    o.method, uriEncode(url.pathname, false), "", canonicalHeaders, names.join(";"), payloadHash,
+  ].join("\n");
+  const scope = `${dateStamp}/${o.region}/${o.service}/aws4_request`;
+  const stringToSign = ["AWS4-HMAC-SHA256", o.amzDate, scope, sha256Hex(canonicalRequest)].join("\n");
+  const kSigning = hmac(hmac(hmac(hmac("AWS4" + o.secretKey, dateStamp), o.region), o.service), "aws4_request");
+  return hmac(kSigning, stringToSign).toString("hex");
+}
+
+// ── mocked fetch ───────────────────────────────────────────────────────
+let captured: { url: string; init: RequestInit }[] = [];
+function mockFetch(make: () => Response) {
+  captured = [];
+  globalThis.fetch = (async (url: string, init: RequestInit) => {
+    captured.push({ url: String(url), init });
+    return make();
+  }) as any;
+}
+const authParts = (h: string) => ({
+  cred: /Credential=([^,]+)/.exec(h)?.[1] ?? "",
+  signed: /SignedHeaders=([^,]+)/.exec(h)?.[1] ?? "",
+  sig: /Signature=([0-9a-f]+)/.exec(h)?.[1] ?? "",
+});
+
+const CANON: S3Env = {
+  S3_ENDPOINT: "https://s3.us-east-1.example.com", S3_REGION: "us-east-1",
+  S3_BUCKET: "etzhayyim-cdn", S3_ACCESS_KEY_ID: "AKIDEXAMPLE",
+  S3_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+};
+const B2: S3Env = {
+  B2_ENDPOINT: "https://s3.us-east-005.backblazeb2.com", B2_REGION: "us-east-005",
+  B2_BUCKET: "etzhayyim-cache", B2_KEY_ID: "00bbexamplekeyid",
+  B2_APPLICATION_KEY: "K005exampleapplicationkey",
+};
+
+test("SigV4 signature matches independent node:crypto derivation (GET)", async () => {
+  mockFetch(() => new Response("hello", { status: 200 }));
+  await s3Get(CANON, "blobs/abc123");
+  const h = captured[0].init.headers as Record<string, string>;
+  const { cred, signed, sig } = authParts(h.Authorization);
+  assert.equal(signed, "host;x-amz-content-sha256;x-amz-date");
+  assert.match(cred, /^AKIDEXAMPLE\/\d{8}\/us-east-1\/s3\/aws4_request$/);
+  assert.equal(sig, expectedSignature({
+    method: "GET", endpoint: CANON.S3_ENDPOINT!, bucket: CANON.S3_BUCKET!, key: "blobs/abc123",
+    region: "us-east-1", service: "s3", secretKey: CANON.S3_SECRET_ACCESS_KEY!, amzDate: h["X-Amz-Date"],
+  }));
+});
+
+test("request targets bucket/key path + sets amz headers", async () => {
+  mockFetch(() => new Response(null, { status: 404 }));
+  await s3Get(CANON, "blobs/abc123");
+  const h = captured[0].init.headers as Record<string, string>;
+  assert.equal(captured[0].url, "https://s3.us-east-1.example.com/etzhayyim-cdn/blobs/abc123");
+  assert.equal(h["X-Amz-Content-Sha256"], sha256Hex(""));
+});
+
+test("s3Put sends body + content-type, signs content-type", async () => {
+  mockFetch(() => new Response(null, { status: 200, headers: { etag: '"deadbeef"' } }));
+  const res = await s3Put(CANON, "img/cat.jpg", new Uint8Array([1, 2, 3]), { contentType: "image/jpeg" });
+  assert.equal(captured[0].init.method, "PUT");
+  assert.deepEqual(new Uint8Array(captured[0].init.body as ArrayBuffer), new Uint8Array([1, 2, 3]));
+  const h = captured[0].init.headers as Record<string, string>;
+  assert.equal(h["Content-Type"], "image/jpeg");
+  assert.equal(authParts(h.Authorization).signed, "content-type;host;x-amz-content-sha256;x-amz-date");
+  assert.equal(res.etag, '"deadbeef"');
+});
+
+test("s3Get 404→null, 200→parsed", async () => {
+  mockFetch(() => new Response(null, { status: 404 }));
+  assert.equal(await s3Get(CANON, "missing"), null);
+  mockFetch(() => new Response("payload-bytes", {
+    status: 200, headers: { "content-length": "13", "content-type": "video/mp4", etag: '"v1"' },
+  }));
+  const got = await s3Get(CANON, "vid/clip.mp4");
+  assert.ok(got);
+  assert.equal(got!.size, 13);
+  assert.equal(got!.contentType, "video/mp4");
+  assert.equal(await got!.text(), "payload-bytes");
+});
+
+test("s3Head 404→null, 200→size/type", async () => {
+  mockFetch(() => new Response(null, { status: 404 }));
+  assert.equal(await s3Head(CANON, "missing"), null);
+  mockFetch(() => new Response(null, { status: 200, headers: { "content-length": "1048576", "content-type": "video/mp4" } }));
+  assert.deepEqual(await s3Head(CANON, "vid/clip.mp4"), { size: 1048576, etag: null, contentType: "video/mp4" });
+});
+
+test("s3Delete idempotent on 404/204, throws on 500", async () => {
+  mockFetch(() => new Response(null, { status: 404 }));
+  await s3Delete(CANON, "gone");
+  mockFetch(() => new Response(null, { status: 204 }));
+  await s3Delete(CANON, "ok");
+  mockFetch(() => new Response("boom", { status: 500 }));
+  await assert.rejects(() => s3Delete(CANON, "err"), /s3Delete/);
+});
+
+test("legacy B2_* env honoured as fallback (B2 = one S3 endpoint)", async () => {
+  mockFetch(() => new Response(null, { status: 200 }));
+  await s3Put(B2, "k", "v");
+  const { cred } = authParts((captured[0].init.headers as Record<string, string>).Authorization);
+  assert.equal(captured[0].url, "https://s3.us-east-005.backblazeb2.com/etzhayyim-cache/k");
+  assert.match(cred, /^00bbexamplekeyid\/\d{8}\/us-east-005\/s3\/aws4_request$/);
+});
+
+test("missing config throws a clear error", async () => {
+  await assert.rejects(
+    () => s3Get({ S3_REGION: "us-east-1" } as S3Env, "k"),
+    /missing S3_ENDPOINT.*S3_BUCKET.*S3_ACCESS_KEY_ID.*S3_SECRET_ACCESS_KEY/,
+  );
+});

--- a/crates/kotoba-kotodama/sdk/kotodama-host-sdk/test/s3.test.ts
+++ b/crates/kotoba-kotodama/sdk/kotodama-host-sdk/test/s3.test.ts
@@ -1,0 +1,235 @@
+/**
+ * Unit tests for the generic S3-compatible blob helpers (`src/s3.ts`) and
+ * the `b2` backward-compat shim (`src/b2.ts`).
+ *
+ * Verification strategy (no live network / no real credentials):
+ *  1. SigV4 correctness — an INDEPENDENT re-implementation of AWS SigV4
+ *     using node:crypto recomputes the signature and asserts it matches
+ *     the Authorization header s3.ts produced (two implementations
+ *     agreeing = real correctness check, not a tautology).
+ *  2. Round-trip semantics over a mocked fetch — PUT body/headers, GET
+ *     404→null, HEAD size parse, DELETE idempotency.
+ *  3. Provider-agnostic config — S3_* canonical env AND legacy B2_*
+ *     fallback both work (proves nothing is hard-coded to Backblaze).
+ *  4. b2* aliases still resolve to the s3 implementation.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createHmac, createHash } from "node:crypto";
+import { s3Get, s3Put, s3Head, s3Delete, type S3Env } from "../src/s3.js";
+import { b2Get, b2Put, b2Head, b2Delete } from "../src/b2.js";
+
+// ── independent SigV4 reference (node:crypto) ──────────────────────────
+const FIXED_ISO = "2026-04-25T10:15:30.000Z";
+const AMZ_DATE = "20260425T101530Z";
+const DATE_STAMP = "20260425";
+
+function sha256Hex(s: string): string {
+  return createHash("sha256").update(s, "utf8").digest("hex");
+}
+function hmac(key: Buffer | string, msg: string): Buffer {
+  return createHmac("sha256", key).update(msg, "utf8").digest();
+}
+function uriEncode(s: string, encodeSlash: boolean): string {
+  return s.split("").map((c) => {
+    if (/[A-Za-z0-9\-_.~]/.test(c)) return c;
+    if (c === "/" && !encodeSlash) return c;
+    return encodeURIComponent(c).toUpperCase();
+  }).join("");
+}
+
+/** Re-derive the expected SigV4 signature for an empty-payload request. */
+function expectedSignature(opts: {
+  method: string; endpoint: string; bucket: string; key: string;
+  region: string; service: string; secretKey: string;
+}): string {
+  const url = new URL(`${opts.endpoint}/${opts.bucket}/${opts.key}`);
+  const payloadHash = sha256Hex(""); // empty body
+  const headers: Record<string, string> = {
+    host: url.host,
+    "x-amz-content-sha256": payloadHash,
+    "x-amz-date": AMZ_DATE,
+  };
+  const names = Object.keys(headers).sort();
+  const canonicalHeaders = names.map((n) => `${n}:${headers[n]}\n`).join("");
+  const signedHeaders = names.join(";");
+  const canonicalRequest = [
+    opts.method,
+    uriEncode(url.pathname, false),
+    "", // no query
+    canonicalHeaders,
+    signedHeaders,
+    payloadHash,
+  ].join("\n");
+  const scope = `${DATE_STAMP}/${opts.region}/${opts.service}/aws4_request`;
+  const stringToSign = [
+    "AWS4-HMAC-SHA256",
+    AMZ_DATE,
+    scope,
+    sha256Hex(canonicalRequest),
+  ].join("\n");
+  const kDate = hmac("AWS4" + opts.secretKey, DATE_STAMP);
+  const kRegion = hmac(kDate, opts.region);
+  const kService = hmac(kRegion, opts.service);
+  const kSigning = hmac(kService, "aws4_request");
+  return hmac(kSigning, stringToSign).toString("hex");
+}
+
+// ── mocked fetch ───────────────────────────────────────────────────────
+interface Captured { url: string; init: RequestInit; }
+let captured: Captured[];
+
+function mockFetchReturning(make: (call: Captured) => Response) {
+  return vi.fn(async (url: string, init: RequestInit) => {
+    const call = { url: String(url), init };
+    captured.push(call);
+    return make(call);
+  });
+}
+
+const CANON_ENV: S3Env = {
+  S3_ENDPOINT: "https://s3.us-east-1.example.com",
+  S3_REGION: "us-east-1",
+  S3_BUCKET: "etzhayyim-cdn",
+  S3_ACCESS_KEY_ID: "AKIDEXAMPLE",
+  S3_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
+};
+
+const LEGACY_B2_ENV: S3Env = {
+  B2_ENDPOINT: "https://s3.us-east-005.backblazeb2.com",
+  B2_REGION: "us-east-005",
+  B2_BUCKET: "etzhayyim-cache",
+  B2_KEY_ID: "00bbexamplekeyid",
+  B2_APPLICATION_KEY: "K005exampleapplicationkey",
+};
+
+function authParts(header: string) {
+  // AWS4-HMAC-SHA256 Credential=<id>/<scope>, SignedHeaders=<h>, Signature=<sig>
+  const cred = /Credential=([^,]+)/.exec(header)?.[1] ?? "";
+  const signed = /SignedHeaders=([^,]+)/.exec(header)?.[1] ?? "";
+  const sig = /Signature=([0-9a-f]+)/.exec(header)?.[1] ?? "";
+  return { cred, signed, sig };
+}
+
+beforeEach(() => {
+  captured = [];
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(FIXED_ISO));
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("s3 SigV4 signing — correctness vs independent reference", () => {
+  it("produces a signature matching an independent node:crypto SigV4 derivation (GET)", async () => {
+    globalThis.fetch = mockFetchReturning(() => new Response("hello", { status: 200 })) as any;
+    await s3Get(CANON_ENV, "blobs/abc123");
+
+    const header = (captured[0].init.headers as Record<string, string>).Authorization;
+    const { cred, signed, sig } = authParts(header);
+
+    expect(header.startsWith("AWS4-HMAC-SHA256 ")).toBe(true);
+    expect(cred).toBe("AKIDEXAMPLE/20260425/us-east-1/s3/aws4_request");
+    expect(signed).toBe("host;x-amz-content-sha256;x-amz-date");
+    expect(sig).toBe(expectedSignature({
+      method: "GET", endpoint: CANON_ENV.S3_ENDPOINT!, bucket: CANON_ENV.S3_BUCKET!,
+      key: "blobs/abc123", region: "us-east-1", service: "s3",
+      secretKey: CANON_ENV.S3_SECRET_ACCESS_KEY!,
+    }));
+  });
+
+  it("sets x-amz-date / x-amz-content-sha256 and signs the bucket/key path", async () => {
+    globalThis.fetch = mockFetchReturning(() => new Response(null, { status: 404 })) as any;
+    await s3Get(CANON_ENV, "blobs/abc123");
+    const h = captured[0].init.headers as Record<string, string>;
+    expect(h["X-Amz-Date"]).toBe(AMZ_DATE);
+    expect(h["X-Amz-Content-Sha256"]).toBe(sha256Hex(""));
+    expect(captured[0].url).toBe("https://s3.us-east-1.example.com/etzhayyim-cdn/blobs/abc123");
+  });
+});
+
+describe("s3 round-trip semantics over mocked fetch", () => {
+  it("s3Put sends the body, content-type, and signs content-type", async () => {
+    globalThis.fetch = mockFetchReturning(() => new Response(null, { status: 200, headers: { etag: '"deadbeef"' } })) as any;
+    const res = await s3Put(CANON_ENV, "img/cat.jpg", new Uint8Array([1, 2, 3]), { contentType: "image/jpeg" });
+
+    expect(captured[0].init.method).toBe("PUT");
+    expect(new Uint8Array(captured[0].init.body as ArrayBuffer)).toEqual(new Uint8Array([1, 2, 3]));
+    const h = captured[0].init.headers as Record<string, string>;
+    expect(h["Content-Type"]).toBe("image/jpeg");
+    // content-type must be part of the signed header set for a PUT
+    expect(authParts(h.Authorization).signed).toBe("content-type;host;x-amz-content-sha256;x-amz-date");
+    expect(res.etag).toBe('"deadbeef"');
+  });
+
+  it("s3Get returns null on 404, parses metadata on 200", async () => {
+    globalThis.fetch = mockFetchReturning(() => new Response(null, { status: 404 })) as any;
+    expect(await s3Get(CANON_ENV, "missing")).toBeNull();
+
+    globalThis.fetch = mockFetchReturning(() => new Response("payload-bytes", {
+      status: 200, headers: { "content-length": "13", "content-type": "video/mp4", etag: '"v1"' },
+    })) as any;
+    const got = await s3Get(CANON_ENV, "vid/clip.mp4");
+    expect(got).not.toBeNull();
+    expect(got!.size).toBe(13);
+    expect(got!.contentType).toBe("video/mp4");
+    expect(await got!.text()).toBe("payload-bytes");
+  });
+
+  it("s3Head returns null on 404 and size/type on 200", async () => {
+    globalThis.fetch = mockFetchReturning(() => new Response(null, { status: 404 })) as any;
+    expect(await s3Head(CANON_ENV, "missing")).toBeNull();
+
+    globalThis.fetch = mockFetchReturning(() => new Response(null, {
+      status: 200, headers: { "content-length": "1048576", "content-type": "video/mp4" },
+    })) as any;
+    const head = await s3Head(CANON_ENV, "vid/clip.mp4");
+    expect(head).toEqual({ size: 1048576, etag: null, contentType: "video/mp4" });
+  });
+
+  it("s3Delete treats 404 and 204 as success, throws on 500", async () => {
+    globalThis.fetch = mockFetchReturning(() => new Response(null, { status: 404 })) as any;
+    await expect(s3Delete(CANON_ENV, "gone")).resolves.toBeUndefined();
+
+    globalThis.fetch = mockFetchReturning(() => new Response(null, { status: 204 })) as any;
+    await expect(s3Delete(CANON_ENV, "ok")).resolves.toBeUndefined();
+
+    globalThis.fetch = mockFetchReturning(() => new Response("boom", { status: 500 })) as any;
+    await expect(s3Delete(CANON_ENV, "err")).rejects.toThrow(/s3Delete/);
+  });
+});
+
+describe("provider-agnostic config (not hard-coded to Backblaze)", () => {
+  it("works with canonical S3_* env against a non-B2 endpoint", async () => {
+    globalThis.fetch = mockFetchReturning(() => new Response(null, { status: 200 })) as any;
+    await s3Put(CANON_ENV, "k", "v");
+    expect(captured[0].url).toBe("https://s3.us-east-1.example.com/etzhayyim-cdn/k");
+  });
+
+  it("honours legacy B2_* env as a fallback (same code path, B2 = just one S3 endpoint)", async () => {
+    globalThis.fetch = mockFetchReturning(() => new Response(null, { status: 200 })) as any;
+    await s3Put(LEGACY_B2_ENV, "k", "v");
+    const { cred } = authParts((captured[0].init.headers as Record<string, string>).Authorization);
+    expect(captured[0].url).toBe("https://s3.us-east-005.backblazeb2.com/etzhayyim-cache/k");
+    expect(cred).toBe("00bbexamplekeyid/20260425/us-east-005/s3/aws4_request");
+  });
+
+  it("throws a clear error listing missing config keys", async () => {
+    await expect(s3Get({ S3_REGION: "us-east-1" } as S3Env, "k"))
+      .rejects.toThrow(/missing S3_ENDPOINT.*S3_BUCKET.*S3_ACCESS_KEY_ID.*S3_SECRET_ACCESS_KEY/);
+  });
+});
+
+describe("b2* backward-compat aliases resolve to the s3 implementation", () => {
+  it("b2Get/b2Put/b2Head/b2Delete behave identically", async () => {
+    expect(b2Get).toBe(s3Get);
+    expect(b2Put).toBe(s3Put);
+    expect(b2Head).toBe(s3Head);
+    expect(b2Delete).toBe(s3Delete);
+
+    globalThis.fetch = mockFetchReturning(() => new Response(null, { status: 200, headers: { etag: '"x"' } })) as any;
+    const r = await b2Put(LEGACY_B2_ENV, "legacy/key", "data", { contentType: "image/png" });
+    expect(r.etag).toBe('"x"');
+    expect(captured[0].url).toBe("https://s3.us-east-005.backblazeb2.com/etzhayyim-cache/legacy/key");
+  });
+});


### PR DESCRIPTION
## What

The shared blob upload/fetch helper in the kotodama host-sdk was hard-coded to **Backblaze B2** (`B2_*` env, `b2.ts`). This generalizes it to a **provider-agnostic S3-compatible** client so B2 is just one of many possible S3 endpoints (AWS S3 / Cloudflare R2 / MinIO / Linode / Vultr Object Storage).

## Changes

- **new `src/s3.ts`** — canonical `s3Get` / `s3Put` / `s3Head` / `s3Delete`. Config via `S3_*`:
  `S3_ENDPOINT` / `S3_REGION` / `S3_BUCKET` / `S3_ACCESS_KEY_ID` / `S3_SECRET_ACCESS_KEY` (+ optional `S3_SERVICE`, default `s3`). SigV4 signing unchanged (`crypto.subtle`, Cloudflare-Worker-friendly, no external SDK).
- **legacy `B2_*` env still honoured as a fallback** (`B2_ENDPOINT→S3_ENDPOINT`, `B2_KEY_ID→S3_ACCESS_KEY_ID`, `B2_APPLICATION_KEY→S3_SECRET_ACCESS_KEY`, …) — existing Backblaze-configured deployments (e.g. the k8s `atproto-pds` `B2_*` env) keep working with **no config change**.
- **`src/b2.ts`** is now a thin backward-compat shim re-exporting `s3.ts`; `b2Get`/`b2Put`/`b2Head`/`b2Delete` and the `B2*` types remain as aliases.
- `index.ts` re-exports `s3*` (keeps `b2*`); `package.json` adds the `./s3` export entry.

## Verification

`node --test` (Node type-stripping, no toolchain deps) — **8/8 pass**:
- **SigV4 signature cross-checked** against an *independent* `node:crypto` re-derivation (two implementations agreeing, not a tautology).
- put body/content-type (+ content-type is signed) / get 404→null + metadata parse / head size parse / delete 404·204 idempotency + 500 throw.
- both `S3_*` (non-B2 endpoint) and legacy `B2_*` config paths produce correct URL + credential scope.
- clear missing-config error listing absent keys.

A mirrored `vitest` suite (`test/s3.test.ts`) is included for the standard CI toolchain.

## Notes

- A separate per-app file `60-apps/.../cdn-b2.ts` (aws4fetch-based, functionally already S3) is still B2-named — left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)