### PR TITLE
fix(organism/kaizen): pr-agent must commit + push before gh pr create

### DIFF
--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/pr_agent.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/pr_agent.py
@@ -236,26 +236,39 @@ class KaizenPrAgent:
                 logging.info(f"Staging file: {relative_path}")
                 subprocess.run(["git", "add", str(relative_path)], check=True, cwd=self.repo_root)
 
-            # 5. Create PR
             pr_title = proposal.get("summary", "Kaizen Proposal")
             pr_body = kaizen_proposal_to_pr_draft(proposal_ndjson)
             pr_body += HUMAN_IN_LOOP_BOILERPLATE
-
             labels = pr_hint.get("labels", [])
 
-            gh_command = ["gh", "pr", "create", "--title", pr_title, "--body", pr_body]
-            for label in labels:
-                gh_command.extend(["--label", label])
+            # 5. Commit the staged change. `gh pr create` requires commits on the
+            # branch (staged-but-uncommitted changes are not PR-able), so a commit
+            # is mandatory on both the dry-run and real paths.
+            subprocess.run(
+                ["git", "commit", "-m", pr_title], check=True, cwd=self.repo_root, capture_output=True
+            )
 
+            # 6. Open the PR.
             if self.dry_run:
-                gh_command.append("--dry-run")
-                logging.info("Executing dry-run of 'gh pr create'.")
+                # Validate locally only — patch applied + committed on the branch.
+                # No push, no `gh pr create` (which would require a remote branch),
+                # so a dry run has zero remote side effects.
+                logging.info("Dry-run: patched + committed on %s (no push/PR).", branch_name)
+                pr_url = "Dry run successful."
             else:
-                logging.info("Creating GitHub PR.")
-
-            result = subprocess.run(gh_command, check=True, cwd=self.repo_root, capture_output=True, text=True)
-
-            pr_url = result.stdout.strip().splitlines()[-1] if not self.dry_run else "Dry run successful."
+                # Push the branch first — `gh pr create` opens the PR from the
+                # pushed head (non-interactive contexts require the branch on the
+                # remote; `--head` makes the head explicit).
+                logging.info("Pushing %s and creating GitHub PR.", branch_name)
+                subprocess.run(
+                    ["git", "push", "-u", "origin", branch_name],
+                    check=True, cwd=self.repo_root, capture_output=True,
+                )
+                gh_command = ["gh", "pr", "create", "--head", branch_name, "--title", pr_title, "--body", pr_body]
+                for label in labels:
+                    gh_command.extend(["--label", label])
+                result = subprocess.run(gh_command, check=True, cwd=self.repo_root, capture_output=True, text=True)
+                pr_url = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else "PR created"
             logging.info(f"PR result: {pr_url}")
 
             # 6. Update queue file

--- a/crates/kotoba-kotodama/py/tests/organism/test_kaizen_pr_agent.py
+++ b/crates/kotoba-kotodama/py/tests/organism/test_kaizen_pr_agent.py
@@ -128,10 +128,11 @@ def test_consume_one_dry_run(mock_run, mock_check_output, repo_root, proposal_qu
     assert mock_check_output.call_count == 1
 
     calls = mock_run.call_args_list
+    # Dry-run flow (no push, no `gh pr create` — local validation only):
     # 1. gh auth status (in __init__)
     # 2. git checkout -b <branch>
     # 3. git add src/main.py
-    # 4. gh pr create ... --dry-run
+    # 4. git commit -m <title>
     # 5. git checkout main
     assert len(calls) == 5
 
@@ -139,17 +140,13 @@ def test_consume_one_dry_run(mock_run, mock_check_output, repo_root, proposal_qu
     assert call(["git", "checkout", "-b", mock_run.call_args_list[1].args[0][3]], check=True, cwd=repo_root, capture_output=True) in calls
     # Check git add
     assert call(["git", "add", "src/main.py"], check=True, cwd=repo_root) in calls
+    # Check git commit (the change is committed before any PR step)
+    assert call(["git", "commit", "-m", FAKE_PROPOSAL["summary"]], check=True, cwd=repo_root, capture_output=True) in calls
 
-    # Check gh pr create call
-    gh_call = calls[3]
-    assert gh_call.args[0][0:4] == ["gh", "pr", "create", "--title"]
-    assert gh_call.args[0][4] == FAKE_PROPOSAL["summary"]
-
-    expected_body = kaizen_proposal_to_pr_draft(json.dumps(FAKE_PROPOSAL)) + HUMAN_IN_LOOP_BOILERPLATE
-    assert gh_call.args[0][6] == expected_body
-    assert "--label" in gh_call.args[0]
-    assert "kaizen" in gh_call.args[0]
-    assert "--dry-run" in gh_call.args[0]
+    # Dry-run must NOT push or open a PR (zero remote side effects).
+    flat = [c.args[0] for c in calls]
+    assert not any(cmd[:3] == ["gh", "pr", "create"] for cmd in flat)
+    assert not any(cmd[:2] == ["git", "push"] for cmd in flat)
 
     # Check git checkout main
     assert call(["git", "checkout", "main"], check=True, cwd=repo_root) in calls
@@ -169,8 +166,16 @@ def test_consume_one_real_run(mock_run, mock_check_output, repo_root, proposal_q
     result = agent.consume_one()
 
     assert result == pr_url
-    gh_call = mock_run.call_args_list[3]
-    assert "--dry-run" not in gh_call.args[0]
+    flat = [c.args[0] for c in mock_run.call_args_list]
+    # Real run must: commit the staged change, push the branch, then open the PR
+    # from the pushed head (regression guard — the actuator previously staged but
+    # never committed/pushed, so `gh pr create` failed on the live fleet).
+    assert any(cmd[:2] == ["git", "commit"] for cmd in flat), "must commit before PR"
+    assert any(cmd[:2] == ["git", "push"] for cmd in flat), "must push the branch"
+    gh_cmds = [cmd for cmd in flat if cmd[:3] == ["gh", "pr", "create"]]
+    assert gh_cmds, "must call gh pr create"
+    assert "--head" in gh_cmds[0]
+    assert "--dry-run" not in gh_cmds[0]
 
 @patch('subprocess.check_output', return_value="main\n")
 @patch('subprocess.run')


### PR DESCRIPTION
**Found on the live fleet** (naphtali k3s, 2026-06-08) while running the resident kaizen-pr-agent for real: the non-dry-run PR path never worked. `consume_one` staged the patch (`git add`) but **never `git commit`** and **never pushed the branch**, so `gh pr create` failed: *"no commits between … / must first push the current branch to a remote, or use --head"*. Only mocked-subprocess tests + the dry-run path exercised this, so the bug was latent.

- Always `git commit -m <title>` after staging.
- **Dry-run**: local validation only (patch + commit), no push, no `gh pr create` → zero remote side effects.
- **Real**: `git push -u origin <branch>` then `gh pr create --head <branch>`.

Tests updated + regression guard (commit+push+`--head` on real; absent on dry-run). 42 kaizen tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)