### PR TITLE
build(kotodama image): install git + gh for the kaizen-pr-agent actuator

### DIFF
--- a/crates/kotoba-kotodama/py/Dockerfile
+++ b/crates/kotoba-kotodama/py/Dockerfile
@@ -16,11 +16,12 @@ ENV PYTHONUNBUFFERED=1 PYTHONDONTWRITEBYTECODE=1
 ENV ETZ_REPO=/repo
 ARG WASMTIME_VERSION=44.0.0
 ARG FOUNDRY_VERSION=1.5.0
+ARG GH_VERSION=2.63.2
 ARG TARGETARCH
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends bash postgresql-client ca-certificates poppler-utils tesseract-ocr tesseract-ocr-jpn \
+ && apt-get install -y --no-install-recommends bash git postgresql-client ca-certificates poppler-utils tesseract-ocr tesseract-ocr-jpn \
  && rm -rf /var/lib/apt/lists/*
 
 ARG CACHE_BUST=1
@@ -38,6 +39,8 @@ RUN apt-get update \
     | tar -xJ --strip-components=1 -C /usr/local/bin "wasmtime-v${WASMTIME_VERSION}-${wasmtime_arch}/wasmtime" \
  && curl -fsSL "https://github.com/foundry-rs/foundry/releases/download/v${FOUNDRY_VERSION}/foundry_v${FOUNDRY_VERSION}_linux_${foundry_arch}.tar.gz" \
     | tar -xz -C /usr/local/bin cast \
+ && curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_${foundry_arch}.tar.gz" \
+    | tar -xz --strip-components=2 -C /usr/local/bin "gh_${GH_VERSION}_linux_${foundry_arch}/bin/gh" \
  && apt-get purge -y --auto-remove curl xz-utils \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The kaizen-pr-agent self-evolution actuator (`kotoba.organism.kaizen_pr_agent_main`) shells out to **git** (clone/branch/add) and **gh** (pr/issue create), but the kotodama image shipped neither — so the actuator would `_verify_gh_auth`/clone-fail even with a GH_TOKEN.

Confirmed while bringing up the fleet k3s on 2026-06-08: the `etzhayyim-organism` namespace is empty and the image lacks git/gh.

- **git**: added to base apt install.
- **gh v2.63.2**: cli/cli release tarball (same curl+tar pattern as wasmtime/foundry), arch-matched amd64/arm64 → /usr/local/bin; asset names verified.

Unblocks the Wave-4 actuator (etzhayyim/root kaizen-pr-agent Deployment #1466/#1467) once the image is rebuilt + pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)