### PR TITLE
feat(organism/kaizen): structured edits + issue-only + consume_all liveness + resident PR-agent

### DIFF
--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/__init__.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/__init__.py
@@ -130,6 +130,13 @@ class SuggestedAction:
     target_files: list[str] = field(default_factory=list)
     patch_hint: str = ""
     test_plan: list[str] = field(default_factory=list)
+    # Structured, machine-applicable edits (preferred over patch_hint string
+    # parsing). Each edit targets one file by an unambiguous selector:
+    #   env-set:        {"file", "var", "value"}  — set a k8s env var's value
+    #   literal-replace:{"file", "old", "new"}    — first-occurrence str replace
+    # The Kaizen PR agent applies these deterministically; patch_hint remains
+    # the human-readable summary and the fallback path.
+    patch_edits: list[dict[str, str]] = field(default_factory=list)
 
 
 @dataclass
@@ -174,6 +181,7 @@ class KaizenProposal:
                 "targetFiles": sa.target_files,
                 "patchHint": sa.patch_hint,
                 "testPlan": sa.test_plan,
+                "patchEdits": sa.patch_edits,
             }
         if self.pr_agent_hint is not None:
             out["prAgentHint"] = {
@@ -293,6 +301,15 @@ class SweepLatencyP95Rule:
                             if shard.warm_capacity > 0
                             else "env UNISPSC_ORGANISM_LRU_MAX → next power-of-two up; verify against limits.memory."
                         ),
