### PR TITLE
fix(organism/kaizen): gh auth setup-git before actuator push

### DIFF
--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/pr_agent.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/pr_agent.py
@@ -260,6 +260,13 @@ class KaizenPrAgent:
                 # pushed head (non-interactive contexts require the branch on the
                 # remote; `--head` makes the head explicit).
                 logging.info("Pushing %s and creating GitHub PR.", branch_name)
+                # Configure git to authenticate pushes via the gh credential
+                # helper (uses GH_TOKEN). An anonymous clone of a public repo has
+                # no push credentials, so a bare `git push` fails with exit 128;
+                # `gh auth setup-git` wires github.com to gh's token.
+                subprocess.run(
+                    ["gh", "auth", "setup-git"], check=True, cwd=self.repo_root, capture_output=True
+                )
                 subprocess.run(
                     ["git", "push", "-u", "origin", branch_name],
                     check=True, cwd=self.repo_root, capture_output=True,


### PR DESCRIPTION
4th latent real-PR bug found on the live fleet: anonymous public clone has no push creds → `git push` exit 128. Add `gh auth setup-git` before push. Completes the real path: commit→setup-git→push→`gh pr create --head`. 🤖 Generated with Claude Code