### PR TITLE
feat(git): git smart-HTTP wire protocol over datomic + IPFS (clone/fetch/push)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1949,6 +1949,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
 
 [[package]]
+name = "etzhayyim-chargespot-bma"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "kotoba-core",
+ "kotoba-kqe",
+ "kotoba-store",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "etzhayyim-chargespot-ingest"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "ciborium",
+ "ed25519-dalek",
+ "kotoba-auth",
+ "kotoba-core",
+ "kotoba-kqe",
+ "multibase",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2542,40 +2576,6 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
-]
-
-[[package]]
-name = "etzhayyim-chargespot-bma"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "kotoba-core",
- "kotoba-kqe",
- "kotoba-store",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "gftdcojp-chargespot-ingest"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "ciborium",
- "ed25519-dalek",
- "kotoba-auth",
- "kotoba-core",
- "kotoba-kqe",
- "multibase",
- "rand 0.8.6",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "tokio",
- "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -3545,10 +3545,8 @@ checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 name = "kotoba-auth"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "base64 0.22.1",
  "bs58",
- "bytes",
  "ciborium",
  "ed25519-dalek",
  "hex",
@@ -3581,7 +3579,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tracing",
  "tracing-subscriber",
  "urlencoding",
 ]
@@ -3597,8 +3594,6 @@ dependencies = [
  "ciborium",
  "cid",
  "data-encoding",
- "multibase",
- "multihash",
  "reqwest 0.12.28",
  "serde",
  "serde_bytes",
@@ -3615,7 +3610,6 @@ dependencies = [
  "aes-gcm",
  "async-trait",
  "base64 0.22.1",
- "bytes",
  "hex",
  "hkdf",
  "hmac",
@@ -3660,7 +3654,6 @@ dependencies = [
  "ciborium",
  "ed25519-dalek",
  "hex",
- "kotoba-auth",
  "kotoba-core",
  "kotoba-kqe",
  "kotoba-kse",
@@ -3688,7 +3681,6 @@ name = "kotoba-edn"
 version = "0.1.0"
 dependencies = [
  "ordered-float 4.6.0",
- "serde",
  "serde_json",
  "thiserror 1.0.69",
 ]
@@ -3697,7 +3689,6 @@ dependencies = [
 name = "kotoba-git"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "flate2",
  "hex",
  "kotoba-core",
@@ -3758,7 +3749,6 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "bytes",
- "futures",
  "kotoba-core",
  "kotoba-crypto",
  "kotoba-graph",
@@ -3821,7 +3811,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlparser",
- "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -3888,18 +3877,14 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
- "bytes",
  "ciborium",
  "futures",
  "hex",
- "kotoba-core",
- "kotoba-kse",
  "kotoba-rt",
  "libp2p",
  "serde",
  "serde_bytes",
  "serde_json",
- "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -3924,20 +3909,16 @@ name = "kotoba-runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bytes",
  "ciborium",
  "dashmap",
  "hex",
- "http 1.4.0",
  "hyper 1.9.0",
  "kotoba-auth",
  "kotoba-core",
  "kotoba-kqe",
- "kotoba-kse",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
- "tokio",
  "tracing",
  "ureq",
  "wasmtime",
@@ -3957,6 +3938,7 @@ dependencies = [
  "ciborium",
  "dashmap",
  "ed25519-dalek",
+ "flate2",
  "futures",
  "hex",
  "hmac",
@@ -3967,6 +3949,7 @@ dependencies = [
  "kotoba-dht",
  "kotoba-didcomm",
  "kotoba-edn",
+ "kotoba-git",
  "kotoba-graph",
  "kotoba-ingest",
  "kotoba-ipfs",
@@ -4002,18 +3985,14 @@ dependencies = [
 name = "kotoba-signal"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
  "bytes",
  "ed25519-dalek",
  "hkdf",
- "hmac",
  "kotoba-crypto",
  "kotoba-kse",
  "rand 0.8.6",
- "rand_core 0.6.4",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
  "x25519-dalek",
@@ -4028,7 +4007,6 @@ dependencies = [
  "bytes",
  "criterion",
  "dashmap",
- "data-encoding",
  "hex",
  "hmac",
  "kotoba-core",
@@ -4050,9 +4028,7 @@ dependencies = [
  "bytes",
  "js-sys",
  "kotoba-core",
- "serde",
  "serde-wasm-bindgen",
- "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
@@ -4084,7 +4060,6 @@ dependencies = [
  "kotoba-core",
  "kotoba-dht",
  "kotoba-kqe",
- "kotoba-kse",
  "kotoba-runtime",
  "kotoba-store",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,14 @@ members = [
     "crates/kotoba-git",
     "examples/ashiba-bmc",
     "examples/etzhayyim-chargespot-bma",
-    "examples/etzhayyim-chargespot-ingest", "crates/kotoba-kotodama",
+    "examples/etzhayyim-chargespot-ingest",
+]
+# kotoba-kotodama is its own nested workspace root (separate TS-native / e7m
+# build pipeline — see crates/kotoba-kotodama/CLAUDE.md). Listing it as a member
+# conflicts with its own [workspace] table ("multiple workspace roots"), so it is
+# excluded from this Rust workspace and built independently.
+exclude = [
+    "crates/kotoba-kotodama",
 ]
 resolver = "2"
 

--- a/crates/kotoba-git/src/lib.rs
+++ b/crates/kotoba-git/src/lib.rs
@@ -44,6 +44,7 @@ pub mod oid;
 pub mod pack;
 pub mod repo;
 pub mod schema;
+pub mod wire;
 
 pub use error::{GitError, Result};
 pub use object::{GitObject, GitObjectKind, TreeEntry};
@@ -106,6 +107,13 @@ impl<'a> GitStore<'a> {
         Ok(())
     }
 
+    /// A fresh read snapshot of the queryable projection. The wire protocol
+    /// (`wire::smart_http`) takes a new snapshot after each write so a
+    /// receive-pack sees the objects it just ingested when validating refs.
+    pub fn db(&self) -> Db {
+        self.conn.db()
+    }
+
     /// The `KotobaCid` of the framed block for `oid`, from the projection.
     pub fn object_cid(&self, db: &Db, oid: GitOid) -> Result<KotobaCid> {
         object_cid(db, oid)
@@ -134,6 +142,113 @@ impl<'a> GitStore<'a> {
     pub fn materialize_object(&self, db: &Db, oid: GitOid) -> Result<GitObject> {
         let framed = self.materialize_framed(db, oid)?;
         GitObject::parse_framed(&framed)
+    }
+
+    // ── Durable snapshot / rehydrate ──────────────────────────────────────────
+    //
+    // The object *bytes* are already durable: every `put_object` writes the
+    // framed block into the content-addressed `BlockStore` (IPFS), which a real
+    // deployment backs with Kubo. What is *not* inherently durable is the
+    // in-memory projection: the `oid↔cid` index and the refs. These two
+    // methods make a git repo durable by writing that index + refs into one more
+    // content-addressed block (the **manifest**) and rebuilding the projection
+    // from it — so after a restart, given the manifest CID, the full repo
+    // (objects + refs + queryable DAG) is reconstructable purely from IPFS
+    // blocks. The single mutable thing left is "repo → latest manifest CID",
+    // which the caller persists in its mutable-name boundary (e.g. `KseStore`).
+
+    /// Serialize the projection (object `oid↔cid` index + refs) into a
+    /// content-addressed manifest block and return its CID.
+    ///
+    /// Format (line-oriented ASCII, every git oid/refname is space-free):
+    /// ```text
+    /// kotoba-git-snapshot v1
+    /// O <oid-hex> <cid-multibase>      # one per object
+    /// R <refname> <oid-hex>            # a direct ref
+    /// S <refname> <target-refname>     # a symbolic ref (e.g. HEAD)
+    /// ```
+    pub fn snapshot_manifest(&self) -> Result<KotobaCid> {
+        let db = self.db();
+        let mut out = String::from("kotoba-git-snapshot v1\n");
+        for (oid, cid) in all_objects(&db) {
+            out.push_str(&format!("O {} {}\n", oid.to_hex(), cid.to_multibase()));
+        }
+        for (name, target) in list_refs(&db) {
+            match target {
+                RefTarget::Oid(oid) => out.push_str(&format!("R {} {}\n", name, oid.to_hex())),
+                RefTarget::Symbolic(t) => out.push_str(&format!("S {name} {t}\n")),
+            }
+        }
+        let bytes = out.into_bytes();
+        let cid = KotobaCid::from_bytes(&bytes);
+        put_verified(self.store, &cid, &bytes).map_err(|e| GitError::Store(e.to_string()))?;
+        Ok(cid)
+    }
+
+    /// Rebuild the projection from a manifest block previously produced by
+    /// [`Self::snapshot_manifest`]. Re-projects every object from its (durable)
+    /// block and restores all refs.
+    ///
+    /// Best-effort on missing object blocks: if a referenced block is absent
+    /// (e.g. a dev in-memory store that lost its blocks across restart) that
+    /// object is skipped and counted, rather than failing the whole repo load.
+    /// Returns `(objects_restored, objects_missing)`.
+    pub async fn rehydrate(&self, manifest_cid: &KotobaCid) -> Result<(usize, usize)> {
+        let bytes = self
+            .store
+            .get(manifest_cid)
+            .map_err(|e| GitError::Store(e.to_string()))?
+            .ok_or_else(|| GitError::BlockMissing(manifest_cid.to_multibase()))?;
+        let text = std::str::from_utf8(&bytes).map_err(|_| GitError::MalformedHeader)?;
+
+        let mut lines = text.lines();
+        match lines.next() {
+            Some(l) if l.starts_with("kotoba-git-snapshot ") => {}
+            _ => return Err(GitError::MalformedHeader),
+        }
+
+        let mut restored = 0usize;
+        let mut missing = 0usize;
+        // Two passes: objects first (so refs resolve), then refs.
+        let mut ref_lines: Vec<(char, String, String)> = Vec::new();
+        for line in lines {
+            let mut parts = line.splitn(3, ' ');
+            match (parts.next(), parts.next(), parts.next()) {
+                (Some("O"), Some(_oid), Some(cid_mb)) => {
+                    let Some(cid) = KotobaCid::from_multibase(cid_mb) else {
+                        missing += 1;
+                        continue;
+                    };
+                    match self.store.get(&cid) {
+                        Ok(Some(framed)) => {
+                            let obj = GitObject::parse_framed(&framed)?;
+                            self.put_object(&obj).await?;
+                            restored += 1;
+                        }
+                        _ => missing += 1,
+                    }
+                }
+                (Some("R"), Some(name), Some(oid)) => {
+                    ref_lines.push(('R', name.to_string(), oid.to_string()))
+                }
+                (Some("S"), Some(name), Some(target)) => {
+                    ref_lines.push(('S', name.to_string(), target.to_string()))
+                }
+                _ => {} // tolerate blank/unknown lines
+            }
+        }
+        for (kind, name, val) in ref_lines {
+            match kind {
+                'R' => {
+                    if let Ok(oid) = GitOid::from_hex(&val) {
+                        self.put_ref(&name, oid).await?;
+                    }
+                }
+                'S' => self.put_symbolic_ref(&name, &val).await?,
+                _ => {}
+            }
+        }
+        Ok((restored, missing))
     }
 }
 
@@ -487,6 +602,85 @@ first\n"
                 "b4ed918248039b78f24383523fa4e51f80994fac".into()
             )]]
         );
+    }
+
+    #[tokio::test]
+    async fn snapshot_then_rehydrate_into_fresh_connection() {
+        // A shared block store stands in for durable IPFS: the projection
+        // Connection is thrown away and rebuilt from the manifest CID alone.
+        let store = MemoryBlockStore::new();
+        let manifest_cid;
+        let commit_oid;
+        let blob_oid;
+        {
+            let conn = Connection::new();
+            let git = GitStore::new(&conn, &store);
+            git.install_schema().await.unwrap();
+            let blob = GitObject::blob(b"hello\n".to_vec());
+            let (b, _) = git.put_object(&blob).await.unwrap();
+            blob_oid = b;
+            let tree = GitObject::tree(&[TreeEntry {
+                mode: b"100644".to_vec(),
+                name: b"f.txt".to_vec(),
+                oid: blob_oid,
+            }]);
+            let (tree_oid, _) = git.put_object(&tree).await.unwrap();
+            let commit = GitObject::new(
+                GitObjectKind::Commit,
+                format!("tree {tree_oid}\n\nfirst\n").into_bytes(),
+            );
+            let (c, _) = git.put_object(&commit).await.unwrap();
+            commit_oid = c;
+            git.put_ref("refs/heads/main", commit_oid).await.unwrap();
+            git.put_symbolic_ref("HEAD", "refs/heads/main").await.unwrap();
+            manifest_cid = git.snapshot_manifest().unwrap();
+        }
+
+        // Fresh Connection (projection wiped), same block store (durable blocks).
+        let conn2 = Connection::new();
+        let git2 = GitStore::new(&conn2, &store);
+        git2.install_schema().await.unwrap();
+        let (restored, missing) = git2.rehydrate(&manifest_cid).await.unwrap();
+        assert_eq!((restored, missing), (3, 0));
+
+        let db = conn2.db();
+        assert_eq!(resolve_ref(&db, "refs/heads/main"), Some(commit_oid));
+        assert_eq!(resolve_ref(&db, "HEAD"), Some(commit_oid));
+        assert_eq!(all_objects(&db).len(), 3);
+        // round-trip byte-exact through the rebuilt projection
+        let framed = git2.materialize_framed(&db, blob_oid).unwrap();
+        assert_eq!(framed, b"blob 6\0hello\n");
+    }
+
+    #[tokio::test]
+    async fn rehydrate_counts_and_skips_missing_object_blocks() {
+        // Snapshot against one store, then rehydrate against an EMPTY store:
+        // the manifest is reachable (we hand it over) but the object blocks are
+        // gone — rehydrate must count them missing rather than fail.
+        let store_a = MemoryBlockStore::new();
+        let manifest_bytes;
+        let manifest_cid;
+        {
+            let conn = Connection::new();
+            let git = GitStore::new(&conn, &store_a);
+            git.install_schema().await.unwrap();
+            let (oid, _) = git.put_object(&GitObject::blob(b"hi\n".to_vec())).await.unwrap();
+            git.put_ref("refs/heads/main", oid).await.unwrap();
+            manifest_cid = git.snapshot_manifest().unwrap();
+            manifest_bytes = store_a.get(&manifest_cid).unwrap().unwrap().to_vec();
+        }
+
+        // Fresh store containing ONLY the manifest block, not the object blocks.
+        let store_b = MemoryBlockStore::new();
+        kotoba_store::put_verified(&store_b, &manifest_cid, &manifest_bytes).unwrap();
+        let conn2 = Connection::new();
+        let git2 = GitStore::new(&conn2, &store_b);
+        git2.install_schema().await.unwrap();
+
+        let (restored, missing) = git2.rehydrate(&manifest_cid).await.unwrap();
+        assert_eq!((restored, missing), (0, 1), "the one object block is missing");
+        // The ref is still recorded even though its target object is absent.
+        assert!(list_refs(&conn2.db()).iter().any(|(n, _)| n == "refs/heads/main"));
     }
 
     #[tokio::test]

--- a/crates/kotoba-git/src/pack.rs
+++ b/crates/kotoba-git/src/pack.rs
@@ -19,12 +19,12 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::path::Path;
 
-const OBJ_COMMIT: u8 = 1;
-const OBJ_TREE: u8 = 2;
-const OBJ_BLOB: u8 = 3;
-const OBJ_TAG: u8 = 4;
-const OBJ_OFS_DELTA: u8 = 6;
-const OBJ_REF_DELTA: u8 = 7;
+pub(crate) const OBJ_COMMIT: u8 = 1;
+pub(crate) const OBJ_TREE: u8 = 2;
+pub(crate) const OBJ_BLOB: u8 = 3;
+pub(crate) const OBJ_TAG: u8 = 4;
+pub(crate) const OBJ_OFS_DELTA: u8 = 6;
+pub(crate) const OBJ_REF_DELTA: u8 = 7;
 
 struct Pack {
     data: Vec<u8>,
@@ -184,7 +184,7 @@ impl PackSet {
     }
 }
 
-fn pack_type_to_kind(t: u8) -> Result<GitObjectKind> {
+pub(crate) fn pack_type_to_kind(t: u8) -> Result<GitObjectKind> {
     Ok(match t {
         OBJ_COMMIT => GitObjectKind::Commit,
         OBJ_TREE => GitObjectKind::Tree,
@@ -201,8 +201,24 @@ fn pack_type_to_kind(t: u8) -> Result<GitObjectKind> {
 /// generous enough for legitimately large blobs, but not unbounded.
 const MAX_INFLATE: u64 = 1 << 30; // 1 GiB
 
-fn inflate(buf: &[u8]) -> Result<Vec<u8>> {
+pub(crate) fn inflate(buf: &[u8]) -> Result<Vec<u8>> {
     inflate_capped(buf, MAX_INFLATE)
+}
+
+/// Inflate a zlib stream at the start of `buf`, returning the decompressed bytes
+/// **and** the number of compressed input bytes consumed. The streaming pack
+/// reader needs the consumed length to advance to the next object, which the
+/// on-disk reader (driven by idx offsets) never needed.
+pub(crate) fn inflate_counted(buf: &[u8]) -> Result<(Vec<u8>, usize)> {
+    let mut decoder = ZlibDecoder::new(buf).take(MAX_INFLATE.saturating_add(1));
+    let mut out = Vec::new();
+    decoder.read_to_end(&mut out).map_err(GitError::Io)?;
+    if out.len() as u64 > MAX_INFLATE {
+        return Err(GitError::MalformedHeader);
+    }
+    // total_in() counts the compressed bytes the decoder actually read from `buf`.
+    let consumed = decoder.get_ref().total_in() as usize;
+    Ok((out, consumed))
 }
 
 /// Inflate `buf`, refusing to materialise more than `max` decompressed bytes.
@@ -257,7 +273,7 @@ fn parse_idx(idx: &[u8]) -> Result<HashMap<GitOid, u64>> {
 }
 
 /// OFS_DELTA base-offset varint (big-endian, with the `+1` continuation trick).
-fn read_ofs_varint(buf: &[u8]) -> Result<(u64, usize)> {
+pub(crate) fn read_ofs_varint(buf: &[u8]) -> Result<(u64, usize)> {
     let mut i = 0;
     let mut b = *buf.get(i).ok_or(GitError::MalformedHeader)?;
     i += 1;
@@ -287,7 +303,7 @@ fn read_size_varint(buf: &[u8], pos: &mut usize) -> Result<u64> {
 }
 
 /// Apply a git delta (`base` + `delta` → result).
-fn apply_delta(base: &[u8], delta: &[u8]) -> Result<Vec<u8>> {
+pub(crate) fn apply_delta(base: &[u8], delta: &[u8]) -> Result<Vec<u8>> {
     let mut pos = 0;
     let _src_size = read_size_varint(delta, &mut pos)?;
     let dst_size = read_size_varint(delta, &mut pos)? as usize;

--- a/crates/kotoba-git/src/wire/mod.rs
+++ b/crates/kotoba-git/src/wire/mod.rs
@@ -1,0 +1,15 @@
+//! git **wire protocol** — pkt-line framing, pack encode/ingest, and the
+//! smart-HTTP service layer that lets a real `git` client clone, fetch and push
+//! against a [`crate::GitStore`].
+//!
+//! The substrate underneath is unchanged: every git object is still a
+//! content-addressed [`kotoba_core::cid::KotobaCid`] block (IPFS) plus its
+//! `:git/*` Datom projection (datomic). This module is purely the transport that
+//! moves objects in and out over the network — it adds no new storage model.
+
+pub mod pack_encode;
+pub mod pack_ingest;
+pub mod pktline;
+pub mod smart_http;
+
+pub use smart_http::{advertise_refs, receive_pack, upload_pack, GitService};

--- a/crates/kotoba-git/src/wire/pack_encode.rs
+++ b/crates/kotoba-git/src/wire/pack_encode.rs
@@ -1,0 +1,143 @@
+//! git **packfile encoder** (pack v2, full objects, no delta compression).
+//!
+//! [`crate::pack`] decodes packs; this is the write side, used to serve `git
+//! clone` / `git fetch`: the server gathers the objects a client wants and
+//! serialises them into a single pack stream.
+//!
+//! We emit every object *undeltified* (pack type = its real kind, body inflated
+//! in full). git accepts such packs — delta compression is purely a size
+//! optimisation, never a correctness requirement — so this is a complete,
+//! spec-valid encoder. The trade-off is wire size, not interoperability.
+
+use crate::object::{GitObject, GitObjectKind};
+use crate::oid::GitOid;
+use crate::pack::{OBJ_BLOB, OBJ_COMMIT, OBJ_TAG, OBJ_TREE};
+use crate::Result;
+use flate2::write::ZlibEncoder;
+use flate2::Compression;
+use sha1::{Digest, Sha1};
+use std::io::Write;
+
+fn kind_to_pack_type(kind: GitObjectKind) -> u8 {
+    match kind {
+        GitObjectKind::Commit => OBJ_COMMIT,
+        GitObjectKind::Tree => OBJ_TREE,
+        GitObjectKind::Blob => OBJ_BLOB,
+        GitObjectKind::Tag => OBJ_TAG,
+    }
+}
+
+/// Encode the variable-length pack object header: 3-bit type + size, where the
+/// size's low 4 bits ride in the first byte and the rest are little-endian
+/// 7-bit groups with MSB as the continuation flag.
+fn write_obj_header(out: &mut Vec<u8>, pack_type: u8, mut size: usize) {
+    let mut byte = (pack_type << 4) | ((size & 0x0f) as u8);
+    size >>= 4;
+    if size > 0 {
+        byte |= 0x80;
+    }
+    out.push(byte);
+    while size > 0 {
+        let mut b = (size & 0x7f) as u8;
+        size >>= 7;
+        if size > 0 {
+            b |= 0x80;
+        }
+        out.push(b);
+    }
+}
+
+fn deflate(body: &[u8]) -> Result<Vec<u8>> {
+    let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
+    enc.write_all(body).map_err(crate::error::GitError::Io)?;
+    enc.finish().map_err(crate::error::GitError::Io)
+}
+
+/// Serialise `objects` into a complete pack v2 stream (`PACK` header, each
+/// object undeltified, 20-byte SHA-1 trailer over everything preceding).
+///
+/// Object order is preserved; for clone/fetch it does not matter because every
+/// object is self-contained (no OFS/REF deltas referencing neighbours).
+pub fn encode_pack(objects: &[GitObject]) -> Result<Vec<u8>> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"PACK");
+    out.extend_from_slice(&2u32.to_be_bytes());
+    out.extend_from_slice(&(objects.len() as u32).to_be_bytes());
+
+    for obj in objects {
+        write_obj_header(&mut out, kind_to_pack_type(obj.kind), obj.body.len());
+        out.extend_from_slice(&deflate(&obj.body)?);
+    }
+
+    // Trailer: SHA-1 of all preceding pack bytes (git verifies this on receive).
+    let mut hasher = Sha1::new();
+    hasher.update(&out);
+    out.extend_from_slice(&hasher.finalize());
+    Ok(out)
+}
+
+/// Convenience: the git oids of `objects`, in encode order (handy for tests and
+/// for ref-advertisement bookkeeping).
+pub fn oids(objects: &[GitObject]) -> Vec<GitOid> {
+    objects.iter().map(GitObject::oid).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object::TreeEntry;
+
+    #[test]
+    fn pack_header_is_well_formed() {
+        let pack = encode_pack(&[GitObject::blob(b"hello\n".to_vec())]).unwrap();
+        assert_eq!(&pack[0..4], b"PACK");
+        assert_eq!(&pack[4..8], &2u32.to_be_bytes()); // version 2
+        assert_eq!(&pack[8..12], &1u32.to_be_bytes()); // 1 object
+        assert_eq!(pack.len() >= 12 + 20, true); // header + at least the trailer
+    }
+
+    #[test]
+    fn trailer_is_sha1_of_body() {
+        let pack = encode_pack(&[GitObject::blob(b"xyz".to_vec())]).unwrap();
+        let (body, trailer) = pack.split_at(pack.len() - 20);
+        let mut h = Sha1::new();
+        h.update(body);
+        assert_eq!(trailer, h.finalize().as_slice());
+    }
+
+    #[test]
+    fn obj_header_size_encoding_small_and_large() {
+        // size 6 → single byte: (type<<4)|6, no continuation
+        let mut out = Vec::new();
+        write_obj_header(&mut out, OBJ_BLOB, 6);
+        assert_eq!(out, vec![(OBJ_BLOB << 4) | 6]);
+
+        // size 0x1234: low nibble 0x4 in byte0; remaining 0x123 = 291 → 7-bit groups.
+        // 0x1234 >> 4 = 0x123 (291). 291 & 0x7f = 0x23, 291>>7 = 2.
+        let mut out = Vec::new();
+        write_obj_header(&mut out, OBJ_TREE, 0x1234);
+        assert_eq!(out, vec![(OBJ_TREE << 4) | 0x04 | 0x80, 0x23 | 0x80, 0x02]);
+    }
+
+    #[test]
+    fn pack_roundtrips_through_the_decoder() {
+        // Encode a blob/tree/commit set, then decode it back via the on-disk
+        // reader path by writing an idx — but simpler: assert the decoder's
+        // streaming ingest (super::super::pack_ingest) reproduces the objects.
+        let blob = GitObject::blob(b"hello\n".to_vec());
+        let tree = GitObject::tree(&[TreeEntry {
+            mode: b"100644".to_vec(),
+            name: b"f.txt".to_vec(),
+            oid: blob.oid(),
+        }]);
+        let objs = vec![blob.clone(), tree.clone()];
+        let pack = encode_pack(&objs).unwrap();
+
+        let decoded = crate::wire::pack_ingest::parse_pack(&pack, |_| Ok(None)).unwrap();
+        let mut got: Vec<_> = decoded.into_iter().map(|(o, _)| o).collect();
+        got.sort_by_key(|o| o.oid());
+        let mut want = objs;
+        want.sort_by_key(|o| o.oid());
+        assert_eq!(got, want);
+    }
+}

--- a/crates/kotoba-git/src/wire/pack_ingest.rs
+++ b/crates/kotoba-git/src/wire/pack_ingest.rs
@@ -1,0 +1,449 @@
+//! Streaming **packfile ingest** — parse a pack received over the wire (from
+//! `git push`) into [`GitObject`]s.
+//!
+//! Unlike [`crate::pack`], which is driven by an on-disk `*.idx` (random access
+//! by offset), a pushed pack arrives as a single self-describing byte stream
+//! with no index: a `PACK` header, `N` objects laid out sequentially, then a
+//! 20-byte SHA-1 trailer. We must walk it front-to-back, recording each
+//! object's byte offset so that `OBJ_OFS_DELTA` (negative offset to base) and
+//! `OBJ_REF_DELTA` (base by oid) can be resolved.
+//!
+//! Bases may legitimately appear *after* their deltas, and a pushed pack may be
+//! **thin** (a `REF_DELTA` whose base is an object the server already has, not
+//! in the pack). We therefore resolve by fixpoint: repeatedly sweep the
+//! unresolved objects, applying any whose base is now available (in-pack or via
+//! the `resolve_external` callback), until everything resolves or a sweep makes
+//! no progress (a genuinely broken/incomplete pack).
+
+use crate::error::GitError;
+use crate::object::{GitObject, GitObjectKind};
+use crate::oid::GitOid;
+use crate::pack::{
+    apply_delta, inflate_counted, pack_type_to_kind, read_ofs_varint, OBJ_BLOB, OBJ_COMMIT,
+    OBJ_OFS_DELTA, OBJ_REF_DELTA, OBJ_TAG, OBJ_TREE,
+};
+use crate::Result;
+use sha1::{Digest, Sha1};
+use std::collections::HashMap;
+
+/// A raw, not-yet-resolved pack object record.
+enum Raw {
+    Full {
+        kind: GitObjectKind,
+        body: Vec<u8>,
+    },
+    OfsDelta {
+        base_offset: usize,
+        delta: Vec<u8>,
+    },
+    RefDelta {
+        base_oid: GitOid,
+        delta: Vec<u8>,
+    },
+}
+
+/// Parse a complete pack byte stream into `(object, oid)` pairs.
+///
+/// `resolve_external` supplies the body of a base object the server already
+/// stores (for thin packs); return `Ok(None)` if it is unknown. Every returned
+/// object's oid is recomputed from its framed bytes — the caller can trust it.
+pub fn parse_pack<F>(pack: &[u8], resolve_external: F) -> Result<Vec<(GitObject, GitOid)>>
+where
+    F: Fn(GitOid) -> Result<Option<(GitObjectKind, Vec<u8>)>>,
+{
+    // Header + trailer integrity.
+    if pack.len() < 12 + 20 || &pack[0..4] != b"PACK" {
+        return Err(GitError::MalformedHeader);
+    }
+    let version = u32::from_be_bytes([pack[4], pack[5], pack[6], pack[7]]);
+    if version != 2 {
+        return Err(GitError::UnknownObjectKind(format!("pack version {version}")));
+    }
+    let count = u32::from_be_bytes([pack[8], pack[9], pack[10], pack[11]]) as usize;
+
+    let body_end = pack.len() - 20;
+    let mut hasher = Sha1::new();
+    hasher.update(&pack[..body_end]);
+    if hasher.finalize()[..] != pack[body_end..] {
+        return Err(GitError::MalformedHeader); // trailer checksum mismatch
+    }
+
+    // ── Pass 1: split the stream into raw records, keyed by byte offset. ──────
+    let mut raws: Vec<(usize, Raw)> = Vec::with_capacity(count);
+    let mut pos = 12;
+    for _ in 0..count {
+        let obj_offset = pos;
+        let (obj_type, _size, hdr_len) = parse_obj_header(pack, pos)?;
+        pos += hdr_len;
+        match obj_type {
+            OBJ_COMMIT | OBJ_TREE | OBJ_BLOB | OBJ_TAG => {
+                let (body, consumed) = inflate_counted(&pack[pos..])?;
+                pos += consumed;
+                raws.push((
+                    obj_offset,
+                    Raw::Full {
+                        kind: pack_type_to_kind(obj_type)?,
+                        body,
+                    },
+                ));
+            }
+            OBJ_OFS_DELTA => {
+                let (neg, used) = read_ofs_varint(&pack[pos..])?;
+                pos += used;
+                let base_offset = obj_offset
+                    .checked_sub(neg as usize)
+                    .ok_or(GitError::MalformedHeader)?;
+                let (delta, consumed) = inflate_counted(&pack[pos..])?;
+                pos += consumed;
+                raws.push((obj_offset, Raw::OfsDelta { base_offset, delta }));
+            }
+            OBJ_REF_DELTA => {
+                let base_oid =
+                    GitOid::from_raw(pack.get(pos..pos + 20).ok_or(GitError::MalformedHeader)?)?;
+                pos += 20;
+                let (delta, consumed) = inflate_counted(&pack[pos..])?;
+                pos += consumed;
+                raws.push((obj_offset, Raw::RefDelta { base_oid, delta }));
+            }
+            other => return Err(GitError::UnknownObjectKind(format!("pack type {other}"))),
+        }
+    }
+    if pos != body_end {
+        return Err(GitError::MalformedHeader); // trailing junk or short read
+    }
+
+    // ── Pass 2: resolve by fixpoint (handles out-of-order + thin bases). ─────
+    let mut by_offset: HashMap<usize, (GitObjectKind, Vec<u8>)> = HashMap::with_capacity(count);
+    let mut by_oid: HashMap<GitOid, (GitObjectKind, Vec<u8>)> = HashMap::with_capacity(count);
+    let mut pending: Vec<usize> = (0..raws.len()).collect();
+
+    while !pending.is_empty() {
+        let mut next_pending = Vec::new();
+        let mut progressed = false;
+
+        for &i in &pending {
+            let (offset, raw) = &raws[i];
+            let resolved: Option<(GitObjectKind, Vec<u8>)> = match raw {
+                Raw::Full { kind, body } => Some((*kind, body.clone())),
+                Raw::OfsDelta { base_offset, delta } => by_offset
+                    .get(base_offset)
+                    .map(|(k, b)| apply_delta(b, delta).map(|body| (*k, body)))
+                    .transpose()?,
+                Raw::RefDelta { base_oid, delta } => {
+                    let base = by_oid
+                        .get(base_oid)
+                        .cloned()
+                        .map(Ok)
+                        .or_else(|| resolve_external(*base_oid).transpose())
+                        .transpose()?;
+                    base.map(|(k, b)| apply_delta(&b, delta).map(|body| (k, body)))
+                        .transpose()?
+                }
+            };
+
+            match resolved {
+                Some((kind, body)) => {
+                    let obj = GitObject::new(kind, body.clone());
+                    let oid = obj.oid();
+                    by_offset.insert(*offset, (kind, body.clone()));
+                    by_oid.insert(oid, (kind, body));
+                    progressed = true;
+                }
+                None => next_pending.push(i),
+            }
+        }
+
+        if !progressed {
+            // A whole sweep resolved nothing → an unresolvable base (broken or
+            // incomplete thin pack). Report the first missing base oid.
+            let missing = pending.first().map(|&i| match &raws[i].1 {
+                Raw::RefDelta { base_oid, .. } => base_oid.to_hex(),
+                _ => "ofs-delta base".to_string(),
+            });
+            return Err(GitError::ObjectNotFound(
+                missing.unwrap_or_else(|| "delta base".into()),
+            ));
+        }
+        pending = next_pending;
+    }
+
+    // Materialise final objects in a stable (oid-sorted) order.
+    let mut out: Vec<(GitObject, GitOid)> = by_oid
+        .into_iter()
+        .map(|(oid, (kind, body))| (GitObject::new(kind, body), oid))
+        .collect();
+    out.sort_by_key(|(_, oid)| *oid);
+    Ok(out)
+}
+
+/// Parse a pack object header at `pos`: 3-bit type + variable size.
+/// Returns `(pack_type, size, header_byte_len)`.
+fn parse_obj_header(buf: &[u8], pos: usize) -> Result<(u8, u64, usize)> {
+    let first = *buf.get(pos).ok_or(GitError::MalformedHeader)?;
+    let obj_type = (first >> 4) & 0x07;
+    let mut size = (first & 0x0f) as u64;
+    let mut shift = 4;
+    let mut i = pos + 1;
+    let mut byte = first;
+    while byte & 0x80 != 0 {
+        byte = *buf.get(i).ok_or(GitError::MalformedHeader)?;
+        size |= ((byte & 0x7f) as u64) << shift;
+        shift += 7;
+        i += 1;
+    }
+    Ok((obj_type, size, i - pos))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object::TreeEntry;
+    use crate::wire::pack_encode::encode_pack;
+
+    #[test]
+    fn full_objects_roundtrip_encode_then_ingest() {
+        let blob = GitObject::blob(b"hello\n".to_vec());
+        let tree = GitObject::tree(&[TreeEntry {
+            mode: b"100644".to_vec(),
+            name: b"f.txt".to_vec(),
+            oid: blob.oid(),
+        }]);
+        let commit = GitObject::new(
+            GitObjectKind::Commit,
+            format!("tree {}\n\nmsg\n", tree.oid()).into_bytes(),
+        );
+        let objs = vec![blob, tree, commit];
+
+        let pack = encode_pack(&objs).unwrap();
+        let got = parse_pack(&pack, |_| Ok(None)).unwrap();
+
+        // every returned oid is the real recomputed oid
+        for (obj, oid) in &got {
+            assert_eq!(obj.oid(), *oid);
+        }
+        let got_oids: std::collections::HashSet<_> = got.iter().map(|(_, o)| *o).collect();
+        let want_oids: std::collections::HashSet<_> = objs.iter().map(|o| o.oid()).collect();
+        assert_eq!(got_oids, want_oids);
+    }
+
+    #[test]
+    fn rejects_corrupt_trailer() {
+        let mut pack = encode_pack(&[GitObject::blob(b"x".to_vec())]).unwrap();
+        let last = pack.len() - 1;
+        pack[last] ^= 0xff; // flip a trailer byte
+        assert!(parse_pack(&pack, |_| Ok(None)).is_err());
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let mut pack = encode_pack(&[GitObject::blob(b"x".to_vec())]).unwrap();
+        pack[0] = b'X';
+        assert!(parse_pack(&pack, |_| Ok(None)).is_err());
+    }
+
+    #[test]
+    fn thin_pack_ref_delta_resolves_via_external_base() {
+        // Build a REF_DELTA-bearing pack by hand: base "hello world" lives in the
+        // store (external), the pack carries only a delta producing "hello!!".
+        let base = GitObject::blob(b"hello world".to_vec());
+        let base_oid = base.oid();
+
+        // delta: src_size=11, dst_size=7, copy base[0..5], insert "!!"
+        let delta = vec![0x0b, 0x07, 0x91, 0x00, 0x05, 0x02, b'!', b'!'];
+        let expected = GitObject::blob(b"hello!!".to_vec());
+
+        let pack = build_ref_delta_pack(base_oid, &delta);
+        let resolver = |oid: GitOid| -> Result<Option<(GitObjectKind, Vec<u8>)>> {
+            if oid == base_oid {
+                Ok(Some((GitObjectKind::Blob, b"hello world".to_vec())))
+            } else {
+                Ok(None)
+            }
+        };
+        let got = parse_pack(&pack, resolver).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].0, expected);
+    }
+
+    #[test]
+    fn missing_thin_base_errors_cleanly() {
+        let base_oid = GitObject::blob(b"hello world".to_vec()).oid();
+        let delta = vec![0x0b, 0x07, 0x91, 0x00, 0x05, 0x02, b'!', b'!'];
+        let pack = build_ref_delta_pack(base_oid, &delta);
+        // resolver knows nothing → unresolved base, clean Err (not a panic/loop)
+        let err = parse_pack(&pack, |_| Ok(None)).unwrap_err();
+        assert!(matches!(err, GitError::ObjectNotFound(_)));
+    }
+
+    // ── A flexible hand-roller for multi-object packs (full / ofs / ref). ─────
+    enum E<'a> {
+        Full(u8, &'a [u8]),       // (pack type, body)
+        Ofs(usize, &'a [u8]),     // (index of an already-emitted base, delta)
+        Ref(GitOid, &'a [u8]),    // (base oid, delta)
+    }
+
+    fn write_obj_header(out: &mut Vec<u8>, pack_type: u8, mut size: usize) {
+        let mut byte = (pack_type << 4) | ((size & 0x0f) as u8);
+        size >>= 4;
+        if size > 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        while size > 0 {
+            let mut b = (size & 0x7f) as u8;
+            size >>= 7;
+            if size > 0 {
+                b |= 0x80;
+            }
+            out.push(b);
+        }
+    }
+
+    /// Inverse of `read_ofs_varint` (the `+1`-continuation big-endian form).
+    fn write_ofs_varint(out: &mut Vec<u8>, mut n: u64) {
+        let mut tmp = vec![(n & 0x7f) as u8];
+        n >>= 7;
+        while n > 0 {
+            n -= 1;
+            tmp.push((n & 0x7f) as u8);
+            n >>= 7;
+        }
+        let len = tmp.len();
+        for (i, b) in tmp.iter().rev().enumerate() {
+            out.push(if i < len - 1 { b | 0x80 } else { *b });
+        }
+    }
+
+    fn deflate(data: &[u8]) -> Vec<u8> {
+        use flate2::{write::ZlibEncoder, Compression};
+        use std::io::Write;
+        let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(data).unwrap();
+        enc.finish().unwrap()
+    }
+
+    fn build_pack(entries: &[E]) -> Vec<u8> {
+        let mut out = Vec::new();
+        out.extend_from_slice(b"PACK");
+        out.extend_from_slice(&2u32.to_be_bytes());
+        out.extend_from_slice(&(entries.len() as u32).to_be_bytes());
+        let mut offsets = Vec::new();
+        for e in entries {
+            let off = out.len();
+            match e {
+                E::Full(t, body) => {
+                    write_obj_header(&mut out, *t, body.len());
+                    out.extend_from_slice(&deflate(body));
+                }
+                E::Ofs(base_idx, delta) => {
+                    write_obj_header(&mut out, OBJ_OFS_DELTA, delta.len());
+                    write_ofs_varint(&mut out, (off - offsets[*base_idx]) as u64);
+                    out.extend_from_slice(&deflate(delta));
+                }
+                E::Ref(oid, delta) => {
+                    write_obj_header(&mut out, OBJ_REF_DELTA, delta.len());
+                    out.extend_from_slice(oid.raw());
+                    out.extend_from_slice(&deflate(delta));
+                }
+            }
+            offsets.push(off);
+        }
+        let mut h = Sha1::new();
+        h.update(&out);
+        out.extend_from_slice(&h.finalize());
+        out
+    }
+
+    // delta over "hello world" (src 11) producing "hello!!" (dst 7):
+    // copy base[0..5] then insert "!!".
+    const HELLO_DELTA: &[u8] = &[0x0b, 0x07, 0x91, 0x00, 0x05, 0x02, b'!', b'!'];
+
+    #[test]
+    fn ofs_delta_resolves_against_in_pack_base() {
+        // [ full "hello world" , ofs_delta → that base ]
+        let pack = build_pack(&[
+            E::Full(OBJ_BLOB, b"hello world"),
+            E::Ofs(0, HELLO_DELTA),
+        ]);
+        let got = parse_pack(&pack, |_| Ok(None)).unwrap();
+        let blobs: std::collections::HashSet<Vec<u8>> =
+            got.into_iter().map(|(o, _)| o.body).collect();
+        assert!(blobs.contains(&b"hello world".to_vec()));
+        assert!(blobs.contains(&b"hello!!".to_vec()));
+    }
+
+    #[test]
+    fn ref_delta_base_appearing_after_delta_resolves_via_fixpoint() {
+        // Base is emitted *after* the delta that needs it — the fixpoint sweep
+        // must still resolve it (packs do not guarantee base-before-delta order).
+        let base_oid = GitObject::blob(b"hello world".to_vec()).oid();
+        let pack = build_pack(&[
+            E::Ref(base_oid, HELLO_DELTA),
+            E::Full(OBJ_BLOB, b"hello world"),
+        ]);
+        let got = parse_pack(&pack, |_| Ok(None)).unwrap();
+        let blobs: std::collections::HashSet<Vec<u8>> =
+            got.into_iter().map(|(o, _)| o.body).collect();
+        assert!(blobs.contains(&b"hello!!".to_vec()), "out-of-order base must resolve");
+    }
+
+    #[test]
+    fn rejects_unsupported_version_and_trailing_junk() {
+        // version 3 → rejected
+        let mut p = build_pack(&[E::Full(OBJ_BLOB, b"x")]);
+        p[7] = 3;
+        // (trailer no longer matches either, but version is checked first)
+        assert!(parse_pack(&p, |_| Ok(None)).is_err());
+
+        // trailing junk between last object and trailer → pos != body_end
+        let mut p = build_pack(&[E::Full(OBJ_BLOB, b"x")]);
+        let trailer = p.split_off(p.len() - 20);
+        p.extend_from_slice(b"JUNK");
+        // recompute trailer over the (now longer) body so the checksum passes and
+        // the *structural* `pos != body_end` check is what fails.
+        let mut h = Sha1::new();
+        h.update(&p);
+        let _ = trailer; // old trailer discarded
+        let new_trailer = h.finalize();
+        p.extend_from_slice(&new_trailer);
+        assert!(parse_pack(&p, |_| Ok(None)).is_err());
+    }
+
+    /// Hand-build a 1-object pack whose sole object is an OBJ_REF_DELTA.
+    fn build_ref_delta_pack(base_oid: GitOid, delta: &[u8]) -> Vec<u8> {
+        use flate2::{write::ZlibEncoder, Compression};
+        use std::io::Write;
+
+        let mut out = Vec::new();
+        out.extend_from_slice(b"PACK");
+        out.extend_from_slice(&2u32.to_be_bytes());
+        out.extend_from_slice(&1u32.to_be_bytes());
+
+        // object header: type=OBJ_REF_DELTA(7), size = delta.len()
+        let size = delta.len();
+        let mut byte = (OBJ_REF_DELTA << 4) | ((size & 0x0f) as u8);
+        let mut rest = size >> 4;
+        if rest > 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        while rest > 0 {
+            let mut b = (rest & 0x7f) as u8;
+            rest >>= 7;
+            if rest > 0 {
+                b |= 0x80;
+            }
+            out.push(b);
+        }
+        out.extend_from_slice(base_oid.raw());
+        let mut enc = ZlibEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(delta).unwrap();
+        out.extend_from_slice(&enc.finish().unwrap());
+
+        let mut h = Sha1::new();
+        h.update(&out);
+        let trailer = h.finalize();
+        out.extend_from_slice(&trailer);
+        out
+    }
+}

--- a/crates/kotoba-git/src/wire/pktline.rs
+++ b/crates/kotoba-git/src/wire/pktline.rs
@@ -1,0 +1,218 @@
+//! git **pkt-line** framing (the wire envelope used by smart-HTTP and the
+//! pack protocol).
+//!
+//! A pkt-line is a 4-byte ASCII hex length prefix followed by `length - 4`
+//! payload bytes. The length *includes* the 4 prefix bytes. Two prefixes are
+//! special control packets carrying no payload:
+//!
+//! * `0000` — **flush-pkt**, the end-of-section marker.
+//! * `0001` — **delim-pkt** (protocol v2 section delimiter).
+//!
+//! The maximum pkt-line is 65520 bytes, so the maximum payload is 65516.
+//! This module is a pure codec — no I/O, no allocation beyond the produced
+//! buffers — and is exercised by byte-exact round-trip tests.
+
+use crate::error::GitError;
+use crate::Result;
+
+/// Largest legal pkt-line length (prefix + payload), per the git protocol.
+pub const MAX_PKT_LEN: usize = 65520;
+/// Largest payload that fits in one data pkt-line.
+pub const MAX_PAYLOAD: usize = MAX_PKT_LEN - 4;
+
+/// The flush-pkt (`0000`) — ends a section/response.
+pub const FLUSH: &[u8] = b"0000";
+/// The delim-pkt (`0001`) — separates sections in protocol v2.
+pub const DELIM: &[u8] = b"0001";
+
+/// One decoded pkt-line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PktLine {
+    /// A data packet with its payload (the trailing `\n` git usually appends is
+    /// part of the payload and preserved verbatim).
+    Data(Vec<u8>),
+    /// `0000`.
+    Flush,
+    /// `0001`.
+    Delim,
+}
+
+/// Append a single data pkt-line for `payload` to `out`.
+///
+/// Errors if `payload` exceeds [`MAX_PAYLOAD`] (callers must chunk larger data,
+/// e.g. side-band streaming in [`super::smart_http`]).
+pub fn write_data(out: &mut Vec<u8>, payload: &[u8]) -> Result<()> {
+    if payload.len() > MAX_PAYLOAD {
+        return Err(GitError::MalformedHeader);
+    }
+    let len = payload.len() + 4;
+    // 4-digit lowercase hex, exactly as git emits it.
+    out.extend_from_slice(format!("{len:04x}").as_bytes());
+    out.extend_from_slice(payload);
+    Ok(())
+}
+
+/// Append a data pkt-line for a string payload.
+pub fn write_str(out: &mut Vec<u8>, s: &str) -> Result<()> {
+    write_data(out, s.as_bytes())
+}
+
+/// Append a flush-pkt (`0000`).
+pub fn write_flush(out: &mut Vec<u8>) {
+    out.extend_from_slice(FLUSH);
+}
+
+/// Append a delim-pkt (`0001`).
+pub fn write_delim(out: &mut Vec<u8>) {
+    out.extend_from_slice(DELIM);
+}
+
+/// Encode one data pkt-line into a fresh buffer.
+pub fn data(payload: &[u8]) -> Result<Vec<u8>> {
+    let mut out = Vec::with_capacity(payload.len() + 4);
+    write_data(&mut out, payload)?;
+    Ok(out)
+}
+
+/// A forward-only reader over a pkt-line stream.
+///
+/// Holds a borrowed byte slice and yields [`PktLine`]s until the input is
+/// exhausted. Malformed length prefixes (non-hex, or a length that overruns the
+/// buffer) produce an error rather than a panic — the bytes come from an
+/// untrusted client.
+pub struct PktLineReader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> PktLineReader<'a> {
+    pub fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    /// Bytes not yet consumed (used by the pack protocol to hand the trailing
+    /// raw packfile — which is *not* pkt-line framed — to the pack reader).
+    pub fn remaining(&self) -> &'a [u8] {
+        &self.buf[self.pos.min(self.buf.len())..]
+    }
+
+    /// Read the next pkt-line, or `None` at end of input.
+    pub fn next_pkt(&mut self) -> Result<Option<PktLine>> {
+        if self.pos >= self.buf.len() {
+            return Ok(None);
+        }
+        let prefix = self
+            .buf
+            .get(self.pos..self.pos + 4)
+            .ok_or(GitError::MalformedHeader)?;
+        let len = parse_hex4(prefix)?;
+        match len {
+            0 => {
+                self.pos += 4;
+                Ok(Some(PktLine::Flush))
+            }
+            1 => {
+                self.pos += 4;
+                Ok(Some(PktLine::Delim))
+            }
+            // 2 and 3 are reserved/illegal: a length must be 0/1 or ≥4.
+            2 | 3 => Err(GitError::MalformedHeader),
+            _ => {
+                let end = self.pos + len;
+                if len < 4 || end > self.buf.len() {
+                    return Err(GitError::MalformedHeader);
+                }
+                let payload = self.buf[self.pos + 4..end].to_vec();
+                self.pos = end;
+                Ok(Some(PktLine::Data(payload)))
+            }
+        }
+    }
+}
+
+impl Iterator for PktLineReader<'_> {
+    type Item = Result<PktLine>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_pkt().transpose()
+    }
+}
+
+/// Parse a 4-byte ASCII lowercase/uppercase hex length prefix.
+fn parse_hex4(b: &[u8]) -> Result<usize> {
+    if b.len() != 4 {
+        return Err(GitError::MalformedHeader);
+    }
+    let s = std::str::from_utf8(b).map_err(|_| GitError::MalformedHeader)?;
+    usize::from_str_radix(s, 16).map_err(|_| GitError::MalformedHeader)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_line_length_prefix_matches_git() {
+        // git: `printf 'hello\n' | git ...` → "000ahello\n" (4 + 6 = 10 = 0x0a).
+        let line = data(b"hello\n").unwrap();
+        assert_eq!(line, b"000ahello\n");
+    }
+
+    #[test]
+    fn flush_and_delim_constants() {
+        assert_eq!(FLUSH, b"0000");
+        assert_eq!(DELIM, b"0001");
+    }
+
+    #[test]
+    fn roundtrip_stream() {
+        let mut buf = Vec::new();
+        write_str(&mut buf, "# service=git-upload-pack\n").unwrap();
+        write_flush(&mut buf);
+        write_data(&mut buf, b"want abc\n").unwrap();
+        write_delim(&mut buf);
+        write_flush(&mut buf);
+
+        let got: Vec<PktLine> = PktLineReader::new(&buf).map(|r| r.unwrap()).collect();
+        assert_eq!(
+            got,
+            vec![
+                PktLine::Data(b"# service=git-upload-pack\n".to_vec()),
+                PktLine::Flush,
+                PktLine::Data(b"want abc\n".to_vec()),
+                PktLine::Delim,
+                PktLine::Flush,
+            ]
+        );
+    }
+
+    #[test]
+    fn reader_exposes_trailing_raw_bytes() {
+        // A receive-pack body is pkt-lines, a flush, then a raw packfile.
+        let mut buf = Vec::new();
+        write_data(&mut buf, b"old new refs/heads/main\0report-status\n").unwrap();
+        write_flush(&mut buf);
+        let pack_start = buf.len();
+        buf.extend_from_slice(b"PACK....raw....");
+
+        let mut r = PktLineReader::new(&buf);
+        assert!(matches!(r.next_pkt().unwrap(), Some(PktLine::Data(_))));
+        assert_eq!(r.next_pkt().unwrap(), Some(PktLine::Flush));
+        assert_eq!(r.remaining(), &buf[pack_start..]);
+    }
+
+    #[test]
+    fn rejects_truncated_and_bad_prefix() {
+        // length prefix claims 0x0064 bytes but buffer is short
+        assert!(PktLineReader::new(b"0064hi").next_pkt().is_err());
+        // non-hex prefix
+        assert!(PktLineReader::new(b"zzzzpayload").next_pkt().is_err());
+        // reserved length 2
+        assert!(PktLineReader::new(b"0002").next_pkt().is_err());
+    }
+
+    #[test]
+    fn oversized_payload_rejected() {
+        let big = vec![0u8; MAX_PAYLOAD + 1];
+        assert!(data(&big).is_err());
+    }
+}

--- a/crates/kotoba-git/src/wire/smart_http.rs
+++ b/crates/kotoba-git/src/wire/smart_http.rs
@@ -1,0 +1,885 @@
+//! git **smart-HTTP** service layer — the glue that lets a real `git` client
+//! clone / fetch / push against a [`GitStore`] (datomic projection + IPFS
+//! blocks).
+//!
+//! Three entry points mirror the three HTTP requests git makes:
+//!
+//! | git operation        | HTTP                                   | fn |
+//! |----------------------|----------------------------------------|----|
+//! | ref discovery        | `GET  …/info/refs?service=…`           | [`advertise_refs`] |
+//! | clone / fetch        | `POST …/git-upload-pack`               | [`upload_pack`] |
+//! | push                 | `POST …/git-receive-pack`              | [`receive_pack`] |
+//!
+//! We speak protocol **v0** (the most broadly compatible), advertise a minimal
+//! capability set, and emit **undeltified** packs. Negotiation uses the basic
+//! (non-multi_ack) ACK/NAK handshake, which terminates cleanly over git's
+//! stateless-HTTP transport. See the inline notes for the precise wire shapes.
+
+use crate::oid::GitOid;
+use crate::wire::pack_encode::encode_pack;
+use crate::wire::pack_ingest::parse_pack;
+use crate::wire::pktline::{self, PktLine, PktLineReader};
+use crate::{list_refs, object_cid, resolve_ref, GitStore, RefTarget, Result};
+use kotoba_datomic::Db;
+use std::collections::HashSet;
+
+const AGENT: &str = "agent=kotoba-git/0.1";
+/// Capabilities advertised for fetch. `side-band-64k` lets us multiplex the
+/// pack (and is what modern git prefers); `ofs-delta` is harmless to advertise
+/// even though we currently emit full objects.
+const UPLOAD_CAPS: &str = "side-band-64k ofs-delta";
+/// Capabilities advertised for push. `report-status` lets the client learn the
+/// per-ref outcome. (We do not advertise `delete-refs` — see [`receive_pack`].)
+const RECEIVE_CAPS: &str = "report-status ofs-delta";
+
+const ZERO_OID: &str = "0000000000000000000000000000000000000000";
+
+/// The two git wire services.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitService {
+    UploadPack,
+    ReceivePack,
+}
+
+impl GitService {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            GitService::UploadPack => "git-upload-pack",
+            GitService::ReceivePack => "git-receive-pack",
+        }
+    }
+
+    /// Parse the `service=` query value git sends to `info/refs`.
+    pub fn from_query(s: &str) -> Option<Self> {
+        match s {
+            "git-upload-pack" => Some(GitService::UploadPack),
+            "git-receive-pack" => Some(GitService::ReceivePack),
+            _ => None,
+        }
+    }
+
+    fn caps(self) -> &'static str {
+        match self {
+            GitService::UploadPack => UPLOAD_CAPS,
+            GitService::ReceivePack => RECEIVE_CAPS,
+        }
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// GET /info/refs?service=…
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Build the smart-HTTP `info/refs` advertisement body for `service`.
+///
+/// Layout (protocol v0 over HTTP):
+/// ```text
+/// <pkt> "# service=git-upload-pack\n"
+/// 0000
+/// <pkt> "<oid> HEAD\0<caps> symref=HEAD:refs/heads/main\n"
+/// <pkt> "<oid> refs/heads/main\n"
+/// …
+/// 0000
+/// ```
+/// An empty repository advertises the canonical zero-id `capabilities^{}` line
+/// so `git clone` of an empty repo (and the first `git push`) work.
+pub fn advertise_refs(git: &GitStore, service: GitService) -> Result<Vec<u8>> {
+    let db = git.db();
+    let caps = format!("{} {}", service.caps(), AGENT);
+
+    let mut out = Vec::new();
+    pktline::write_str(&mut out, &format!("# service={}\n", service.as_str()))?;
+    pktline::write_flush(&mut out);
+
+    let lines = ref_advert_lines(&db);
+    if lines.is_empty() {
+        pktline::write_str(&mut out, &format!("{ZERO_OID} capabilities^{{}}\0{caps}\n"))?;
+    } else {
+        let head_symref = head_symref_target(&db);
+        for (i, (oid_hex, name)) in lines.iter().enumerate() {
+            if i == 0 {
+                let mut capstr = caps.clone();
+                if let Some(target) = &head_symref {
+                    capstr.push_str(&format!(" symref=HEAD:{target}"));
+                }
+                pktline::write_str(&mut out, &format!("{oid_hex} {name}\0{capstr}\n"))?;
+            } else {
+                pktline::write_str(&mut out, &format!("{oid_hex} {name}\n"))?;
+            }
+        }
+    }
+    pktline::write_flush(&mut out);
+    Ok(out)
+}
+
+/// `(oid_hex, refname)` advertisement lines: `HEAD` first (resolved), then each
+/// direct ref sorted by name (git's canonical ordering).
+fn ref_advert_lines(db: &Db) -> Vec<(String, String)> {
+    let mut lines = Vec::new();
+    if let Some(head) = resolve_ref(db, "HEAD") {
+        lines.push((head.to_hex(), "HEAD".to_string()));
+    }
+    let mut direct: Vec<(String, GitOid)> = list_refs(db)
+        .into_iter()
+        .filter_map(|(name, target)| match target {
+            RefTarget::Oid(oid) if name != "HEAD" => Some((name, oid)),
+            _ => None,
+        })
+        .collect();
+    direct.sort_by(|a, b| a.0.cmp(&b.0));
+    for (name, oid) in direct {
+        lines.push((oid.to_hex(), name));
+    }
+    lines
+}
+
+fn head_symref_target(db: &Db) -> Option<String> {
+    list_refs(db).into_iter().find_map(|(name, target)| match target {
+        RefTarget::Symbolic(t) if name == "HEAD" => Some(t),
+        _ => None,
+    })
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// POST /git-upload-pack   (clone / fetch)
+// ───────────────────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+struct UploadRequest {
+    wants: Vec<GitOid>,
+    haves: Vec<GitOid>,
+    done: bool,
+    side_band_64k: bool,
+}
+
+fn parse_upload_request(body: &[u8]) -> Result<UploadRequest> {
+    let mut req = UploadRequest::default();
+    let mut reader = PktLineReader::new(body);
+    while let Some(pkt) = reader.next_pkt()? {
+        if let PktLine::Data(data) = pkt {
+            let line = String::from_utf8_lossy(&data);
+            let line = line.trim_end_matches('\n');
+            if let Some(rest) = line.strip_prefix("want ") {
+                // `want <oid>[ <cap> <cap> …]` — caps ride on the first want.
+                let mut parts = rest.splitn(2, ' ');
+                if let Some(oid_hex) = parts.next() {
+                    if let Ok(oid) = GitOid::from_hex(oid_hex) {
+                        req.wants.push(oid);
+                    }
+                }
+                if let Some(caps) = parts.next() {
+                    if caps.split(' ').any(|c| c == "side-band-64k") {
+                        req.side_band_64k = true;
+                    }
+                }
+            } else if let Some(oid_hex) = line.strip_prefix("have ") {
+                if let Ok(oid) = GitOid::from_hex(oid_hex.trim()) {
+                    req.haves.push(oid);
+                }
+            } else if line == "done" {
+                req.done = true;
+            }
+        }
+    }
+    Ok(req)
+}
+
+/// Handle a `git-upload-pack` request body, returning the response body.
+///
+/// * Negotiation round (no `done`): reply `ACK <oid>` if we share a `have`,
+///   else `NAK` — and nothing else. git then sends `done` and we send the pack.
+/// * Terminal round (`done`): final `ACK <oid>`/`NAK`, then the packfile of
+///   everything reachable from the wants minus what the shared haves already
+///   cover (so a `fetch` ships only the delta of history, a `clone` ships all).
+pub fn upload_pack(git: &GitStore, body: &[u8]) -> Result<Vec<u8>> {
+    let db = git.db();
+    let req = parse_upload_request(body)?;
+
+    // Which of the client's haves do we actually possess?
+    let common: Vec<GitOid> = req
+        .haves
+        .iter()
+        .copied()
+        .filter(|oid| object_cid(&db, *oid).is_ok())
+        .collect();
+
+    let mut out = Vec::new();
+    match common.last() {
+        Some(oid) => pktline::write_str(&mut out, &format!("ACK {}\n", oid.to_hex()))?,
+        None => pktline::write_str(&mut out, "NAK\n")?,
+    }
+    if !req.done {
+        // Negotiation continues; no pack yet.
+        return Ok(out);
+    }
+
+    // Reachable(wants) − Reachable(common) = the objects the client lacks.
+    let exclude = collect_reachable(git, &db, &common)?;
+    let mut send: Vec<GitOid> = collect_reachable(git, &db, &req.wants)?
+        .into_iter()
+        .filter(|oid| !exclude.contains(oid))
+        .collect();
+    send.sort();
+
+    let mut objects = Vec::with_capacity(send.len());
+    for oid in send {
+        objects.push(git.materialize_object(&db, oid)?);
+    }
+    let pack = encode_pack(&objects)?;
+
+    if req.side_band_64k {
+        write_sideband_pack(&mut out, &pack)?;
+    } else {
+        out.extend_from_slice(&pack);
+    }
+    Ok(out)
+}
+
+/// Pack data on side-band channel 1, each chunk a pkt-line, terminated by a
+/// flush-pkt. Band byte (`0x01`) + payload must fit one pkt-line.
+fn write_sideband_pack(out: &mut Vec<u8>, pack: &[u8]) -> Result<()> {
+    const CHUNK: usize = pktline::MAX_PAYLOAD - 1; // leave room for the band byte
+    for chunk in pack.chunks(CHUNK) {
+        let mut payload = Vec::with_capacity(chunk.len() + 1);
+        payload.push(1u8);
+        payload.extend_from_slice(chunk);
+        pktline::write_data(out, &payload)?;
+    }
+    pktline::write_flush(out);
+    Ok(())
+}
+
+/// Transitive closure of the object DAG from `roots`: commits pull in their
+/// tree and parents, trees pull in their entries (sub-trees + blobs), tags pull
+/// in their target. Objects not present in the store are skipped (a `have` the
+/// client cited that we lack simply doesn't expand).
+fn collect_reachable(git: &GitStore, db: &Db, roots: &[GitOid]) -> Result<HashSet<GitOid>> {
+    use crate::object::GitObjectKind::*;
+    let mut seen = HashSet::new();
+    let mut stack: Vec<GitOid> = roots.to_vec();
+    while let Some(oid) = stack.pop() {
+        if !seen.insert(oid) {
+            continue;
+        }
+        // A cited oid we don't have: skip it (don't fail the whole walk).
+        let Ok(obj) = git.materialize_object(db, oid) else {
+            seen.remove(&oid);
+            continue;
+        };
+        match obj.kind {
+            Commit => {
+                if let Some(tree) = obj.header_value("tree") {
+                    if let Ok(t) = GitOid::from_hex(&tree) {
+                        stack.push(t);
+                    }
+                }
+                for parent in obj.header_values("parent") {
+                    if let Ok(p) = GitOid::from_hex(&parent) {
+                        stack.push(p);
+                    }
+                }
+            }
+            Tree => {
+                for entry in obj.tree_entries()? {
+                    stack.push(entry.oid);
+                }
+            }
+            Tag => {
+                if let Some(target) = obj.header_value("object") {
+                    if let Ok(t) = GitOid::from_hex(&target) {
+                        stack.push(t);
+                    }
+                }
+            }
+            Blob => {}
+        }
+    }
+    Ok(seen)
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// POST /git-receive-pack   (push)
+// ───────────────────────────────────────────────────────────────────────────
+
+/// One ref-update command from a push.
+struct RefCommand {
+    old: GitOid,
+    new: GitOid,
+    name: String,
+}
+
+struct ReceiveRequest {
+    commands: Vec<RefCommand>,
+    report_status: bool,
+    pack: Vec<u8>,
+}
+
+fn parse_receive_request(body: &[u8]) -> Result<ReceiveRequest> {
+    let mut commands = Vec::new();
+    let mut report_status = false;
+    let mut reader = PktLineReader::new(body);
+    let mut first = true;
+    while let Some(pkt) = reader.next_pkt()? {
+        match pkt {
+            PktLine::Flush => break,
+            PktLine::Delim => continue,
+            PktLine::Data(data) => {
+                // First command: `<old> <new> <ref>\0<caps>`; rest: `<old> <new> <ref>`.
+                let (cmd_bytes, caps) = match data.iter().position(|&b| b == 0) {
+                    Some(nul) => (&data[..nul], Some(&data[nul + 1..])),
+                    None => (&data[..], None),
+                };
+                if first {
+                    if let Some(caps) = caps {
+                        let caps = String::from_utf8_lossy(caps);
+                        if caps.split([' ', '\n']).any(|c| c == "report-status") {
+                            report_status = true;
+                        }
+                    }
+                    first = false;
+                }
+                let line = String::from_utf8_lossy(cmd_bytes);
+                let line = line.trim_end_matches('\n');
+                let mut parts = line.splitn(3, ' ');
+                let (Some(old), Some(new), Some(name)) =
+                    (parts.next(), parts.next(), parts.next())
+                else {
+                    return Err(crate::error::GitError::MalformedHeader);
+                };
+                commands.push(RefCommand {
+                    old: GitOid::from_hex(old)?,
+                    new: GitOid::from_hex(new)?,
+                    name: name.to_string(),
+                });
+            }
+        }
+    }
+    // Everything after the flush-pkt is the raw packfile (absent for pure deletes).
+    let pack = reader.remaining().to_vec();
+    Ok(ReceiveRequest {
+        commands,
+        report_status,
+        pack,
+    })
+}
+
+fn is_zero(oid: &GitOid) -> bool {
+    oid.0 == [0u8; 20]
+}
+
+/// Handle a `git-receive-pack` request body (a push): ingest the packfile into
+/// the store, then apply the ref updates. Returns the `report-status` body when
+/// the client asked for it (the default), else an empty body.
+///
+/// **Concurrency / fast-forward policy.** Each command carries the `old` value
+/// the client believed the ref held; we reject (`ng … stale`) when it disagrees
+/// with the stored ref, which is git's lost-update protection. We do *not*
+/// additionally enforce fast-forward-only (no force signal exists on the wire),
+/// so this behaves like `receive.denyNonFastForwards=false`.
+///
+/// Ref **deletion** (`new` = zero-oid) is reported `ng` — the append-only Datom
+/// projection has no retract path here yet, and we deliberately do not advertise
+/// `delete-refs`.
+pub async fn receive_pack(git: &GitStore<'_>, body: &[u8]) -> Result<Vec<u8>> {
+    let req = parse_receive_request(body)?;
+
+    // ── Ingest the packfile (if any). Thin-pack bases resolve from the store. ──
+    let mut unpack_status = "ok".to_string();
+    if req.pack.starts_with(b"PACK") {
+        let db = git.db();
+        let resolver = |oid: GitOid| -> Result<Option<(crate::object::GitObjectKind, Vec<u8>)>> {
+            match git.materialize_object(&db, oid) {
+                Ok(obj) => Ok(Some((obj.kind, obj.body))),
+                Err(_) => Ok(None),
+            }
+        };
+        match parse_pack(&req.pack, resolver) {
+            Ok(objects) => {
+                for (obj, _oid) in objects {
+                    git.put_object(&obj).await?;
+                }
+            }
+            Err(e) => unpack_status = format!("unpack-failed: {e}"),
+        }
+    }
+
+    // ── Apply ref updates (only if the pack unpacked cleanly). ─────────────────
+    let mut results: Vec<(String, std::result::Result<(), String>)> = Vec::new();
+    if unpack_status == "ok" {
+        let db = git.db();
+        for cmd in &req.commands {
+            let outcome = apply_command(git, &db, cmd).await;
+            results.push((cmd.name.clone(), outcome));
+        }
+        // Adopt a default branch: a bare repo needs `HEAD` to resolve so clients
+        // know which branch to check out on clone. If `HEAD` is dangling after
+        // this push (e.g. the very first push to a fresh repo), point it at the
+        // pushed branch — preferring `main`, then `master`, then any branch.
+        let db = git.db();
+        if resolve_ref(&db, "HEAD").is_none() {
+            if let Some(branch) = pick_default_branch(&db) {
+                let _ = git.put_symbolic_ref("HEAD", &branch).await;
+            }
+        }
+    } else {
+        for cmd in &req.commands {
+            results.push((cmd.name.clone(), Err("unpack failed".into())));
+        }
+    }
+
+    if !req.report_status {
+        return Ok(Vec::new());
+    }
+
+    let mut out = Vec::new();
+    pktline::write_str(&mut out, &format!("unpack {unpack_status}\n"))?;
+    for (name, outcome) in results {
+        match outcome {
+            Ok(()) => pktline::write_str(&mut out, &format!("ok {name}\n"))?,
+            Err(reason) => pktline::write_str(&mut out, &format!("ng {name} {reason}\n"))?,
+        }
+    }
+    pktline::write_flush(&mut out);
+    Ok(out)
+}
+
+/// Choose a default branch for `HEAD` among the `refs/heads/*` present:
+/// `refs/heads/main`, else `refs/heads/master`, else the first by name.
+fn pick_default_branch(db: &Db) -> Option<String> {
+    let mut branches: Vec<String> = list_refs(db)
+        .into_iter()
+        .filter_map(|(name, target)| match target {
+            RefTarget::Oid(_) if name.starts_with("refs/heads/") => Some(name),
+            _ => None,
+        })
+        .collect();
+    branches.sort();
+    if branches.iter().any(|b| b == "refs/heads/main") {
+        return Some("refs/heads/main".to_string());
+    }
+    if branches.iter().any(|b| b == "refs/heads/master") {
+        return Some("refs/heads/master".to_string());
+    }
+    branches.into_iter().next()
+}
+
+async fn apply_command(
+    git: &GitStore<'_>,
+    db: &Db,
+    cmd: &RefCommand,
+) -> std::result::Result<(), String> {
+    if is_zero(&cmd.new) {
+        return Err("deletion unsupported".into());
+    }
+    // Lost-update guard: the client's expected `old` must match the stored ref.
+    let current = resolve_ref(db, &cmd.name);
+    let expected = if is_zero(&cmd.old) { None } else { Some(cmd.old) };
+    if current != expected {
+        return Err("stale info: fetch first".into());
+    }
+    // Connectivity: the new tip must actually be in the store after ingest.
+    if object_cid(db, cmd.new).is_err() {
+        return Err("missing necessary objects".into());
+    }
+    git.put_ref(&cmd.name, cmd.new)
+        .await
+        .map_err(|e| format!("ref update failed: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object::{GitObject, GitObjectKind, TreeEntry};
+    use crate::GitStore;
+    use kotoba_datomic::Connection;
+    use kotoba_store::MemoryBlockStore;
+
+    async fn fixture() -> (Connection, MemoryBlockStore) {
+        let conn = Connection::new();
+        let store = MemoryBlockStore::new();
+        GitStore::new(&conn, &store).install_schema().await.unwrap();
+        (conn, store)
+    }
+
+    /// Seed a blob→tree→commit chain on `refs/heads/main` + HEAD symref.
+    async fn seed_commit(git: &GitStore<'_>) -> GitOid {
+        let blob = GitObject::blob(b"hello\n".to_vec());
+        let (blob_oid, _) = git.put_object(&blob).await.unwrap();
+        let tree = GitObject::tree(&[TreeEntry {
+            mode: b"100644".to_vec(),
+            name: b"f.txt".to_vec(),
+            oid: blob_oid,
+        }]);
+        let (tree_oid, _) = git.put_object(&tree).await.unwrap();
+        let commit = GitObject::new(
+            GitObjectKind::Commit,
+            format!(
+                "tree {tree_oid}\nauthor t <t@t> 1700000000 +0000\ncommitter t <t@t> 1700000000 +0000\n\nfirst\n"
+            )
+            .into_bytes(),
+        );
+        let (commit_oid, _) = git.put_object(&commit).await.unwrap();
+        git.put_ref("refs/heads/main", commit_oid).await.unwrap();
+        git.put_symbolic_ref("HEAD", "refs/heads/main").await.unwrap();
+        commit_oid
+    }
+
+    #[tokio::test]
+    async fn advertise_lists_head_and_branch_with_caps() {
+        let (conn, store) = fixture().await;
+        let git = GitStore::new(&conn, &store);
+        let commit = seed_commit(&git).await;
+
+        let body = advertise_refs(&git, GitService::UploadPack).unwrap();
+        let text = String::from_utf8_lossy(&body);
+        assert!(text.contains("# service=git-upload-pack"));
+        assert!(text.contains(&commit.to_hex()));
+        assert!(text.contains("refs/heads/main"));
+        assert!(text.contains("symref=HEAD:refs/heads/main"));
+        assert!(text.contains("side-band-64k"));
+    }
+
+    #[tokio::test]
+    async fn advertise_empty_repo_uses_zero_capabilities_line() {
+        let (conn, store) = fixture().await;
+        let git = GitStore::new(&conn, &store);
+        let body = advertise_refs(&git, GitService::ReceivePack).unwrap();
+        let text = String::from_utf8_lossy(&body);
+        assert!(text.contains(&format!("{ZERO_OID} capabilities^{{}}")));
+        assert!(text.contains("report-status"));
+    }
+
+    #[tokio::test]
+    async fn upload_pack_clone_sends_all_reachable_objects() {
+        let (conn, store) = fixture().await;
+        let git = GitStore::new(&conn, &store);
+        let commit = seed_commit(&git).await;
+
+        // A clone: `want <commit>` + flush + done, no haves, no side-band.
+        let mut body = Vec::new();
+        pktline::write_str(&mut body, &format!("want {}\n", commit.to_hex())).unwrap();
+        pktline::write_flush(&mut body);
+        pktline::write_str(&mut body, "done\n").unwrap();
+
+        let resp = upload_pack(&git, &body).unwrap();
+        // NAK pkt-line, then a raw pack.
+        assert!(resp.starts_with(b"0008NAK\n"));
+        let pack = &resp[8..];
+        let got = parse_pack(pack, |_| Ok(None)).unwrap();
+        assert_eq!(got.len(), 3, "blob + tree + commit");
+    }
+
+    #[tokio::test]
+    async fn upload_pack_negotiation_round_acks_without_pack() {
+        let (conn, store) = fixture().await;
+        let git = GitStore::new(&conn, &store);
+        let commit = seed_commit(&git).await;
+
+        // Client already has `commit`: send want + have, NO done.
+        let mut body = Vec::new();
+        pktline::write_str(&mut body, &format!("want {}\n", commit.to_hex())).unwrap();
+        pktline::write_flush(&mut body);
+        pktline::write_str(&mut body, &format!("have {}\n", commit.to_hex())).unwrap();
+
+        let resp = upload_pack(&git, &body).unwrap();
+        let text = String::from_utf8_lossy(&resp);
+        assert!(text.contains(&format!("ACK {}", commit.to_hex())));
+        assert!(!text.contains("PACK"), "no pack until the client says done");
+    }
+
+    #[tokio::test]
+    async fn receive_pack_ingests_and_updates_ref() {
+        // Source store with a commit; produce a pack of its objects.
+        let (src_conn, src_store) = fixture().await;
+        let src = GitStore::new(&src_conn, &src_store);
+        let commit = seed_commit(&src).await;
+        let objs: Vec<GitObject> = {
+            let db = src.db();
+            let reach = collect_reachable(&src, &db, &[commit]).unwrap();
+            let mut v: Vec<GitOid> = reach.into_iter().collect();
+            v.sort();
+            v.into_iter().map(|o| src.materialize_object(&db, o).unwrap()).collect()
+        };
+        let pack = encode_pack(&objs).unwrap();
+
+        // Empty destination receives a push creating refs/heads/main.
+        let (dst_conn, dst_store) = fixture().await;
+        let dst = GitStore::new(&dst_conn, &dst_store);
+
+        let mut body = Vec::new();
+        pktline::write_data(
+            &mut body,
+            format!("{ZERO_OID} {} refs/heads/main\0report-status\n", commit.to_hex())
+                .as_bytes(),
+        )
+        .unwrap();
+        pktline::write_flush(&mut body);
+        body.extend_from_slice(&pack);
+
+        let resp = receive_pack(&dst, &body).await.unwrap();
+        let text = String::from_utf8_lossy(&resp);
+        assert!(text.contains("unpack ok"), "got: {text}");
+        assert!(text.contains("ok refs/heads/main"), "got: {text}");
+
+        // The ref now resolves and every object round-trips byte-exact.
+        let db = dst.db();
+        assert_eq!(resolve_ref(&db, "refs/heads/main"), Some(commit));
+        // The first push to a fresh repo adopts a default branch for HEAD so a
+        // subsequent `git clone` knows which branch to check out.
+        assert_eq!(resolve_ref(&db, "HEAD"), Some(commit));
+        for obj in &objs {
+            let framed = dst.materialize_framed(&db, obj.oid()).unwrap();
+            assert_eq!(GitOid::of_framed(&framed), obj.oid());
+        }
+    }
+
+    #[tokio::test]
+    async fn upload_pack_side_band_64k_frames_the_pack_on_channel_1() {
+        let (conn, store) = fixture().await;
+        let git = GitStore::new(&conn, &store);
+        let commit = seed_commit(&git).await;
+
+        // Clone requesting side-band-64k (as real git does).
+        let mut body = Vec::new();
+        pktline::write_str(
+            &mut body,
+            &format!("want {} side-band-64k\n", commit.to_hex()),
+        )
+        .unwrap();
+        pktline::write_flush(&mut body);
+        pktline::write_str(&mut body, "done\n").unwrap();
+
+        let resp = upload_pack(&git, &body).unwrap();
+        // NAK line, then side-band pkt-lines (band byte 0x01), then flush.
+        assert!(resp.starts_with(b"0008NAK\n"));
+        let mut reader = PktLineReader::new(&resp[8..]);
+        let mut pack = Vec::new();
+        let mut saw_band1 = false;
+        while let Some(p) = reader.next_pkt().unwrap() {
+            match p {
+                PktLine::Data(d) => {
+                    assert_eq!(d[0], 1, "pack must ride side-band channel 1");
+                    saw_band1 = true;
+                    pack.extend_from_slice(&d[1..]);
+                }
+                PktLine::Flush => break,
+                PktLine::Delim => {}
+            }
+        }
+        assert!(saw_band1);
+        // The de-multiplexed bytes are a valid pack of all 3 objects.
+        assert_eq!(parse_pack(&pack, |_| Ok(None)).unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn upload_pack_fetch_excludes_objects_reachable_from_common_haves() {
+        let (conn, store) = fixture().await;
+        let git = GitStore::new(&conn, &store);
+        let c1 = seed_commit(&git).await; // blob+tree+commit
+
+        // A second commit on top, reusing nothing new but a fresh tree/blob.
+        let blob2 = GitObject::blob(b"world\n".to_vec());
+        let (b2, _) = git.put_object(&blob2).await.unwrap();
+        let tree2 = GitObject::tree(&[TreeEntry {
+            mode: b"100644".to_vec(),
+            name: b"g.txt".to_vec(),
+            oid: b2,
+        }]);
+        let (t2, _) = git.put_object(&tree2).await.unwrap();
+        let commit2 = GitObject::new(
+            GitObjectKind::Commit,
+            format!("tree {t2}\nparent {c1}\n\nsecond\n").into_bytes(),
+        );
+        let (c2, _) = git.put_object(&commit2).await.unwrap();
+        git.put_ref("refs/heads/main", c2).await.unwrap();
+
+        // Fetch c2 while already having c1: pack must omit c1's closure.
+        let mut body = Vec::new();
+        pktline::write_str(&mut body, &format!("want {}\n", c2.to_hex())).unwrap();
+        pktline::write_flush(&mut body);
+        pktline::write_str(&mut body, &format!("have {}\n", c1.to_hex())).unwrap();
+        pktline::write_str(&mut body, "done\n").unwrap();
+
+        let resp = upload_pack(&git, &body).unwrap();
+        // ACK <c1> then a raw pack (no side-band requested).
+        let text = String::from_utf8_lossy(&resp);
+        assert!(text.contains(&format!("ACK {}", c1.to_hex())));
+        let pack_start = resp
+            .windows(4)
+            .position(|w| w == b"PACK")
+            .expect("a pack follows the ACK");
+        let got = parse_pack(&resp[pack_start..], |_| Ok(None)).unwrap();
+        let oids: std::collections::HashSet<_> = got.iter().map(|(_, o)| *o).collect();
+        // Only c2's new objects (commit2 + tree2 + blob2); NOT c1's closure.
+        assert!(oids.contains(&c2) && oids.contains(&t2) && oids.contains(&b2));
+        assert!(!oids.contains(&c1), "objects reachable from the have must be excluded");
+        assert_eq!(oids.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn upload_pack_serves_annotated_tag_and_its_target_closure() {
+        let (conn, store) = fixture().await;
+        let git = GitStore::new(&conn, &store);
+        let commit = seed_commit(&git).await;
+        let tag = GitObject::new(
+            GitObjectKind::Tag,
+            format!(
+                "object {commit}\ntype commit\ntag v1\ntagger t <t@t> 1700000000 +0000\n\nrel\n"
+            )
+            .into_bytes(),
+        );
+        let (tag_oid, _) = git.put_object(&tag).await.unwrap();
+        git.put_ref("refs/tags/v1", tag_oid).await.unwrap();
+
+        let mut body = Vec::new();
+        pktline::write_str(&mut body, &format!("want {}\n", tag_oid.to_hex())).unwrap();
+        pktline::write_flush(&mut body);
+        pktline::write_str(&mut body, "done\n").unwrap();
+
+        let resp = upload_pack(&git, &body).unwrap();
+        let pack = &resp[resp.windows(4).position(|w| w == b"PACK").unwrap()..];
+        let oids: std::collections::HashSet<_> =
+            parse_pack(pack, |_| Ok(None)).unwrap().into_iter().map(|(_, o)| o).collect();
+        // tag → commit → tree → blob, all four reachable from the tag.
+        assert!(oids.contains(&tag_oid) && oids.contains(&commit));
+        assert_eq!(oids.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn receive_pack_reports_unpack_failed_on_corrupt_pack() {
+        let (conn, store) = fixture().await;
+        let git = GitStore::new(&conn, &store);
+        let commit = GitObject::blob(b"x".to_vec()).oid(); // arbitrary
+
+        let mut body = Vec::new();
+        pktline::write_data(
+            &mut body,
+            format!("{ZERO_OID} {} refs/heads/main\0report-status\n", commit.to_hex())
+                .as_bytes(),
+        )
+        .unwrap();
+        pktline::write_flush(&mut body);
+        body.extend_from_slice(b"PACK\x00\x00\x00\x02corrupt-not-a-real-pack-trailer!!"); // bad
+
+        let resp = receive_pack(&git, &body).await.unwrap();
+        let text = String::from_utf8_lossy(&resp);
+        assert!(text.contains("unpack unpack-failed"), "got: {text}");
+        assert!(text.contains("ng refs/heads/main"), "got: {text}");
+    }
+
+    #[tokio::test]
+    async fn receive_pack_reports_per_command_ok_and_ng_independently() {
+        // One push carrying two commands: a valid create of refs/heads/feature
+        // and a stale update of refs/heads/main. The pack supplies the objects.
+        let (conn, store) = fixture().await;
+        let git = GitStore::new(&conn, &store);
+        let commit = seed_commit(&git).await; // main is at `commit`; objects present
+
+        let objs: Vec<GitObject> = {
+            let db = git.db();
+            let mut v: Vec<GitOid> = collect_reachable(&git, &db, &[commit]).unwrap().into_iter().collect();
+            v.sort();
+            v.into_iter().map(|o| git.materialize_object(&db, o).unwrap()).collect()
+        };
+        let pack = encode_pack(&objs).unwrap();
+
+        let mut body = Vec::new();
+        // cmd 1 (first → carries caps): create refs/heads/feature @ commit  → ok
+        pktline::write_data(
+            &mut body,
+            format!("{ZERO_OID} {} refs/heads/feature\0report-status\n", commit.to_hex())
+                .as_bytes(),
+        )
+        .unwrap();
+        // cmd 2: update main claiming old=zero (but it exists @ commit) → stale ng
+        pktline::write_data(
+            &mut body,
+            format!("{ZERO_OID} {} refs/heads/main\n", commit.to_hex()).as_bytes(),
+        )
+        .unwrap();
+        pktline::write_flush(&mut body);
+        body.extend_from_slice(&pack);
+
+        let resp = receive_pack(&git, &body).await.unwrap();
+        let text = String::from_utf8_lossy(&resp);
+        assert!(text.contains("unpack ok"), "got: {text}");
+        assert!(text.contains("ok refs/heads/feature"), "create must succeed: {text}");
+        assert!(text.contains("ng refs/heads/main"), "stale update must be rejected: {text}");
+        // The accepted ref took effect; the rejected one did not change.
+        let db = git.db();
+        assert_eq!(resolve_ref(&db, "refs/heads/feature"), Some(commit));
+    }
+
+    #[tokio::test]
+    async fn receive_pack_rejects_ref_deletion() {
+        let (conn, store) = fixture().await;
+        let git = GitStore::new(&conn, &store);
+        let commit = seed_commit(&git).await;
+
+        // Delete request: new-oid = zero. No pack.
+        let mut body = Vec::new();
+        pktline::write_data(
+            &mut body,
+            format!("{} {ZERO_OID} refs/heads/main\0report-status\n", commit.to_hex())
+                .as_bytes(),
+        )
+        .unwrap();
+        pktline::write_flush(&mut body);
+
+        let resp = receive_pack(&git, &body).await.unwrap();
+        let text = String::from_utf8_lossy(&resp);
+        assert!(text.contains("unpack ok"), "got: {text}");
+        assert!(text.contains("ng refs/heads/main deletion unsupported"), "got: {text}");
+    }
+
+    #[test]
+    fn pick_default_branch_prefers_main_then_master_then_first() {
+        use crate::object::GitObjectKind;
+        // We need a Db with some refs/heads/* present. Build via a Connection.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let (conn, store) = fixture().await;
+            let git = GitStore::new(&conn, &store);
+            let c = GitObject::new(GitObjectKind::Commit, b"tree x\n\nm\n".to_vec());
+            let (oid, _) = git.put_object(&c).await.unwrap();
+            git.put_ref("refs/heads/zeta", oid).await.unwrap();
+            git.put_ref("refs/heads/master", oid).await.unwrap();
+            assert_eq!(
+                pick_default_branch(&git.db()).as_deref(),
+                Some("refs/heads/master"),
+                "master preferred over an alphabetically-first branch"
+            );
+            git.put_ref("refs/heads/main", oid).await.unwrap();
+            assert_eq!(
+                pick_default_branch(&git.db()).as_deref(),
+                Some("refs/heads/main"),
+                "main preferred over master"
+            );
+        });
+    }
+
+    #[tokio::test]
+    async fn receive_pack_rejects_stale_old_value() {
+        let (conn, store) = fixture().await;
+        let git = GitStore::new(&conn, &store);
+        let commit = seed_commit(&git).await; // ref is at `commit`
+
+        // Push claims old=zero (i.e. "ref doesn't exist") but it does → stale.
+        let mut body = Vec::new();
+        pktline::write_data(
+            &mut body,
+            format!("{ZERO_OID} {} refs/heads/main\0report-status\n", commit.to_hex())
+                .as_bytes(),
+        )
+        .unwrap();
+        pktline::write_flush(&mut body);
+        // No pack needed — the command is rejected before connectivity matters,
+        // but the object already exists so connectivity would pass anyway.
+
+        let resp = receive_pack(&git, &body).await.unwrap();
+        let text = String::from_utf8_lossy(&resp);
+        assert!(text.contains("ng refs/heads/main"), "got: {text}");
+    }
+}

--- a/crates/kotoba-server/Cargo.toml
+++ b/crates/kotoba-server/Cargo.toml
@@ -24,6 +24,8 @@ kotoba-ingest.workspace  = true
 kotoba-core.workspace    = true
 kotoba-edn               = { path = "../kotoba-edn" }
 kotoba-datomic           = { path = "../kotoba-datomic" }
+kotoba-git               = { path = "../kotoba-git" }
+flate2.workspace         = true                       # decompress gzip-encoded git smart-HTTP request bodies
 kotoba-ipfs              = { path = "../kotoba-ipfs" }
 kotoba-vc                = { path = "../kotoba-vc" }
 kotoba-didcomm           = { path = "../kotoba-didcomm" }

--- a/crates/kotoba-server/src/git_http.rs
+++ b/crates/kotoba-server/src/git_http.rs
@@ -1,0 +1,277 @@
+//! Git **smart-HTTP** endpoints — let a real `git` client clone, fetch and push
+//! against kotoba, with every object landing as an IPFS block + `:git/*` Datom
+//! projection (ADR-2606015000 made the git ↔ kotoba bridge; this opens it to the
+//! network).
+//!
+//! Routes (mounted by `build_router`):
+//!
+//! | Method | Path                              | Handler            | git op |
+//! |--------|-----------------------------------|--------------------|--------|
+//! | GET    | `/git/:repo/info/refs?service=…`  | [`info_refs`]      | discovery |
+//! | POST   | `/git/:repo/git-upload-pack`      | [`upload_pack`]    | clone / fetch |
+//! | POST   | `/git/:repo/git-receive-pack`     | [`receive_pack`]   | push |
+//!
+//! `:repo` names a per-repo [`kotoba_datomic::Connection`] (the queryable git
+//! projection) paired with the node's shared `block_store` (the lossless,
+//! content-addressed object bytes) — i.e. **datomic + IPFS**, the substrate the
+//! whole crate is built on. The wire protocol itself lives in
+//! [`kotoba_git::wire`]; this module is the thin HTTP/auth shell around it.
+//!
+//! ## AuthZ
+//!
+//! * **Reads** (clone/fetch) are gated by the node read policy
+//!   (`KOTOBA_DEFAULT_VISIBILITY`), reusing [`graph_auth::check_read_access`] —
+//!   the same gate as the firehose.
+//! * **Push** is gated by [`graph_auth::require_operator_auth`] (a Bearer JWT
+//!   whose `sub` is the operator DID) — pushing mutates the node's git state, so
+//!   it requires operator authority by default. Set
+//!   `KOTOBA_GIT_ALLOW_ANON_PUSH=1` to allow anonymous push (local dev / tests).
+
+use std::sync::Arc;
+
+use axum::{
+    body::{Body, Bytes},
+    extract::{Path, Query, State},
+    http::{header, HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+};
+use serde::Deserialize;
+use std::io::Read;
+
+use crate::graph_auth::{self, AccessDenied};
+use crate::server::KotobaState;
+use kotoba_core::cid::KotobaCid;
+use kotoba_git::wire::{self, GitService};
+use kotoba_git::GitStore;
+
+/// Cap on a single request body (pack upload). 1 GiB matches the per-object
+/// inflate cap in `kotoba-git` and bounds memory for a push.
+pub const GIT_BODY_LIMIT: usize = 1 << 30;
+
+#[derive(Debug, Deserialize)]
+pub struct InfoRefsQuery {
+    service: Option<String>,
+}
+
+/// `GET /git/:repo/info/refs?service=git-upload-pack|git-receive-pack`
+pub async fn info_refs(
+    State(state): State<Arc<KotobaState>>,
+    Path(repo): Path<String>,
+    Query(q): Query<InfoRefsQuery>,
+    headers: HeaderMap,
+) -> Response {
+    // Only the smart protocol is supported (no dumb-HTTP file serving).
+    let Some(service) = q.service.as_deref().and_then(GitService::from_query) else {
+        return (
+            StatusCode::FORBIDDEN,
+            "only the git smart HTTP protocol is supported (missing ?service=)",
+        )
+            .into_response();
+    };
+
+    // Gate by service: discovery for push must pass the push gate.
+    let gate = match service {
+        GitService::UploadPack => read_gate(&state, &headers).await,
+        GitService::ReceivePack => push_gate(&state, &headers, &repo),
+    };
+    if let Err(e) = gate {
+        return e.into_response();
+    }
+
+    let conn = state.git_connection(&repo).await;
+    let git = GitStore::new(&conn, &*state.block_store);
+    match wire::advertise_refs(&git, service) {
+        Ok(body) => smart_response(
+            &format!("application/x-{}-advertisement", service.as_str()),
+            body,
+        ),
+        Err(e) => git_error(e),
+    }
+}
+
+/// `POST /git/:repo/git-upload-pack` (clone / fetch).
+pub async fn upload_pack(
+    State(state): State<Arc<KotobaState>>,
+    Path(repo): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if let Err(e) = read_gate(&state, &headers).await {
+        return e.into_response();
+    }
+    let body = match decode_body(&headers, body) {
+        Ok(b) => b,
+        Err(e) => return e.into_response(),
+    };
+
+    let conn = state.git_connection(&repo).await;
+    let git = GitStore::new(&conn, &*state.block_store);
+    match wire::upload_pack(&git, &body) {
+        Ok(out) => smart_response("application/x-git-upload-pack-result", out),
+        Err(e) => git_error(e),
+    }
+}
+
+/// `POST /git/:repo/git-receive-pack` (push).
+pub async fn receive_pack(
+    State(state): State<Arc<KotobaState>>,
+    Path(repo): Path<String>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    if let Err(e) = push_gate(&state, &headers, &repo) {
+        return e.into_response();
+    }
+    let body = match decode_body(&headers, body) {
+        Ok(b) => b,
+        Err(e) => return e.into_response(),
+    };
+
+    let conn = state.git_connection(&repo).await;
+    let git = GitStore::new(&conn, &*state.block_store);
+    match wire::receive_pack(&git, &body).await {
+        Ok(out) => {
+            // Persist the updated projection (objects are already durable blocks;
+            // this snapshots the oid↔cid index + refs and records the pointer).
+            state.git_persist(&repo, &git).await;
+            smart_response("application/x-git-receive-pack-result", out)
+        }
+        Err(e) => git_error(e),
+    }
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+/// The CACAO credential git carries, if any. git sets it via
+/// `git -c http.extraHeader="x-kotoba-cacao: <b64>"`. A custom header (not the
+/// `Authorization` Bearer) so it never collides with an operator JWT.
+fn cacao_header(headers: &HeaderMap) -> Option<&str> {
+    headers.get("x-kotoba-cacao").and_then(|v| v.to_str().ok())
+}
+
+/// Read gate: node default visibility (`KOTOBA_DEFAULT_VISIBILITY`), reusing the
+/// firehose's `check_read_access`. A CACAO read credential (capability
+/// `datom:read`) may ride in the `x-kotoba-cacao` header. No nonce store: a
+/// clone reuses the same credential across `info/refs` + `upload-pack`.
+async fn read_gate(
+    state: &KotobaState,
+    headers: &HeaderMap,
+) -> Result<(), (StatusCode, String)> {
+    // Sentinel all-zero CID → node default visibility (not a registered graph).
+    let visibility = state.graph_visibility(&KotobaCid([0u8; 36])).await;
+    graph_auth::check_read_access(
+        &visibility,
+        headers,
+        cacao_header(headers),
+        Some(&state.operator_did),
+        None,
+    )
+    .map_err(AccessDenied::into_response)
+}
+
+/// Push gate, in precedence order:
+/// 1. `KOTOBA_GIT_ALLOW_ANON_PUSH=1` — open (local dev / tests).
+/// 2. A CACAO granting `git.receive/push` on scope `git/repo/<repo>`, rooted at
+///    the operator DID — capability-based, governance-delegable push authority.
+/// 3. An operator Bearer JWT (`sub == operator_did`).
+fn push_gate(
+    state: &KotobaState,
+    headers: &HeaderMap,
+    repo: &str,
+) -> Result<(), (StatusCode, String)> {
+    if std::env::var("KOTOBA_GIT_ALLOW_ANON_PUSH").as_deref() == Ok("1") {
+        return Ok(());
+    }
+    if let Some(cacao_b64) = cacao_header(headers) {
+        let scope = format!("git/repo/{repo}");
+        return graph_auth::verify_cacao_capability(
+            cacao_b64,
+            "git.receive/push",
+            &scope,
+            &state.operator_did,
+            Some(&state.operator_did),
+            None, // git reuses the credential across info/refs + receive-pack
+        )
+        .map_err(AccessDenied::into_response);
+    }
+    graph_auth::require_operator_auth(headers, &state.operator_did)
+}
+
+/// Decompress the body if the client sent `Content-Encoding: gzip` (git does
+/// this for larger upload-pack requests).
+fn decode_body(headers: &HeaderMap, body: Bytes) -> Result<Vec<u8>, (StatusCode, String)> {
+    let gzipped = headers
+        .get(header::CONTENT_ENCODING)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.eq_ignore_ascii_case("gzip"))
+        .unwrap_or(false);
+    if !gzipped {
+        return Ok(body.to_vec());
+    }
+    let mut out = Vec::new();
+    flate2::read::GzDecoder::new(&body[..])
+        .read_to_end(&mut out)
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                format!("malformed gzip request body: {e}"),
+            )
+        })?;
+    Ok(out)
+}
+
+/// Build a smart-HTTP response with the right content-type and no-cache headers
+/// (git is strict about caching the dynamic protocol endpoints).
+fn smart_response(content_type: &str, body: Vec<u8>) -> Response {
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, content_type)
+        .header(header::CACHE_CONTROL, "no-cache, max-age=0, must-revalidate")
+        .body(Body::from(body))
+        .expect("static header values are valid")
+}
+
+fn git_error(e: kotoba_git::GitError) -> Response {
+    tracing::warn!(error = %e, "git smart-HTTP request failed");
+    (StatusCode::BAD_REQUEST, format!("git protocol error: {e}")).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn gzip(data: &[u8]) -> Vec<u8> {
+        let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        enc.write_all(data).unwrap();
+        enc.finish().unwrap()
+    }
+
+    #[test]
+    fn decode_body_passes_through_plain_and_inflates_gzip() {
+        let payload = b"0032want 1111111111111111111111111111111111111111\n0000".to_vec();
+
+        // No Content-Encoding → returned verbatim.
+        let plain = decode_body(&HeaderMap::new(), Bytes::from(payload.clone())).unwrap();
+        assert_eq!(plain, payload);
+
+        // Content-Encoding: gzip → inflated back to the original bytes.
+        let mut h = HeaderMap::new();
+        h.insert(header::CONTENT_ENCODING, "gzip".parse().unwrap());
+        let got = decode_body(&h, Bytes::from(gzip(&payload))).unwrap();
+        assert_eq!(got, payload);
+
+        // Case-insensitive ("GZIP") is also handled.
+        let mut h = HeaderMap::new();
+        h.insert(header::CONTENT_ENCODING, "GZIP".parse().unwrap());
+        assert_eq!(decode_body(&h, Bytes::from(gzip(&payload))).unwrap(), payload);
+    }
+
+    #[test]
+    fn decode_body_rejects_corrupt_gzip() {
+        let mut h = HeaderMap::new();
+        h.insert(header::CONTENT_ENCODING, "gzip".parse().unwrap());
+        let err = decode_body(&h, Bytes::from_static(b"not actually gzip")).unwrap_err();
+        assert_eq!(err.0, StatusCode::BAD_REQUEST);
+    }
+}

--- a/crates/kotoba-server/src/graph_auth.rs
+++ b/crates/kotoba-server/src/graph_auth.rs
@@ -499,6 +499,78 @@ pub fn check_read_access(
     }
 }
 
+/// Verify a CACAO delegation that grants `capability` on graph-scope
+/// `graph_scope`, rooted at `required_issuer` (the delegator who alone may
+/// grant it). Mirrors the Private-read branch of [`check_read_access`] but for
+/// an arbitrary capability — used by the git push gate (`git.receive/push`).
+///
+/// `nonce_store` is `Option` and typically `None` for git: a single git
+/// operation reuses the same credential across its discovery (`info/refs`) and
+/// pack requests, so CAIP-74 single-use nonces would false-positive on the
+/// second request. Pass a store only where the credential is single-request.
+pub fn verify_cacao_capability(
+    cacao_b64: &str,
+    capability: &str,
+    graph_scope: &str,
+    required_issuer: &str,
+    expected_aud: Option<&str>,
+    nonce_store: Option<&crate::nonce_store::NonceStore>,
+) -> Result<(), AccessDenied> {
+    const MAX_CACAO_B64_LEN: usize = 8 * 1024;
+    if cacao_b64.len() > MAX_CACAO_B64_LEN {
+        return Err(AccessDenied::CacaoDecodeError(format!(
+            "cacao_b64 too large ({} bytes, limit {MAX_CACAO_B64_LEN})",
+            cacao_b64.len()
+        )));
+    }
+    let cbor = B64
+        .decode(cacao_b64)
+        .map_err(|e| AccessDenied::CacaoDecodeError(e.to_string()))?;
+    let cacao = Cacao::from_cbor(&cbor).map_err(|e| AccessDenied::CacaoParseError(e.to_string()))?;
+    let chain = DelegationChain::new(cacao);
+
+    let issuer_did = match expected_aud {
+        Some(aud) => chain
+            .verify_with_aud(graph_scope, capability, aud)
+            .map_err(|e| match e {
+                kotoba_auth::DelegationError::AudienceMismatch { expected, got } => {
+                    AccessDenied::AudienceMismatch { expected, got }
+                }
+                other => AccessDenied::DelegationError(other.to_string()),
+            })?,
+        None => chain
+            .verify(graph_scope, capability)
+            .map_err(|e| AccessDenied::DelegationError(e.to_string()))?,
+    };
+
+    if issuer_did != required_issuer {
+        return Err(AccessDenied::IssuerMismatch {
+            expected: required_issuer.to_string(),
+            got: issuer_did,
+        });
+    }
+
+    if let Some(store) = nonce_store {
+        let nonce = chain.chain[0].p.nonce.clone();
+        if nonce.is_empty() {
+            return Err(AccessDenied::DelegationError(
+                "CACAO nonce must not be empty".into(),
+            ));
+        }
+        const MAX_CACAO_AGE_SECS: u64 = 7 * 24 * 3600;
+        let expiry_unix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+            .saturating_add(MAX_CACAO_AGE_SECS);
+        if !store.check_and_register(&nonce, expiry_unix) {
+            return Err(AccessDenied::ReplayedNonce(nonce));
+        }
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -6,6 +6,7 @@ pub mod econ;
 pub mod email_xrpc;
 pub mod fingerprint;
 pub mod firehose;
+pub mod git_http;
 pub mod graph_auth;
 pub mod kg;
 pub mod kotobase_xrpc;
@@ -1331,6 +1332,18 @@ pub fn build_router(state: Arc<KotobaState>) -> Router {
         .route(
             &format!("/xrpc/{}", realtime::NSID_SYNC_CONNECT),
             get(realtime::ws_connect),
+        )
+        // ── Git smart-HTTP (clone / fetch / push over datomic + IPFS) ───────
+        .route("/git/:repo/info/refs", get(git_http::info_refs))
+        .route(
+            "/git/:repo/git-upload-pack",
+            post(git_http::upload_pack)
+                .layer(DefaultBodyLimit::max(git_http::GIT_BODY_LIMIT)),
+        )
+        .route(
+            "/git/:repo/git-receive-pack",
+            post(git_http::receive_pack)
+                .layer(DefaultBodyLimit::max(git_http::GIT_BODY_LIMIT)),
         )
         // ── Generic XRPC dispatch ──────────────────────────────────────────
         .route(

--- a/crates/kotoba-server/src/server.rs
+++ b/crates/kotoba-server/src/server.rs
@@ -340,6 +340,14 @@ pub struct KotobaState {
     /// efficacy hook proving the resident cache actually serves steady-state
     /// transacts rather than silently falling through to a cold scan.
     pub datomic_cold_db_loads: Arc<std::sync::atomic::AtomicU64>,
+    // ── Git wire protocol (kotoba-git) ────────────────────────────────────────
+    /// Per-repo git **Datom projection** (the `oid↔cid` bridge + refs + queryable
+    /// commit DAG), keyed by repo name. The lossless object *bytes* live in
+    /// `block_store` (IPFS, content-addressed); this `Connection` is the datomic
+    /// projection over them. Lazily created with the `:git/*` schema installed on
+    /// first access — see `git_connection`.
+    pub git_repos:
+        Arc<tokio::sync::RwLock<HashMap<String, Arc<kotoba_datomic::Connection>>>>,
 }
 
 impl KotobaState {
@@ -850,6 +858,7 @@ impl KotobaState {
             nonce_store: Arc::new(crate::nonce_store::NonceStore::new()),
             datomic_live: Arc::new(std::sync::Mutex::new(HashMap::new())),
             datomic_cold_db_loads: Arc::new(std::sync::atomic::AtomicU64::new(0)),
+            git_repos: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             http_client: reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(10))
                 .build()
@@ -987,6 +996,97 @@ impl KotobaState {
             }
         }
         tracing::info!(seeded, "warm: datomic resident-cache warm-up complete");
+    }
+
+    /// Get (or lazily create) the git Datom projection [`Connection`] for `repo`.
+    ///
+    /// The `:git/*` schema is installed once on creation, and the projection is
+    /// **rehydrated** from the last durable snapshot if one exists (see
+    /// [`Self::git_persist`]). The returned `Connection` is paired with
+    /// [`Self::block_store`] to form a `kotoba_git::GitStore` — datomic
+    /// projection + IPFS blocks — by the `git_http` handlers.
+    pub async fn git_connection(&self, repo: &str) -> Arc<kotoba_datomic::Connection> {
+        if let Some(conn) = self.git_repos.read().await.get(repo) {
+            return Arc::clone(conn);
+        }
+        let mut repos = self.git_repos.write().await;
+        // Re-check under the write lock (another task may have created it).
+        if let Some(conn) = repos.get(repo) {
+            return Arc::clone(conn);
+        }
+        let conn = Arc::new(kotoba_datomic::Connection::new());
+        {
+            let git = kotoba_git::GitStore::new(&conn, &*self.block_store);
+            if let Err(e) = git.install_schema().await {
+                tracing::warn!(repo, error = %e, "git_connection: install_schema failed");
+            }
+            // Rehydrate the projection (oid↔cid index + refs) from the durable
+            // manifest, if this repo was persisted before. Objects come back
+            // from their content-addressed blocks (durable in IPFS/Kubo).
+            if let Some(cid) = self.git_head_cid(repo).await {
+                match git.rehydrate(&cid).await {
+                    Ok((restored, missing)) => tracing::info!(
+                        repo, restored, missing,
+                        "git: rehydrated repo projection from durable snapshot"
+                    ),
+                    Err(e) => tracing::warn!(repo, error = %e, "git: rehydrate failed"),
+                }
+            }
+        }
+        repos.insert(repo.to_string(), Arc::clone(&conn));
+        conn
+    }
+
+    /// Durable mutable pointer key for a repo's latest snapshot manifest CID.
+    fn git_repo_key(repo: &str) -> String {
+        let safe: String = repo
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                    c
+                } else {
+                    '_'
+                }
+            })
+            .collect();
+        format!("git/repo/{safe}/head")
+    }
+
+    /// Resolve the durable snapshot-manifest CID for `repo` from the `KseStore`
+    /// mutable boundary (`None` if no store is configured or none was persisted).
+    async fn git_head_cid(&self, repo: &str) -> Option<KotobaCid> {
+        let ks = self.kse_store.as_ref()?;
+        let bytes = ks.get(&Self::git_repo_key(repo)).await.ok()?;
+        let s = String::from_utf8(bytes.to_vec()).ok()?;
+        KotobaCid::from_multibase(s.trim())
+    }
+
+    /// Persist `repo`'s projection durably: write the snapshot manifest block
+    /// (content-addressed, into the IPFS-backed block store) and record its CID
+    /// in the `KseStore` mutable boundary. Combined with the already-durable
+    /// object blocks, this is the full durable form of the git repo. A no-op for
+    /// the mutable pointer when no `KseStore` is configured (dev / ephemeral),
+    /// though the manifest block is still written.
+    pub async fn git_persist(&self, repo: &str, git: &kotoba_git::GitStore<'_>) {
+        let cid = match git.snapshot_manifest() {
+            Ok(cid) => cid,
+            Err(e) => {
+                tracing::warn!(repo, error = %e, "git: snapshot_manifest failed");
+                return;
+            }
+        };
+        match self.kse_store.as_ref() {
+            Some(ks) => {
+                let key = Self::git_repo_key(repo);
+                if let Err(e) = ks.put(&key, Bytes::from(cid.to_multibase().into_bytes())).await {
+                    tracing::warn!(repo, error = %e, "git: persisting snapshot pointer failed");
+                }
+            }
+            None => tracing::debug!(
+                repo,
+                "git: no KseStore — snapshot block written but pointer is not durable"
+            ),
+        }
     }
 
     /// Attach a GossipSub outbound channel after construction.

--- a/crates/kotoba-server/tests/git_cacao_push.rs
+++ b/crates/kotoba-server/tests/git_cacao_push.rs
@@ -1,0 +1,168 @@
+//! Push authorization via a **CACAO capability** (`git.receive/push`).
+//!
+//! Instead of anonymous push or an operator Bearer JWT, the client presents a
+//! CACAO — a signed, capability-scoped delegation — in the `x-kotoba-cacao`
+//! header. The server accepts the push iff the CACAO grants `git.receive/push`
+//! on scope `git/repo/<repo>` and is rooted at the operator DID. This is the
+//! governance-delegable push-authority path.
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use base64::{engine::general_purpose::STANDARD as B64, engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use ed25519_dalek::{Signer, SigningKey};
+use kotoba_auth::did_key::ed25519_pubkey_to_did_key;
+use kotoba_auth::{Cacao, CacaoHeader, CacaoPayload, CacaoSig};
+use kotoba_server::build_router;
+use kotoba_server::server::KotobaState;
+
+/// Deterministic operator key for the test (32-byte hex seed).
+const SEED_HEX: &str = "1111111111111111111111111111111111111111111111111111111111111111";
+
+fn build_cacao(scope: &str, capability: &str, aud: &str, nonce: &str) -> String {
+    let sk = SigningKey::from_bytes(&hex::decode(SEED_HEX).unwrap().try_into().unwrap());
+    let did = ed25519_pubkey_to_did_key(sk.verifying_key().as_bytes());
+    let mut cacao = Cacao {
+        h: CacaoHeader { t: "caip122".into() },
+        p: CacaoPayload {
+            iss: did.clone(),
+            aud: aud.to_string(),
+            issued_at: "2026-05-26T00:00:00Z".into(),
+            expiry: Some("2099-01-01T00:00:00Z".into()),
+            nonce: nonce.into(),
+            domain: "kotoba.git".into(),
+            statement: None,
+            version: "1".into(),
+            resources: vec![
+                format!("kotoba://graph/{scope}"),
+                format!("kotoba://can/{capability}"),
+            ],
+        },
+        s: CacaoSig { t: "EdDSA".into(), s: String::new() },
+    };
+    let sig: ed25519_dalek::Signature = sk.sign(cacao.siwe_message().as_bytes());
+    cacao.s.s = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+    let mut cbor = Vec::new();
+    ciborium::into_writer(&cacao, &mut cbor).unwrap();
+    B64.encode(&cbor)
+}
+
+fn operator_did() -> String {
+    let sk = SigningKey::from_bytes(&hex::decode(SEED_HEX).unwrap().try_into().unwrap());
+    ed25519_pubkey_to_did_key(sk.verifying_key().as_bytes())
+}
+
+/// Run git; return Ok(stdout) on success, Err(stderr) on failure (so callers
+/// can assert *both* outcomes).
+fn git(cwd: &Path, header: Option<&str>, args: &[&str]) -> Result<String, String> {
+    let mut cmd = Command::new("git");
+    if let Some(h) = header {
+        cmd.arg("-c").arg(format!("http.extraHeader=x-kotoba-cacao: {h}"));
+    }
+    let out = cmd
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .expect("spawn git");
+    if out.status.success() {
+        Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    } else {
+        Err(String::from_utf8_lossy(&out.stderr).to_string())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn push_authorized_by_cacao_capability() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("skipping: git CLI not available");
+        return;
+    }
+
+    // Deterministic operator identity. AgentIdentity::from_env only honors the
+    // seed when all three vars are present, and takes the DID verbatim — so we
+    // set KOTOBA_AGENT_DID to the did:key derived from the same seed the CACAO
+    // is signed with. NO anon push, NO public read.
+    std::env::set_var("KOTOBA_AGENT_ED25519_HEX", SEED_HEX);
+    std::env::set_var(
+        "KOTOBA_AGENT_X25519_HEX",
+        "2222222222222222222222222222222222222222222222222222222222222222",
+    );
+    std::env::set_var("KOTOBA_AGENT_DID", operator_did());
+    std::env::remove_var("KOTOBA_GIT_ALLOW_ANON_PUSH");
+    std::env::remove_var("KOTOBA_DEFAULT_VISIBILITY");
+
+    let state = Arc::new(KotobaState::new(None).expect("KotobaState::new"));
+    assert_eq!(
+        state.operator_did,
+        operator_did(),
+        "server operator DID must derive from the same seed the CACAO is signed with"
+    );
+    let probe = Arc::clone(&state);
+    let router = build_router(Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+    let url = format!("http://127.0.0.1:{}/git/cacaorepo", addr.port());
+    let did = operator_did();
+
+    let work = std::env::temp_dir().join(format!(
+        "kotoba-git-cacao-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let src = work.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    git(&src, None, &["init", "-q", "-b", "main", "."]).unwrap();
+    std::fs::write(src.join("f.txt"), b"cacao-gated\n").unwrap();
+    git(&src, None, &["add", "."]).unwrap();
+    git(&src, None, &["commit", "-q", "-m", "c1"]).unwrap();
+    let head = git(&src, None, &["rev-parse", "HEAD"]).unwrap();
+
+    // 1. NEGATIVE: no credential at all → push rejected.
+    let no_cred = git(&src, None, &["push", "-q", &url, "main:refs/heads/main"]);
+    assert!(no_cred.is_err(), "push with no credential must be rejected");
+
+    // 2. NEGATIVE: a CACAO granting only `datom:read` → wrong capability → rejected.
+    let read_cacao = build_cacao("git/repo/cacaorepo", "datom:read", &did, "n-read");
+    let wrong_cap = git(
+        &src,
+        Some(&read_cacao),
+        &["push", "-q", &url, "main:refs/heads/main"],
+    );
+    assert!(wrong_cap.is_err(), "a datom:read CACAO must not authorize push");
+
+    // 3. POSITIVE: a CACAO granting `git.receive/push` on this repo → accepted.
+    let push_cacao = build_cacao("git/repo/cacaorepo", "git.receive/push", &did, "n-push");
+    git(
+        &src,
+        Some(&push_cacao),
+        &["push", "-q", &url, "main:refs/heads/main"],
+    )
+    .expect("git.receive/push CACAO must authorize the push");
+
+    // The ref landed in the projection.
+    let conn = probe.git_connection("cacaorepo").await;
+    let git_store = kotoba_git::GitStore::new(&conn, &*probe.block_store);
+    assert_eq!(
+        kotoba_git::resolve_ref(&git_store.db(), "refs/heads/main").map(|o| o.to_hex()),
+        Some(head)
+    );
+
+    let _ = std::fs::remove_dir_all(&work);
+    std::env::remove_var("KOTOBA_AGENT_ED25519_HEX");
+    std::env::remove_var("KOTOBA_AGENT_X25519_HEX");
+    std::env::remove_var("KOTOBA_AGENT_DID");
+}

--- a/crates/kotoba-server/tests/git_delta_push.rs
+++ b/crates/kotoba-server/tests/git_delta_push.rs
@@ -1,0 +1,114 @@
+//! Delta-compressed push: exercise the packfile **delta ingest** path with a
+//! pack a *real* git produced.
+//!
+//! Two commits whose large blobs differ by one line — git's `pack-objects`
+//! deltifies the second blob against the first (OFS_DELTA), so the pushed pack
+//! is not all-full-objects. The server's streaming ingest must resolve those
+//! deltas and store byte-exact objects. We verify by (a) cloning back the exact
+//! content and (b) confirming both blob versions round-trip byte-exact from
+//! their IPFS blocks on the server.
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use kotoba_server::build_router;
+use kotoba_server::server::KotobaState;
+
+fn git(cwd: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn real_git_delta_compressed_push_ingests_correctly() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("skipping: git CLI not available");
+        return;
+    }
+    std::env::set_var("KOTOBA_DEFAULT_VISIBILITY", "public");
+    std::env::set_var("KOTOBA_GIT_ALLOW_ANON_PUSH", "1");
+
+    let state = Arc::new(KotobaState::new(None).expect("KotobaState::new"));
+    let probe = Arc::clone(&state);
+    let router = build_router(Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+    let url = format!("http://127.0.0.1:{}/git/delta", addr.port());
+
+    let work = std::env::temp_dir().join(format!(
+        "kotoba-git-delta-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let src = work.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    git(&src, &["init", "-q", "-b", "main", "."]);
+
+    // Six commits of a *growing* file: each version shares a long common prefix
+    // with the previous one (only new lines appended, identical line content),
+    // which `pack-objects` deltifies (copy whole base + append). Verified to
+    // produce delta chains with `git verify-pack`.
+    let versions: Vec<(String, String)> = (1..=6)
+        .map(|n| {
+            let content: String = (0..n * 1500).map(|i| format!("line {i}\n")).collect();
+            std::fs::write(src.join("big.txt"), &content).unwrap();
+            git(&src, &["add", "."]);
+            git(&src, &["commit", "-q", "-m", &format!("c{n}")]);
+            let blob = git(&src, &["rev-parse", "HEAD:big.txt"]);
+            (blob, content)
+        })
+        .collect();
+    let head = git(&src, &["rev-parse", "HEAD"]);
+    let latest = versions.last().unwrap().1.clone();
+
+    // Push all six commits at once → the pack send-pack builds carries deltas.
+    git(&src, &["push", "-q", &url, "main:refs/heads/main"]);
+
+    // Server side: EVERY blob version round-trips byte-exact. A mishandled delta
+    // would corrupt at least one version's bytes, so this is a real delta-ingest
+    // correctness check, not just "the tip is there".
+    {
+        let conn = probe.git_connection("delta").await;
+        let gs = kotoba_git::GitStore::new(&conn, &*probe.block_store);
+        let db = gs.db();
+        for (hex, want) in &versions {
+            let oid = kotoba_git::GitOid::from_hex(hex).unwrap();
+            let obj = gs.materialize_object(&db, oid).expect("blob present after delta ingest");
+            assert_eq!(&String::from_utf8_lossy(&obj.body), want, "blob {hex} byte-exact");
+            assert_eq!(obj.oid().to_hex(), *hex, "recomputed oid matches (fidelity)");
+        }
+        assert_eq!(
+            kotoba_git::resolve_ref(&db, "refs/heads/main").map(|o| o.to_hex()),
+            Some(head.clone())
+        );
+    }
+
+    // Clone back: the checked-out content equals the latest version.
+    git(&work, &["clone", "-q", &url, "clone"]);
+    assert_eq!(std::fs::read_to_string(work.join("clone").join("big.txt")).unwrap(), latest);
+
+    let _ = std::fs::remove_dir_all(&work);
+}

--- a/crates/kotoba-server/tests/git_durability.rs
+++ b/crates/kotoba-server/tests/git_durability.rs
@@ -1,0 +1,113 @@
+//! Durability: a pushed repo survives the loss of its in-memory projection.
+//!
+//! With a `KseStore` configured (`KOTOBA_STORE_PATH`), a push persists the
+//! repo's snapshot-manifest pointer durably and the manifest + object blocks
+//! live in the block store. We then **drop the resident `Connection`** (the
+//! datomic projection) — exactly what a process restart loses — and clone
+//! again. The clone forces `git_connection` to rehydrate the projection purely
+//! from the durable manifest, proving the repo is reconstructable from
+//! datomic-snapshot + IPFS blocks rather than living only in RAM.
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use kotoba_server::build_router;
+use kotoba_server::server::KotobaState;
+
+fn git(cwd: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .expect("spawn git");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pushed_repo_survives_projection_loss() {
+    if Command::new("git").arg("--version").output().is_err() {
+        eprintln!("skipping: git CLI not available");
+        return;
+    }
+
+    // The server roots its KseStore at parent(KOTOBA_STORE_PATH), so give the
+    // store path a *unique* parent dir to isolate this run's durable pointers.
+    let base = std::env::temp_dir().join(format!(
+        "kotoba-git-durable-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let store_path = base.join("store");
+    std::fs::create_dir_all(&store_path).unwrap();
+
+    // KseStore (mutable pointer boundary) → file-backed so the snapshot pointer
+    // is durable. Reads public, push anonymous.
+    std::env::set_var("KOTOBA_STORE_PATH", &store_path);
+    std::env::set_var("KOTOBA_DEFAULT_VISIBILITY", "public");
+    std::env::set_var("KOTOBA_GIT_ALLOW_ANON_PUSH", "1");
+
+    let state = Arc::new(KotobaState::new(None).expect("KotobaState::new"));
+    assert!(
+        state.kse_store.is_some(),
+        "KOTOBA_STORE_PATH should yield a KseStore (durable pointer boundary)"
+    );
+    let probe = Arc::clone(&state);
+    let router = build_router(Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+    let url = format!("http://127.0.0.1:{}/git/durable", addr.port());
+
+    let work = std::env::temp_dir().join(format!(
+        "kotoba-git-durable-work-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let src = work.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+
+    git(&src, &["init", "-q", "-b", "main", "."]);
+    std::fs::write(src.join("data.txt"), b"durable content\n").unwrap();
+    git(&src, &["add", "."]);
+    git(&src, &["commit", "-q", "-m", "c1"]);
+    let head = git(&src, &["rev-parse", "HEAD"]);
+    git(&src, &["push", "-q", &url, "main:refs/heads/main"]);
+
+    // ── Simulate a restart: discard the resident datomic projection. ──────────
+    {
+        let mut repos = probe.git_repos.write().await;
+        assert!(repos.contains_key("durable"), "repo should be resident after push");
+        repos.clear();
+    }
+
+    // Clone now: the server must rehydrate "durable" from the persisted manifest.
+    git(&work, &["clone", "-q", &url, "clone"]);
+    let got = std::fs::read_to_string(work.join("clone").join("data.txt")).unwrap();
+    assert_eq!(got, "durable content\n");
+    let cloned_head = git(&work.join("clone"), &["rev-parse", "HEAD"]);
+    assert_eq!(cloned_head, head, "rehydrated tip must equal the pushed tip");
+
+    let _ = std::fs::remove_dir_all(&work);
+    let _ = std::fs::remove_dir_all(&base);
+}

--- a/crates/kotoba-server/tests/git_http_behavior.rs
+++ b/crates/kotoba-server/tests/git_http_behavior.rs
@@ -1,0 +1,74 @@
+//! HTTP-surface behaviour of the git endpoints: protocol guard + auth gates.
+//!
+//! This binary deliberately sets **no** git env vars, so the node runs at its
+//! defaults — `KOTOBA_DEFAULT_VISIBILITY` unset ⇒ private reads, and anonymous
+//! push disabled. That lets us assert the gates actually reject unauthenticated
+//! access (the inverse of the happy-path clone/push tests, which opt into
+//! public reads + anon push).
+
+use std::sync::Arc;
+
+use kotoba_server::build_router;
+use kotoba_server::server::KotobaState;
+
+async fn boot() -> String {
+    let state = Arc::new(KotobaState::new(None).expect("KotobaState::new"));
+    let router = build_router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+    format!("http://127.0.0.1:{}", addr.port())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn protocol_guard_and_auth_gates() {
+    let base = boot().await;
+    let client = reqwest::Client::new();
+
+    // 1. info/refs without ?service= → only the smart protocol is supported.
+    let r = client
+        .get(format!("{base}/git/repo/info/refs"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(r.status().as_u16(), 403, "missing ?service= must be 403");
+
+    // 2. Private read (no auth) → denied (4xx, not a 200 advertisement).
+    let r = client
+        .get(format!("{base}/git/repo/info/refs?service=git-upload-pack"))
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        r.status().is_client_error(),
+        "private read without auth must be denied, got {}",
+        r.status()
+    );
+
+    // 3. Push discovery (no auth, anon push off) → denied.
+    let r = client
+        .get(format!("{base}/git/repo/info/refs?service=git-receive-pack"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status().as_u16(),
+        401,
+        "receive-pack discovery without operator auth must be 401"
+    );
+
+    // 4. receive-pack POST (no auth) → rejected at the gate, before body parse.
+    let r = client
+        .post(format!("{base}/git/repo/git-receive-pack"))
+        .body(Vec::<u8>::new())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        r.status().as_u16(),
+        401,
+        "unauthenticated push must be 401"
+    );
+}

--- a/crates/kotoba-server/tests/git_smart_http.rs
+++ b/crates/kotoba-server/tests/git_smart_http.rs
@@ -1,0 +1,132 @@
+//! End-to-end: a **real `git` client** clones, pushes and fetches against the
+//! kotoba server's git smart-HTTP endpoints, and every object is verified to
+//! have landed as an IPFS block + `:git/*` Datom projection (datomic).
+//!
+//! This is the integration proof for "git fully supported on kotoba datomic +
+//! IPFS": no GitHub, no on-disk git repo on the server side — the server stores
+//! objects as content-addressed blocks and serves the wire protocol from them.
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use kotoba_server::server::KotobaState;
+use kotoba_server::build_router;
+
+/// Run `git` in `cwd` with a hermetic environment (no user/system config, no
+/// credential prompt). Panics with captured stderr on failure.
+fn git(cwd: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .expect("failed to spawn git");
+    assert!(
+        out.status.success(),
+        "git {args:?} failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn git_available() -> bool {
+    Command::new("git").arg("--version").output().is_ok()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn real_git_clone_push_fetch_over_kotoba() {
+    if !git_available() {
+        eprintln!("skipping: git CLI not available");
+        return;
+    }
+
+    // Reads are public; push is anonymous (local-dev posture) so the real git
+    // client needs no credentials. These gates are exercised by the handlers.
+    std::env::set_var("KOTOBA_DEFAULT_VISIBILITY", "public");
+    std::env::set_var("KOTOBA_GIT_ALLOW_ANON_PUSH", "1");
+
+    // ── Boot the kotoba server (in-memory block store; no Kubo). ──────────────
+    let state = Arc::new(KotobaState::new(None).expect("KotobaState::new"));
+    let state_probe = Arc::clone(&state);
+    let router = build_router(Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, router).await.unwrap();
+    });
+    let repo_url = format!("http://127.0.0.1:{}/git/demo", addr.port());
+
+    // ── Scratch workspace. ────────────────────────────────────────────────────
+    let work = std::env::temp_dir().join(format!(
+        "kotoba-git-e2e-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    let src = work.join("src");
+    let clone = work.join("clone");
+    std::fs::create_dir_all(&src).unwrap();
+
+    // ── Build a source repo with one commit and push it to kotoba. ────────────
+    git(&src, &["init", "-q", "-b", "main", "."]);
+    std::fs::write(src.join("hello.txt"), b"hello kotoba\n").unwrap();
+    git(&src, &["add", "."]);
+    git(&src, &["commit", "-q", "-m", "first"]);
+    let head1 = git(&src, &["rev-parse", "HEAD"]);
+
+    git(&src, &["push", "-q", &repo_url, "main:refs/heads/main"]);
+
+    // The push must have materialised objects in datomic + IPFS. Probe directly.
+    {
+        let conn = state_probe.git_connection("demo").await;
+        let git_store = kotoba_git::GitStore::new(&conn, &*state_probe.block_store);
+        let db = git_store.db();
+        let objs = kotoba_git::all_objects(&db);
+        assert!(
+            objs.len() >= 3,
+            "expected >=3 objects (blob+tree+commit) projected as datoms, got {}",
+            objs.len()
+        );
+        // Every projected object round-trips byte-exact from its IPFS block.
+        for (oid, _cid) in &objs {
+            let framed = git_store.materialize_framed(&db, *oid).unwrap();
+            assert_eq!(kotoba_git::GitOid::of_framed(&framed), *oid);
+        }
+        // The pushed ref resolves to the client's HEAD.
+        assert_eq!(
+            kotoba_git::resolve_ref(&db, "refs/heads/main").map(|o| o.to_hex()),
+            Some(head1.clone())
+        );
+    }
+
+    // ── Clone it back with a fresh git and verify the content + tip. ──────────
+    git(&work, &["clone", "-q", &repo_url, "clone"]);
+    let cloned = std::fs::read_to_string(clone.join("hello.txt")).unwrap();
+    assert_eq!(cloned, "hello kotoba\n");
+    let cloned_head = git(&clone, &["rev-parse", "HEAD"]);
+    assert_eq!(cloned_head, head1, "cloned tip must equal pushed tip");
+
+    // ── Second commit on the source, push, then incremental fetch in clone. ───
+    std::fs::write(src.join("hello.txt"), b"hello kotoba v2\n").unwrap();
+    git(&src, &["add", "."]);
+    git(&src, &["commit", "-q", "-m", "second"]);
+    let head2 = git(&src, &["rev-parse", "HEAD"]);
+    git(&src, &["push", "-q", &repo_url, "main:refs/heads/main"]);
+
+    git(&clone, &["fetch", "-q", "origin"]);
+    let fetched_tip = git(&clone, &["rev-parse", "origin/main"]);
+    assert_eq!(fetched_tip, head2, "incremental fetch must deliver the new tip");
+
+    // ── Clean up scratch dir (best-effort). ──────────────────────────────────
+    let _ = std::fs::remove_dir_all(&work);
+}


### PR DESCRIPTION
## What

Opens the kotoba git ↔ datomic+IPFS bridge (ADR-2606015000) to the network: a real `git` client can **clone, fetch, and push** against kotoba with **no GitHub dependency**. Every object lands as a content-addressed IPFS block + `:git/*` Datom projection, and repos are **durable across restart**.

## kotoba-git — new `wire` module
- **pktline** — git pkt-line codec (data / flush `0000` / delim `0001`)
- **pack_encode** — pack v2 encoder (full objects + SHA-1 trailer) for clone/fetch
- **pack_ingest** — streaming pack parser: `OFS`/`REF` deltas, thin packs, out-of-order bases via fixpoint resolution, trailer + bounds checks
- **smart_http** — `advertise_refs` / `upload_pack` (wants/haves negotiation, reachable closure, side-band-64k) / `receive_pack` (ingest + ref update + report-status, HEAD default-branch adoption)
- **`GitStore::snapshot_manifest` / `rehydrate`** — durable projection snapshot (oid↔cid index + refs) as one content-addressed block; objects stay durable in IPFS, so a repo rebuilds from the manifest CID alone

## kotoba-server — git smart-HTTP endpoints
- `GET /git/:repo/info/refs`, `POST /git/:repo/git-{upload,receive}-pack` over a per-repo `Connection` (datomic projection) + shared `block_store` (IPFS)
- **Durable persistence** via `KseStore` manifest pointer, rehydrate on first access — **no journal/WAL** (consistent with the post-#57 architecture; CommitDag-style content-addressed durability)
- **AuthZ**: reads gated by node visibility; push by anon flag, operator Bearer JWT, or a **CACAO granting `git.receive/push`** (`graph_auth::verify_cacao_capability`)
- gzip request-body support

## Tests & coverage
- kotoba-git: **59 unit** tests + real-git fixtures
- kotoba-server: **5 integration suites** — clone/push/fetch, durability across projection loss, auth gates, CACAO-authorized push, and a real **delta-compressed** push (verified `OFS_DELTA × 5` in the received pack)
- Coverage (cargo-llvm-cov): kotoba-git **91% lines** (wire modules 85–99%), `git_http.rs` 82%

## Incidental fix
Excludes `kotoba-kotodama` (its own nested workspace) from the root Cargo workspace — it was listed as both a member and a workspace root, which broke `cargo` resolution repo-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)