+                        patch_edits=(
+                            [{
+                                "file": f"50-infra/k8s/unispsc-organism-fleet/shard-{shard.shard}/daemonset.yaml",
+                                "var": "UNISPSC_ORGANISM_LRU_MAX",
+                                "value": str(_next_pow2_up(shard.warm_capacity)),
+                            }]
+                            if shard.warm_capacity > 0
+                            else []
+                        ),
                         test_plan=[
                             "kubectl apply -k 50-infra/k8s/unispsc-organism-fleet/",
                             "wait 30 min and probe /healthz: tickDurationMsP95 ≤ 1000",
@@ -353,6 +370,11 @@ class LruSaturationRule:
                         patch_hint=_lru_patch_hint(
                             shard.warm_capacity, _pow2_at_least(shard.owned_count)
                         ),
+                        patch_edits=[{
+                            "file": f"50-infra/k8s/unispsc-organism-fleet/shard-{shard.shard}/daemonset.yaml",
+                            "var": "UNISPSC_ORGANISM_LRU_MAX",
+                            "value": str(_pow2_at_least(shard.owned_count)),
+                        }],
                         test_plan=[
                             "Apply and observe warmCount == ownedCount after warmup",
                             "Memory headroom: kubectl top pod inside limits",

--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/pr_agent.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/pr_agent.py
@@ -1,6 +1,7 @@
 
 import json
 import logging
+import re
 import subprocess
 import time
 from pathlib import Path
@@ -59,6 +60,13 @@ class KaizenPrAgent:
         target_files_str = suggested_action.get("targetFiles", [])
         patch_hint = suggested_action.get("patchHint", "")
 
+        # Prefer structured, machine-applicable edits when present — they target
+        # a file + selector unambiguously (no first-occurrence guessing, no hint
+        # string parsing). Falls through to patch_hint only when absent.
+        patch_edits = suggested_action.get("patchEdits") or []
+        if patch_edits:
+            return self._apply_structured_edits(patch_edits)
+
         if not target_files_str or not patch_hint:
             logging.warning("No target files or patch hint found in proposal. Skipping patch.")
             return []
@@ -98,6 +106,55 @@ class KaizenPrAgent:
             target_path.write_text(new_content)
             modified_paths.append(target_path)
 
+        return modified_paths
+
+    def _apply_structured_edits(self, edits: List[Dict[str, str]]) -> List[Path]:
+        """Apply structured, machine-applicable edits (preferred path).
+
+        Each edit targets one file by an unambiguous selector:
+          - env-set ``{"file", "var", "value"}`` — set a k8s env var's value via
+            a named-var regex (no first-occurrence guessing across the file).
+          - literal ``{"file", "old", "new"}`` — first-occurrence str replace.
+        """
+        modified_paths: List[Path] = []
+        for edit in edits:
+            file_str = edit.get("file")
+            if not file_str:
+                logging.warning("Structured edit missing 'file'; skipping: %s", edit)
+                continue
+            target_path = self.repo_root / file_str
+            if not target_path.is_file():
+                logging.error(f"Target file {target_path} does not exist.")
+                continue
+            content = target_path.read_text()
+
+            if "var" in edit and "value" in edit:
+                var, value = edit["var"], edit["value"]
+                # Match `name: <VAR>` then the following `value: ...` line and
+                # replace only that var's value, preserving quote style.
+                pattern = re.compile(
+                    r'(name:\s*["\']?' + re.escape(var) + r'["\']?\s*\n\s*value:\s*)'
+                    r'(["\']?)[^"\'\n]*(["\']?)'
+                )
+                new_content, n = pattern.subn(rf'\g<1>\g<2>{value}\g<3>', content, count=1)
+                if n == 0:
+                    logging.warning(
+                        "env var %s not found in %s; skipping edit.", var, target_path
+                    )
+                    continue
+            elif "old" in edit and "new" in edit:
+                old, new = edit["old"], edit["new"]
+                if old not in content:
+                    logging.warning("literal '%s' not found in %s; skipping.", old, target_path)
+                    continue
+                new_content = content.replace(old, new, 1)
+            else:
+                logging.warning("Unrecognized structured edit shape; skipping: %s", edit)
+                continue
+
+            logging.info("Applied structured edit to %s", target_path)
+            target_path.write_text(new_content)
+            modified_paths.append(target_path)
         return modified_paths
 
     def consume_one(self) -> Optional[str]:

--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/pr_agent.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/pr_agent.py
@@ -157,6 +157,25 @@ class KaizenPrAgent:
             modified_paths.append(target_path)
         return modified_paths
 
+    def _open_issue(self, proposal: Dict[str, Any], proposal_ndjson: str) -> str:
+        """Open an advisory GitHub issue for an issue-only proposal.
+
+        No branch/patch — the proposal is informational (error-rate,
+        fleet-unreachable, …). Returns the issue URL, or a dry-run message.
+        """
+        title = proposal.get("summary", "Kaizen Observation")
+        body = kaizen_proposal_to_pr_draft(proposal_ndjson) + HUMAN_IN_LOOP_BOILERPLATE
+        labels = (proposal.get("prAgentHint") or {}).get("labels", [])
+        if self.dry_run:
+            logging.info("[dry-run] would open issue: %s", title)
+            return "Dry run successful (issue)."
+        cmd = ["gh", "issue", "create", "--title", title, "--body", body]
+        for lb in labels:
+            cmd += ["--label", lb]
+        result = subprocess.run(cmd, check=True, cwd=self.repo_root, capture_output=True, text=True)
+        out = result.stdout.strip()
+        return out.splitlines()[-1] if out else "issue created"
+
     def consume_one(self) -> Optional[str]:
         """
         Consumes a single proposal from the queue.
@@ -177,6 +196,19 @@ class KaizenPrAgent:
             # Move malformed line to a quarantine file or just drop i
             self.proposal_queue_path.write_text("\n".join(remaining_lines) + "\n")
             return None
+
+        # issue-only proposals carry no code change (e.g. error-rate,
+        # fleet-unreachable). Open an advisory GitHub issue — no branch, no
+        # patch — and drain the proposal, instead of attempting a patch that
+        # finds nothing to change and leaves the proposal stuck in the queue.
+        kind = (proposal.get("suggestedAction") or {}).get("kind", "")
+        if kind == "issue-only":
+            url = self._open_issue(proposal, proposal_ndjson)
+            self.proposal_queue_path.write_text(
+                "\n".join(remaining_lines) + "\n" if remaining_lines else ""
+            )
+            logging.info("issue-only proposal consumed → %s", url)
+            return url
 
         # 1. Generate Branch Name
         pr_hint = proposal.get("prAgentHint", {})

--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/pr_agent.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/pr_agent.py
@@ -276,17 +276,53 @@ class KaizenPrAgent:
             # Do not remove the proposal from the queue, so it can be retried
             raise
 
+    def _quarantine(self, proposal_ndjson: str) -> Path:
+        """Append a stuck proposal to a sibling needs-human queue.
+
+        Non-destructive: the proposal is preserved for human triage / retry,
+        but removed from the live queue so it stops blocking the rest.
+        """
+        qpath = self.proposal_queue_path.parent / (
+            self.proposal_queue_path.stem + ".needs-human.ndjson"
+        )
+        with open(qpath, "a", encoding="utf-8") as f:
+            f.write(proposal_ndjson + "\n")
+        logging.warning("Quarantined stuck proposal → %s", qpath)
+        return qpath
+
     def consume_all(self) -> List[str]:
         """
-        Consumes all proposals in the queue until it's empty.
-        Returns a list of created PR URLs.
+        Drain the queue, returning the created PR/issue URLs.
+
+        Robust to a proposal that cannot be applied: if consume_one returns
+        None while leaving the head in place (a stuck config/code-change patch),
+        the head is quarantined to ``<stem>.needs-human.ndjson`` so the loop
+        keeps making progress instead of blocking on it forever.
         """
         urls = []
         while True:
-            url = self.consume_one()
-            if url is None:
+            if not self.proposal_queue_path.exists():
                 break
-            urls.append(url)
+            lines = self.proposal_queue_path.read_text().splitlines()
+            if not lines:
+                break
+            head_before = lines[0]
+            url = self.consume_one()
+            if url is not None:
+                urls.append(url)
+                continue
+            # None: either the head was drained (handled next loop) or it is
+            # stuck. If the head is unchanged, quarantine it and move on.
+            lines_after = (
+                self.proposal_queue_path.read_text().splitlines()
+                if self.proposal_queue_path.exists()
+                else []
+            )
+            if lines_after and lines_after[0] == head_before:
+                self._quarantine(head_before)
+                self.proposal_queue_path.write_text(
+                    "\n".join(lines_after[1:]) + "\n" if lines_after[1:] else ""
+                )
         logging.info(f"Consumed {len(urls)} proposals.")
         return urls
 

--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen_pr_agent_main.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen_pr_agent_main.py
@@ -1,0 +1,114 @@
+"""kaizen_pr_agent_main — resident entry for the Kaizen PR-agent actuator.
+
+The counterpart to ``kaizen_cell_main`` (the observer). The observer writes
+KaizenProposal NDJSON lines to a shared queue; this resident process drains
+that queue, applies structured patches, and opens GitHub PRs / issues —
+closing the self-evolution loop.
+
+Deployment (per ADR-2605240200 Wave 4): runs on the Murakumo Mac mini fleet as
+a resident Deployment (sibling of the ``kaizen-observer`` Deployment on levi),
+reading the SAME ``/var/lib/etzhayyim/kaizen-proposals/observer.ndjson`` volume
+the observer writes.
+
+Configuration via env vars:
+  - ``KAIZEN_PROPOSAL_PATH``        proposal queue NDJSON (default matches the
+                                    observer's output path).
+  - ``KAIZEN_PR_AGENT_REPO_ROOT``   checkout the PR agent operates on (the
+                                    etzhayyim/root working tree).
+  - ``KAIZEN_PR_AGENT_INTERVAL_S``  poll cadence when running standalone
+                                    (default 600 = 10 min).
+  - ``KAIZEN_PR_AGENT_DRY_RUN``     "true" (default, safe) → patches applied to
+                                    the local checkout + ``gh ... --dry-run``;
+                                    "false" → actually opens PRs/issues.
+  - ``KAIZEN_PR_AGENT_LOG_LEVEL``   stdlib level name (default "INFO").
+
+no-server-key note (ADR-2605231525): opening real PRs requires GitHub write
+auth. This process is operator-credentialed (a short-lived token injected at
+runtime), NOT a platform-held master key, and the default is dry-run so a pod
+that starts without a token drains-and-patches locally without pushing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from kotodama.organism.kaizen.pr_agent import KaizenPrAgent, KaizenPrAgentAuthError
+
+logger = logging.getLogger("kotodama.organism.kaizen_pr_agent")
+
+
+def _default_proposal_path() -> Path:
+    explicit = os.environ.get("KAIZEN_PROPOSAL_PATH")
+    if explicit:
+        return Path(explicit)
+    base = os.environ.get("KAIZEN_PROPOSAL_BASE", "/var/lib/etzhayyim/kaizen-proposals")
+    return Path(base) / "observer.ndjson"
+
+
+def _repo_root() -> Path:
+    return Path(os.environ.get("KAIZEN_PR_AGENT_REPO_ROOT", os.getcwd()))
+
+
+def _dry_run() -> bool:
+    return os.environ.get("KAIZEN_PR_AGENT_DRY_RUN", "true").lower() not in ("0", "false", "no")
+
+
+async def fire() -> dict[str, Any]:
+    """One drain pass over the proposal queue. Returns a status dict.
+
+    Constructs the agent per cycle so a missing/expired GitHub credential is a
+    skipped cycle (logged), not a crashed daemon — the resident loop survives
+    until auth is configured.
+    """
+    proposal_path = _default_proposal_path()
+    repo_root = _repo_root()
+    dry_run = _dry_run()
+
+    loop = asyncio.get_running_loop()
+
+    def _drain() -> dict[str, Any]:
+        try:
+            agent = KaizenPrAgent(proposal_path, repo_root, dry_run=dry_run)
+        except KaizenPrAgentAuthError as exc:
+            logger.warning("PR agent auth not ready — skipping cycle: %s", exc)
+            return {"ok": False, "reason": "auth", "consumed": 0, "urls": []}
+        if not proposal_path.exists() or proposal_path.stat().st_size == 0:
+            return {"ok": True, "consumed": 0, "urls": [], "dryRun": dry_run}
+        urls = agent.consume_all()
+        return {"ok": True, "consumed": len(urls), "urls": urls, "dryRun": dry_run}
+
+    status = await loop.run_in_executor(None, _drain)
+    logger.info(
+        "pr-agent drain: consumed=%d dryRun=%s proposalPath=%s",
+        status.get("consumed", 0), dry_run, proposal_path,
+    )
+    return status
+
+
+async def serve_loop() -> None:
+    """Resident loop. k8s Deployment entrypoint on the Mac mini fleet."""
+    interval_s = int(os.environ.get("KAIZEN_PR_AGENT_INTERVAL_S", "600"))
+    logger.info(
+        "kaizen-pr-agent resident loop start: interval=%ds repo_root=%s dry_run=%s",
+        interval_s, _repo_root(), _dry_run(),
+    )
+    while True:
+        try:
+            await fire()
+        except Exception as exc:  # noqa: BLE001 — resident loop must survive a bad cycle
+            logger.exception("pr-agent cycle failed (continuing): %s", exc)
+        await asyncio.sleep(interval_s)
+
+
+__all__ = ["fire", "serve_loop"]
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=getattr(logging, os.environ.get("KAIZEN_PR_AGENT_LOG_LEVEL", "INFO").upper(), logging.INFO)
+    )
+    asyncio.run(serve_loop())

--- a/crates/kotoba-kotodama/py/tests/organism/test_kaizen_autonomous_loop.py
+++ b/crates/kotoba-kotodama/py/tests/organism/test_kaizen_autonomous_loop.py
@@ -92,3 +92,45 @@ def test_observer_proposal_flows_to_pr_agent_patch(tmp_path: Path):
     assert 'value: "4096"' not in tgt.read_text()
     # Queue drained.
     assert queue.read_text().strip() == ""
+
+
+def test_structured_edit_targets_named_var_not_first_occurrence(tmp_path: Path):
+    """The structured env-set edit bumps LRU_MAX even when another env var
+    shares the same value — proving it targets the named var, not the first
+    `value: "4096"` occurrence in the file."""
+    obs = Observation(
+        ts=1_700_000_000_000,
+        shards=[ShardHealthz(shard=2, reachable=True, owned_count=8541,
+                             warm_count=4096, warm_capacity=4096,
+                             last_tick_duration_ms=8200.0)],
+        history={2: [8200.0] * 8},
+    )
+    observer = KaizenObserver(shard_urls=[], queue_paths=[], proposal_path=Path("/dev/null"))
+    sweep = {p.rule_id: p for p in observer.run_rules(obs)}["sweep-latency-p95"]
+    assert sweep.suggested_action.patch_edits  # structured edit present
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    tgt = repo / "50-infra/k8s/unispsc-organism-fleet/shard-2/daemonset.yaml"
+    tgt.parent.mkdir(parents=True)
+    # TWO env vars share value "4096"; only LRU_MAX must change.
+    tgt.write_text(
+        "        - name: UNISPSC_ORGANISM_TICK_BUDGET\n"
+        '          value: "4096"\n'
+        "        - name: UNISPSC_ORGANISM_LRU_MAX\n"
+        '          value: "4096"\n'
+    )
+    queue = tmp_path / "observer.ndjson"
+    queue.write_text(json.dumps(sweep.to_ndjson_dict(ts_ms=obs.ts)) + "\n")
+
+    with patch("subprocess.check_output", return_value="main\n"), \
+         patch("subprocess.run", return_value=MagicMock(
+             check_returncode=lambda: None, stdout="Dry run successful.")):
+        agent = KaizenPrAgent(queue, repo, dry_run=True)
+        result = agent.consume_one()
+
+    assert result == "Dry run successful."
+    out = tgt.read_text()
+    # LRU_MAX bumped to 8192; the unrelated TICK_BUDGET value untouched.
+    assert 'name: UNISPSC_ORGANISM_LRU_MAX\n          value: "8192"' in out
+    assert 'name: UNISPSC_ORGANISM_TICK_BUDGET\n          value: "4096"' in out

--- a/crates/kotoba-kotodama/py/tests/organism/test_kaizen_autonomous_loop.py
+++ b/crates/kotoba-kotodama/py/tests/organism/test_kaizen_autonomous_loop.py
@@ -167,3 +167,61 @@ def test_issue_only_proposal_opens_issue_and_drains(tmp_path: Path):
     assert queue.read_text().strip() == ""  # drained, not stuck
     # No git branch was created for an issue-only proposal.
     assert not any("checkout" in a for a in calls if isinstance(a, list))
+
+
+def test_consume_all_quarantines_stuck_proposal_and_drains_rest(tmp_path: Path):
+    """A non-applicable proposal at the queue head must not block the rest:
+    consume_all quarantines it to <stem>.needs-human.ndjson and keeps going."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    tgt = repo / "50-infra/k8s/unispsc-organism-fleet/shard-1/daemonset.yaml"
+    tgt.parent.mkdir(parents=True)
+    tgt.write_text('        - name: UNISPSC_ORGANISM_LRU_MAX\n          value: "4096"\n')
+
+    def _mk(rule, kind, edits, summary):
+        return {
+            "v": 1, "ts": 1, "kind": "kaizen-proposal", "ruleId": rule,
+            "category": "performance", "severity": "warn", "actorScope": "shard:1",
+            "summary": summary, "detail": "...",
+            "suggestedAction": {"kind": kind, "description": "d",
+                                "targetFiles": [e["file"] for e in edits],
+                                "patchHint": "", "testPlan": [], "patchEdits": edits},
+            "prAgentHint": {"branchPrefix": "kaizen/x-", "labels": ["kaizen"]},
+        }
+
+    applicable = _mk("sweep-latency-p95", "config-change",
+                     [{"file": "50-infra/k8s/unispsc-organism-fleet/shard-1/daemonset.yaml",
+                       "var": "UNISPSC_ORGANISM_LRU_MAX", "value": "8192"}],
+                     "applicable bump")
+    stuck = _mk("lru-saturation", "config-change",
+                [{"file": "50-infra/k8s/unispsc-organism-fleet/shard-99/daemonset.yaml",
+                  "var": "UNISPSC_ORGANISM_LRU_MAX", "value": "16384"}],
+                "stuck: file missing")
+    issue = {
+        "v": 1, "ts": 1, "kind": "kaizen-proposal", "ruleId": "error-rate",
+        "category": "reliability", "severity": "warn", "actorScope": "shard:1",
+        "summary": "error-rate issue", "detail": "...",
+        "suggestedAction": {"kind": "issue-only", "description": "d",
+                            "targetFiles": [], "patchHint": "", "testPlan": []},
+        "prAgentHint": {"branchPrefix": "kaizen/e-", "labels": ["kaizen"]},
+    }
+
+    queue = tmp_path / "observer.ndjson"
+    queue.write_text("\n".join(json.dumps(p) for p in [applicable, stuck, issue]) + "\n")
+
+    with patch("subprocess.check_output", return_value="main\n"), \
+         patch("subprocess.run", return_value=MagicMock(
+             check_returncode=lambda: None, stdout="Dry run successful.")):
+        agent = KaizenPrAgent(queue, repo, dry_run=True)
+        urls = agent.consume_all()
+
+    # applicable (PR) + issue-only (issue) both produced a result; stuck did not.
+    assert len(urls) == 2
+    # Queue fully drained, no infinite loop / blockage.
+    assert queue.read_text().strip() == ""
+    # The stuck proposal was preserved for human triage.
+    needs_human = tmp_path / "observer.needs-human.ndjson"
+    assert needs_human.is_file()
+    assert "stuck: file missing" in needs_human.read_text()
+    # Applicable patch really applied.
+    assert 'value: "8192"' in tgt.read_text()

--- a/crates/kotoba-kotodama/py/tests/organism/test_kaizen_autonomous_loop.py
+++ b/crates/kotoba-kotodama/py/tests/organism/test_kaizen_autonomous_loop.py
@@ -225,3 +225,44 @@ def test_consume_all_quarantines_stuck_proposal_and_drains_rest(tmp_path: Path):
     assert "stuck: file missing" in needs_human.read_text()
     # Applicable patch really applied.
     assert 'value: "8192"' in tgt.read_text()
+
+
+def test_observer_tick_probe_to_emit_pipeline(tmp_path: Path):
+    """Observer half end-to-end through the real probe(): an injected http_get
+    returns synthetic /healthz, and observer.tick() runs probe → run_rules →
+    dedup → emit, writing real proposals to the NDJSON proposal file."""
+    healthz = {
+        "shard": 1, "ownedCount": 8541, "warmCount": 4096, "warmCapacity": 4096,
+        "tickCount": 100, "lastTickDurationMs": 8200.0,
+        "totalPosts": 12, "totalClassifications": 12, "totalErrors": 0, "uptimeS": 3600,
+    }
+
+    def fake_http_get(url: str, timeout_s: float) -> dict:
+        return dict(healthz)
+
+    proposal_path = tmp_path / "observer-proposals.ndjson"
+    observer = KaizenObserver(
+        shard_urls=["http://localhost:13050"],
+        queue_paths=[],
+        proposal_path=proposal_path,
+        http_get=fake_http_get,
+    )
+
+    base = 1_700_000_000_000
+    # Tick 1: lru-saturation fires immediately (warm==capacity, owned>capacity).
+    s1 = observer.tick(now_ms=base)
+    assert s1["reachable"] == 1
+    assert s1["proposalsWritten"] >= 1
+
+    # Accumulate history; by tick 6 sweep-latency-p95 has >= 6 samples and fires.
+    for i in range(1, 7):
+        observer.tick(now_ms=base + i * 600_000)  # 10-min cadence
+
+    written = [json.loads(line) for line in proposal_path.read_text().splitlines() if line.strip()]
+    rule_ids = {p["ruleId"] for p in written}
+    assert "lru-saturation" in rule_ids
+    assert "sweep-latency-p95" in rule_ids
+    # Every emitted record is a well-formed proposal with an actor scope.
+    for p in written:
+        assert p["kind"] == "kaizen-proposal"
+        assert p["actorScope"].startswith("shard:")

--- a/crates/kotoba-kotodama/py/tests/organism/test_kaizen_autonomous_loop.py
+++ b/crates/kotoba-kotodama/py/tests/organism/test_kaizen_autonomous_loop.py
@@ -134,3 +134,36 @@ def test_structured_edit_targets_named_var_not_first_occurrence(tmp_path: Path):
     # LRU_MAX bumped to 8192; the unrelated TICK_BUDGET value untouched.
     assert 'name: UNISPSC_ORGANISM_LRU_MAX\n          value: "8192"' in out
     assert 'name: UNISPSC_ORGANISM_TICK_BUDGET\n          value: "4096"' in out
+
+
+def test_issue_only_proposal_opens_issue_and_drains(tmp_path: Path):
+    """An issue-only proposal (no code change) opens an advisory issue and is
+    drained from the queue — it must NOT create a branch, attempt a patch, or
+    stall the queue."""
+    proposal = {
+        "v": 1, "ts": 1, "kind": "kaizen-proposal", "ruleId": "error-rate",
+        "category": "reliability", "severity": "warn", "actorScope": "shard:1",
+        "summary": "shard-1 error rate 3% > 1% budget",
+        "detail": "Sustained error rate above the 1% budget.",
+        "suggestedAction": {"kind": "issue-only", "description": "Investigate shard-1 errors",
+                            "targetFiles": [], "patchHint": "", "testPlan": []},
+        "prAgentHint": {"branchPrefix": "kaizen/error-", "labels": ["kaizen", "reliability"]},
+    }
+    queue = tmp_path / "q.ndjson"
+    queue.write_text(json.dumps(proposal) + "\n")
+
+    calls = []
+
+    def _record(args, **kwargs):
+        calls.append(args)
+        return MagicMock(check_returncode=lambda: None, stdout="", stderr="")
+
+    with patch("subprocess.check_output", return_value="main\n"), \
+         patch("subprocess.run", side_effect=_record):
+        agent = KaizenPrAgent(queue, tmp_path, dry_run=True)
+        result = agent.consume_one()
+
+    assert result == "Dry run successful (issue)."
+    assert queue.read_text().strip() == ""  # drained, not stuck
+    # No git branch was created for an issue-only proposal.
+    assert not any("checkout" in a for a in calls if isinstance(a, list))

--- a/crates/kotoba-kotodama/py/tests/organism/test_kaizen_pr_agent_main.py
+++ b/crates/kotoba-kotodama/py/tests/organism/test_kaizen_pr_agent_main.py
@@ -1,0 +1,67 @@
+"""Resident PR-agent entry point (kaizen_pr_agent_main) — the actuator daemon
+counterpart to the observer's kaizen_cell_main."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import kotodama.organism.kaizen_pr_agent_main as prmain
+from kotodama.organism.kaizen.pr_agent import KaizenPrAgentAuthError
+
+
+def _set_env(monkeypatch, queue: Path, repo: Path, dry_run: str = "true"):
+    monkeypatch.setenv("KAIZEN_PROPOSAL_PATH", str(queue))
+    monkeypatch.setenv("KAIZEN_PR_AGENT_REPO_ROOT", str(repo))
+    monkeypatch.setenv("KAIZEN_PR_AGENT_DRY_RUN", dry_run)
+
+
+@pytest.mark.asyncio
+async def test_fire_empty_queue_consumes_nothing(tmp_path, monkeypatch):
+    queue = tmp_path / "observer.ndjson"
+    queue.write_text("")
+    _set_env(monkeypatch, queue, tmp_path)
+    with patch("subprocess.run", return_value=MagicMock(check_returncode=lambda: None, stderr="")):
+        status = await prmain.fire()
+    assert status["ok"] is True
+    assert status["consumed"] == 0
+
+
+@pytest.mark.asyncio
+async def test_fire_drains_issue_only_proposal(tmp_path, monkeypatch):
+    proposal = {
+        "v": 1, "ts": 1, "kind": "kaizen-proposal", "ruleId": "error-rate",
+        "category": "reliability", "severity": "warn", "actorScope": "shard:1",
+        "summary": "error-rate issue", "detail": "...",
+        "suggestedAction": {"kind": "issue-only", "description": "d",
+                            "targetFiles": [], "patchHint": "", "testPlan": []},
+        "prAgentHint": {"branchPrefix": "kaizen/e-", "labels": ["kaizen"]},
+    }
+    queue = tmp_path / "observer.ndjson"
+    queue.write_text(json.dumps(proposal) + "\n")
+    _set_env(monkeypatch, queue, tmp_path, dry_run="true")
+    with patch("subprocess.check_output", return_value="main\n"), \
+         patch("subprocess.run", return_value=MagicMock(
+             check_returncode=lambda: None, stdout="", stderr="")):
+        status = await prmain.fire()
+    assert status["ok"] is True
+    assert status["consumed"] == 1
+    assert status["dryRun"] is True
+    assert queue.read_text().strip() == ""  # drained
+
+
+@pytest.mark.asyncio
+async def test_fire_skips_cycle_when_auth_not_ready(tmp_path, monkeypatch):
+    queue = tmp_path / "observer.ndjson"
+    queue.write_text("{}\n")
+    _set_env(monkeypatch, queue, tmp_path)
+    with patch.object(prmain.KaizenPrAgent, "_verify_gh_auth",
+                      side_effect=KaizenPrAgentAuthError("gh not authed")):
+        status = await prmain.fire()
+    assert status["ok"] is False
+    assert status["reason"] == "auth"
+    # Queue untouched — the daemon retries next cycle.
+    assert queue.read_text().strip() == "{}"


### PR DESCRIPTION
Follow-up to #64 (which squash-merged the earlier commits). These 5 commits were
pushed to the branch after #64 merged, so they are not yet on main:

1. **structured machine-applicable patch edits** — SuggestedAction.patch_edits
   (env-set via named-var regex) so the PR agent targets the right env var, not
   the first `value:` occurrence; preferred over patch_hint string parsing.
2. **issue-only routing** — issue-only proposals (error-rate, fleet-unreachable)
   open an advisory `gh issue` + drain, instead of aborting and stalling the queue.
3. **consume_all quarantine** — a stuck (non-applicable) proposal is quarantined
   to `<stem>.needs-human.ndjson` so the batch keeps draining; per-proposal retry
   contract unchanged.
4. **observer probe→emit integration test** — exercises the real probe() path
   (injected http_get) through run_rules → dedup → emit.
5. **resident PR-agent entry point** — kaizen_pr_agent_main (fire + serve_loop),
   the actuator daemon the new kaizen-pr-agent Deployment (etzhayyim/root#1466,
   merged) invokes on the Mac mini fleet.

Organism-scope suite 307 passed / 2 skipped. Closes the self-evolution loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)