### PR TITLE
feat(cells): salvage sys_adr_corpus_persist R2 ADR-corpus persistence cell onto main

### DIFF
--- a/crates/kotoba-kotodama/cells/sys_adr_corpus_persist/README.md
+++ b/crates/kotoba-kotodama/cells/sys_adr_corpus_persist/README.md
@@ -1,0 +1,11 @@
+# `sys_adr_corpus_persist` cell
+
+Elevates the `kotoba` content-addressed monorepo projection to Phase R2.
+Reads the static NDJSON quad stream generated in Phase R1 (`kotoba-quads.ndjson`) and persists it into the live kotoba EAVT datom log.
+
+Executes using `kotoba-wasm` node bindings and `kotodama` orchestration, running exclusively on the Murakumo fleet.
+
+**References**:
+- ADR-2606071800 (Phase R2 ADR corpus persistence)
+- ADR-2605281700 (R0 schema)
+- ADR-2605281800 (R1 ingest tool)

--- a/crates/kotoba-kotodama/cells/sys_adr_corpus_persist/__init__.py
+++ b/crates/kotoba-kotodama/cells/sys_adr_corpus_persist/__init__.py
@@ -1,0 +1,3 @@
+from .cell import SysAdrCorpusPersistCell
+
+__all__ = ["SysAdrCorpusPersistCell"]

--- a/crates/kotoba-kotodama/cells/sys_adr_corpus_persist/cell.py
+++ b/crates/kotoba-kotodama/cells/sys_adr_corpus_persist/cell.py
@@ -1,0 +1,76 @@
+"""Phase R2 ADR Corpus Persistence Cell.
+
+Purpose:
+    Elevates the ADR monorepo projection to Phase R2 by transacting
+    the R1 kotoba-quads.ndjson into the live kotoba EAVT database.
+    Executes using kotoba-wasm bindings on the Murakumo fleet.
+
+ADR:
+    ADR-2606071800
+
+Constitutional ceiling:
+    Passive ingestion of pre-computed, CID-anchored public ADRs only.
+    Must run on the Murakumo fleet (ADR-2605215000).
+"""
+
+import os
+from typing import Any
+
+# PHASE R2 ACTIVATION GATE
+# Requires an explicit environment flag or Council-signed tx in production.
+SYS_ADR_R2_PERSISTENCE_ACTIVATED = os.environ.get("SYS_ADR_R2_PERSISTENCE_ACTIVATED", "false").lower() == "true"
+
+if not SYS_ADR_R2_PERSISTENCE_ACTIVATED:
+    raise RuntimeError(
+        "sys_adr_corpus_persist R0 scaffold: activate via SYS_ADR_R2_PERSISTENCE_ACTIVATED=true "
+        "before execution on the Murakumo fleet (Phase R2)."
+    )
+
+
+class SysAdrCorpusPersistCell:
+    """Kotodama cell that ingests ADR quads into kotoba using kotoba-wasm."""
+
+    def __init__(self, wasm_engine: Any, quad_source_path: str = "90-docs/_registry/kotoba-quads.ndjson"):
+        """
+        Args:
+            wasm_engine: Injected kotoba-wasm engine binding (providing `commitSigned`).
+            quad_source_path: Path to the R1 NDJSON output.
+        """
+        self.wasm_engine = wasm_engine
+        self.quad_source_path = quad_source_path
+
+    def transact_corpus(self) -> dict[str, Any]:
+        """
+        Reads the NDJSON quad stream and writes it to the EAVT database.
+        Returns a receipt of the transaction containing the new state root (CID).
+        """
+        if not os.path.exists(self.quad_source_path):
+            raise FileNotFoundError(f"Missing ADR quad source: {self.quad_source_path}")
+
+        # In a real environment, this loop would batch quads into tx-datoms
+        # and invoke `self.wasm_engine.transact()` or `commitSigned()`.
+        lines_processed = 0
+        with open(self.quad_source_path, "r", encoding="utf-8") as f:
+            for line in f:
+                if not line.strip():
+                    continue
+                # 1. Parse NDJSON quad
+                # 2. Map to kotoba datom transaction format
+                # 3. Queue for batch commit
+                lines_processed += 1
+
+        # Simulate the commit via the WASM engine
+        commit_receipt = self.wasm_engine.commit(
+            batch_size=lines_processed,
+            graph="kotoba:graph:etzhayyim-root"
+        )
+
+        return {
+            "status": "success",
+            "quads_processed": lines_processed,
+            "root_cid": commit_receipt.get("cid"),
+            "signature": commit_receipt.get("signature")
+        }
+
+
+__all__ = ["SysAdrCorpusPersistCell"]


### PR DESCRIPTION
## Why

While advancing the parent repo's `40-engine/kotoba` submodule pointer to kotoba `main`, the parent's current pin was found to diverge from main, referencing a few commits not on main. One carried **real authored content**: the `sys_adr_corpus_persist` cell (committed via a "workspace batch" chore dump, never PR'd to main). This lands it on main so the submodule-pointer bump loses nothing.

## What

Adds `crates/kotoba-kotodama/cells/sys_adr_corpus_persist/` (README + `__init__.py` + `cell.py`, 90 LOC):
- Phase R2 cell that reads the R1 `kotoba-quads.ndjson` and transacts it into the live kotoba EAVT log via `kotoba-wasm` on the Murakumo fleet.
- **R0 scaffold**: guarded by `SYS_ADR_R2_PERSISTENCE_ACTIVATED` (raises `RuntimeError` until explicitly activated); the transact loop is stubbed. ADR-2606071800.

## Deliberately NOT carried over

The same divergent commits also contained (a) `node_modules` symlink/pointer noise and (b) a **v2.0** `CHARTER-RIDER.md` mirror clause `(j)` — superseded, since the authoritative parent-root `/CHARTER-RIDER.md` already prohibits monopolistic mining/extraction as **v3.0 clause (l)**. Neither is carried here.

## Verification

`python3 -m py_compile` clean; sits alongside the existing 277 cells under the same dir convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)