### PR TITLE
feat(organism/kaizen): meta self-reflection — score + prune the loop from PR outcomes

### DIFF
--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/__init__.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/__init__.py
@@ -965,6 +965,7 @@ class KaizenObserver:
         history_size: int = 144,  # 24h at 10-min cadence
         dedup_window_s: int = 2 * 3600,
         http_get: Callable[[str, float], dict] | None = None,
+        meta_reflector: "Any | None" = None,
     ):
         self.shard_urls = list(shard_urls)
         self.queue_paths = [Path(q) for q in queue_paths]
@@ -972,6 +973,10 @@ class KaizenObserver:
         self.history_size = history_size
         self.dedup_window_s = dedup_window_s
         self.http_get = http_get
+        # Optional MetaReflector (kaizen.fitness): scores rules by PR-acceptance
+        # and prunes (disables) rules humans keep rejecting — the loop pruning
+        # itself. None → all rules active (back-compat).
+        self.meta_reflector = meta_reflector
         self._history: dict[int, list[float]] = {}
         self._last_emit: dict[tuple[str, str], int] = {}
         self._lock = threading.Lock()
@@ -1000,11 +1005,18 @@ class KaizenObserver:
 
     def run_rules(self, obs: Observation) -> list[KaizenProposal]:
         out: list[KaizenProposal] = []
+        disabled = self.meta_reflector.disabled_rules() if self.meta_reflector else set()
         for rule in RULE_REGISTRY.values():
+            rid = getattr(rule, "rule_id", "?")
+            if rid in disabled:
+                # Pruned by the meta-reflector — its proposals keep getting
+                # rejected, so the loop stops emitting from it.
+                logger.info("rule %s pruned (low PR-acceptance fitness); skipping", rid)
+                continue
             try:
                 out.extend(rule(obs))
             except Exception as exc:  # noqa: BLE001 — observer stays alive
-                logger.warning("rule %s failed: %s", getattr(rule, "rule_id", "?"), exc)
+                logger.warning("rule %s failed: %s", rid, exc)
         return out
 
     def _filter_dedup(self, proposals: list[KaizenProposal], now_ms: int) -> list[KaizenProposal]:

--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/fitness.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/fitness.py
@@ -1,0 +1,217 @@
+"""Rule-fitness ledger + meta-reflector — the self-evolution loop scoring AND
+pruning ITSELF.
+
+Closes the meta-loop the bare Kaizen loop lacked. The observer emits proposals
+and the PR-agent opens PRs, but nothing fed the *outcome* (was the PR merged or
+rejected?) back into the loop. This module does:
+
+  belief → observe → update → policy
+
+  - Each rule carries a Beta(alpha, beta) belief over "do my proposals get
+    ACCEPTED (merged)?". Prior Beta(1, 1) = uniform (no evidence → 0.5).
+  - A PR outcome is an observation: merged → accept (+1 alpha), closed-unmerged
+    → reject (+1 beta). This is a minimal active-inference belief update over a
+    generative model of acceptance.
+  - The posterior mean is the rule's FITNESS SCORE.
+  - POLICY (pruning): a rule whose fitness falls below ``prune_below`` after at
+    least ``min_samples`` observations is disabled, so the loop stops emitting
+    proposals humans keep rejecting — the loop prunes itself.
+
+Persistence is an append-friendly JSON snapshot next to the proposal queue
+(same NDJSON-on-hostPath substrate the observer/pr-agent already share), so the
+ledger survives pod restarts without a new backend.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger("kotodama.organism.kaizen.fitness")
+
+
+@dataclass
+class RuleFitness:
+    rule_id: str
+    accepted: int = 0
+    rejected: int = 0
+    last_ts_ms: int = 0
+
+    @property
+    def samples(self) -> int:
+        return self.accepted + self.rejected
+
+    def posterior_mean(self, prior_a: float = 1.0, prior_b: float = 1.0) -> float:
+        """Beta(accepted+prior_a, rejected+prior_b) mean = expected acceptance."""
+        a = self.accepted + prior_a
+        b = self.rejected + prior_b
+        return a / (a + b)
+
+
+class RuleFitnessLedger:
+    """Per-rule Beta belief over proposal acceptance, persisted as JSON."""
+
+    def __init__(self, path: Path | str, *, prior_a: float = 1.0, prior_b: float = 1.0):
+        self.path = Path(path)
+        self.prior_a = prior_a
+        self.prior_b = prior_b
+        self._stats: dict[str, RuleFitness] = {}
+        self.load()
+
+    def load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            raw = json.loads(self.path.read_text() or "{}")
+        except json.JSONDecodeError:
+            logger.warning("fitness ledger %s unreadable; starting fresh", self.path)
+            return
+        for rid, d in raw.get("rules", {}).items():
+            self._stats[rid] = RuleFitness(
+                rule_id=rid,
+                accepted=int(d.get("accepted", 0)),
+                rejected=int(d.get("rejected", 0)),
+                last_ts_ms=int(d.get("lastTsMs", 0)),
+            )
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        out = {
+            "v": 1,
+            "rules": {
+                rid: {
+                    "accepted": s.accepted,
+                    "rejected": s.rejected,
+                    "lastTsMs": s.last_ts_ms,
+                    "fitness": round(s.posterior_mean(self.prior_a, self.prior_b), 4),
+                    "samples": s.samples,
+                }
+                for rid, s in self._stats.items()
+            },
+        }
+        self.path.write_text(json.dumps(out, indent=2))
+
+    def record_outcome(self, rule_id: str, accepted: bool, *, ts_ms: int | None = None) -> None:
+        s = self._stats.setdefault(rule_id, RuleFitness(rule_id=rule_id))
+        if accepted:
+            s.accepted += 1
+        else:
+            s.rejected += 1
+        s.last_ts_ms = ts_ms if ts_ms is not None else int(time.time() * 1000)
+        self.save()
+
+    def fitness(self, rule_id: str) -> float:
+        s = self._stats.get(rule_id)
+        if s is None:
+            return RuleFitness(rule_id).posterior_mean(self.prior_a, self.prior_b)
+        return s.posterior_mean(self.prior_a, self.prior_b)
+
+    def samples(self, rule_id: str) -> int:
+        s = self._stats.get(rule_id)
+        return s.samples if s else 0
+
+    def snapshot(self) -> dict[str, dict[str, Any]]:
+        return {
+            rid: {"fitness": round(s.posterior_mean(self.prior_a, self.prior_b), 4),
+                  "samples": s.samples, "accepted": s.accepted, "rejected": s.rejected}
+            for rid, s in self._stats.items()
+        }
+
+
+class MetaReflector:
+    """Scores + prunes the loop itself from the rule-fitness ledger.
+
+    ``disabled_rules()`` is the POLICY: rules with enough evidence whose expected
+    acceptance is below ``prune_below`` are pruned (disabled). The KaizenObserver
+    consults this to skip emitting from a rule that humans keep rejecting.
+    """
+
+    def __init__(
+        self,
+        ledger: RuleFitnessLedger,
+        *,
+        min_samples: int = 5,
+        prune_below: float = 0.34,
+    ):
+        self.ledger = ledger
+        self.min_samples = min_samples
+        self.prune_below = prune_below
+
+    def disabled_rules(self) -> set[str]:
+        return {
+            rid
+            for rid, st in self.ledger.snapshot().items()
+            if st["samples"] >= self.min_samples and st["fitness"] < self.prune_below
+        }
+
+    def record(self, rule_id: str, accepted: bool, *, ts_ms: int | None = None) -> None:
+        self.ledger.record_outcome(rule_id, accepted, ts_ms=ts_ms)
+
+
+# ── PR-outcome resolution ─────────────────────────────────────────────────
+
+# A PR-state lookup: given a pending-outcome record, return one of
+# "merged" | "closed" | "open" | "unknown".
+PrStateFn = Callable[[dict[str, Any]], str]
+
+
+def append_pending_outcome(outcomes_path: Path | str, *, rule_id: str, pr_url: str,
+                           branch: str, ts_ms: int | None = None) -> None:
+    """Append a {ruleId, prUrl, branch, status:pending} line — the PR-agent calls
+    this when it opens a real PR so the outcome can be resolved later."""
+    p = Path(outcomes_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    rec = {
+        "ruleId": rule_id, "prUrl": pr_url, "branch": branch,
+        "tsMs": ts_ms if ts_ms is not None else int(time.time() * 1000),
+        "status": "pending",
+    }
+    with open(p, "a", encoding="utf-8") as f:
+        f.write(json.dumps(rec) + "\n")
+
+
+def resolve_outcomes(outcomes_path: Path | str, ledger: RuleFitnessLedger,
+                     pr_state_fn: PrStateFn) -> dict[str, int]:
+    """Resolve pending PR outcomes into the fitness ledger.
+
+    For each pending record, ``pr_state_fn`` returns the PR state. merged →
+    accept, closed (unmerged) → reject; both are recorded and dropped from the
+    pending file. open/unknown stay pending. Returns counts.
+    """
+    p = Path(outcomes_path)
+    if not p.exists():
+        return {"resolved": 0, "accepted": 0, "rejected": 0, "pending": 0}
+    lines = [ln for ln in p.read_text().splitlines() if ln.strip()]
+    still_pending: list[str] = []
+    accepted = rejected = 0
+    for ln in lines:
+        try:
+            rec = json.loads(ln)
+        except json.JSONDecodeError:
+            continue
+        state = pr_state_fn(rec)
+        if state == "merged":
+            ledger.record_outcome(rec["ruleId"], True)
+            accepted += 1
+        elif state == "closed":
+            ledger.record_outcome(rec["ruleId"], False)
+            rejected += 1
+        else:  # open / unknown → keep pending
+            still_pending.append(ln)
+    p.write_text(("\n".join(still_pending) + "\n") if still_pending else "")
+    return {"resolved": accepted + rejected, "accepted": accepted,
+            "rejected": rejected, "pending": len(still_pending)}
+
+
+__all__ = [
+    "RuleFitness",
+    "RuleFitnessLedger",
+    "MetaReflector",
+    "append_pending_outcome",
+    "resolve_outcomes",
+    "PrStateFn",
+]

--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/pr_agent.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/pr_agent.py
@@ -278,6 +278,20 @@ class KaizenPrAgent:
                 pr_url = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else "PR created"
             logging.info(f"PR result: {pr_url}")
 
+            # 5b. Record a pending PR outcome so the meta-reflector can later
+            # score this rule by whether the PR was merged or rejected (the loop
+            # learning from its own output). Only real PRs are trackable.
+            if not self.dry_run:
+                try:
+                    from kotodama.organism.kaizen.fitness import append_pending_outcome
+                    rule_id = proposal.get("ruleId", "?")
+                    outcomes_path = self.proposal_queue_path.parent / (
+                        self.proposal_queue_path.stem + ".outcomes.ndjson"
+                    )
+                    append_pending_outcome(outcomes_path, rule_id=rule_id, pr_url=pr_url, branch=branch_name)
+                except Exception as exc:  # noqa: BLE001 — outcome tracking is best-effort
+                    logging.warning("could not record PR outcome for meta-reflection: %s", exc)
+
             # 6. Update queue file
             self.proposal_queue_path.write_text("\n".join(remaining_lines) + "\n" if remaining_lines else "")
             logging.info("Proposal consumed and queue updated.")

--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen_cell_main.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen_cell_main.py
@@ -57,12 +57,34 @@ def _default_proposal_path() -> Path:
     return home / "observer.ndjson"
 
 
+def _fitness_path() -> Path:
+    explicit = os.environ.get("KAIZEN_FITNESS_PATH")
+    if explicit:
+        return Path(explicit)
+    # Sibling of the proposal queue (same shared hostPath the pr-agent updates).
+    pp = _default_proposal_path()
+    return pp.parent / "rule-fitness.json"
+
+
 def _build_observer() -> KaizenObserver:
+    # Meta self-reflection: prune rules whose PRs humans keep rejecting. The
+    # pr-agent resolves PR outcomes into this ledger; the observer reads it to
+    # skip pruned rules. Disabled with KAIZEN_META_REFLECT=0.
+    meta_reflector = None
+    if os.environ.get("KAIZEN_META_REFLECT", "1").lower() not in ("0", "false", "no"):
+        from kotodama.organism.kaizen.fitness import RuleFitnessLedger, MetaReflector
+        ledger = RuleFitnessLedger(_fitness_path())
+        meta_reflector = MetaReflector(
+            ledger,
+            min_samples=int(os.environ.get("KAIZEN_PRUNE_MIN_SAMPLES", "5")),
+            prune_below=float(os.environ.get("KAIZEN_PRUNE_BELOW", "0.34")),
+        )
     return KaizenObserver(
         shard_urls=_default_shard_urls(),
         queue_paths=_default_queue_paths(),
         proposal_path=_default_proposal_path(),
         dedup_window_s=int(os.environ.get("KAIZEN_DEDUP_WINDOW_S", "7200")),
+        meta_reflector=meta_reflector,
     )
 
 

--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen_pr_agent_main.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen_pr_agent_main.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -57,6 +58,39 @@ def _dry_run() -> bool:
     return os.environ.get("KAIZEN_PR_AGENT_DRY_RUN", "true").lower() not in ("0", "false", "no")
 
 
+def _resolve_meta_outcomes(proposal_path: Path, repo_root: Path) -> dict[str, int]:
+    """Resolve pending PR outcomes (via `gh pr view`) into the shared rule-fitness
+    ledger, so the observer can prune rules whose PRs keep getting rejected."""
+    outcomes_path = proposal_path.parent / (proposal_path.stem + ".outcomes.ndjson")
+    if not outcomes_path.exists():
+        return {"resolved": 0}
+    try:
+        from kotodama.organism.kaizen.fitness import RuleFitnessLedger, resolve_outcomes
+    except Exception:  # noqa: BLE001
+        return {"resolved": 0}
+    ledger = RuleFitnessLedger(proposal_path.parent / "rule-fitness.json")
+
+    def _state(rec: dict[str, Any]) -> str:
+        ref = rec.get("branch") or rec.get("prUrl")
+        if not ref:
+            return "unknown"
+        try:
+            out = subprocess.run(
+                ["gh", "pr", "view", str(ref), "--json", "state", "--jq", ".state"],
+                cwd=repo_root, capture_output=True, text=True, timeout=20,
+            )
+            s = (out.stdout or "").strip().upper()
+        except Exception:  # noqa: BLE001 — best-effort; leave pending on error
+            return "unknown"
+        return {"MERGED": "merged", "CLOSED": "closed", "OPEN": "open"}.get(s, "unknown")
+
+    try:
+        return resolve_outcomes(outcomes_path, ledger, _state)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("meta outcome resolution failed: %s", exc)
+        return {"resolved": 0}
+
+
 async def fire() -> dict[str, Any]:
     """One drain pass over the proposal queue. Returns a status dict.
 
@@ -76,10 +110,15 @@ async def fire() -> dict[str, Any]:
         except KaizenPrAgentAuthError as exc:
             logger.warning("PR agent auth not ready — skipping cycle: %s", exc)
             return {"ok": False, "reason": "auth", "consumed": 0, "urls": []}
-        if not proposal_path.exists() or proposal_path.stat().st_size == 0:
-            return {"ok": True, "consumed": 0, "urls": [], "dryRun": dry_run}
-        urls = agent.consume_all()
-        return {"ok": True, "consumed": len(urls), "urls": urls, "dryRun": dry_run}
+        urls = []
+        if proposal_path.exists() and proposal_path.stat().st_size != 0:
+            urls = agent.consume_all()
+        # Meta self-reflection: resolve any pending PR outcomes into the shared
+        # rule-fitness ledger (merged → accept, closed → reject). The observer
+        # reads the same ledger to prune rules humans keep rejecting — closing
+        # the loop's self-scoring + self-pruning across the two resident pods.
+        meta = _resolve_meta_outcomes(proposal_path, repo_root)
+        return {"ok": True, "consumed": len(urls), "urls": urls, "dryRun": dry_run, "meta": meta}
 
     status = await loop.run_in_executor(None, _drain)
     logger.info(

--- a/crates/kotoba-kotodama/py/tests/organism/test_kaizen_fitness.py
+++ b/crates/kotoba-kotodama/py/tests/organism/test_kaizen_fitness.py
@@ -1,0 +1,109 @@
+"""Meta self-reflection: rule-fitness scoring + pruning + PR-outcome learning.
+
+Closes the meta-loop — the loop scores and prunes ITSELF from PR outcomes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from kotodama.organism.kaizen import KaizenObserver, Observation, ShardHealthz
+from kotodama.organism.kaizen.fitness import (
+    RuleFitnessLedger,
+    MetaReflector,
+    append_pending_outcome,
+    resolve_outcomes,
+)
+
+
+def test_ledger_beta_posterior_and_persistence(tmp_path: Path):
+    led = RuleFitnessLedger(tmp_path / "fit.json")
+    # No evidence → uniform prior mean 0.5
+    assert led.fitness("r") == 0.5
+    # 4 accept / 1 reject → Beta(5,2) mean = 5/7
+    for _ in range(4):
+        led.record_outcome("r", True)
+    led.record_outcome("r", False)
+    assert abs(led.fitness("r") - 5 / 7) < 1e-9
+    assert led.samples("r") == 5
+    # Persisted + reloaded
+    led2 = RuleFitnessLedger(tmp_path / "fit.json")
+    assert led2.samples("r") == 5
+    assert abs(led2.fitness("r") - 5 / 7) < 1e-9
+
+
+def test_reflector_prunes_only_with_enough_evidence(tmp_path: Path):
+    led = RuleFitnessLedger(tmp_path / "fit.json")
+    refl = MetaReflector(led, min_samples=5, prune_below=0.34)
+    # 1 reject — below threshold count → NOT pruned (insufficient evidence)
+    led.record_outcome("bad", False)
+    assert refl.disabled_rules() == set()
+    # 5 rejects total → Beta(1,6) mean ≈ 0.143 < 0.34 AND samples>=5 → pruned
+    for _ in range(4):
+        led.record_outcome("bad", False)
+    assert "bad" in refl.disabled_rules()
+    # a mostly-accepted rule with enough samples is NOT pruned
+    for _ in range(6):
+        led.record_outcome("good", True)
+    assert "good" not in refl.disabled_rules()
+
+
+def _saturating_obs() -> Observation:
+    # warm == capacity AND owned > capacity → triggers lru-saturation rule
+    return Observation(
+        ts=0,
+        shards=[ShardHealthz(shard=0, reachable=True, warm_count=4096,
+                             warm_capacity=4096, owned_count=9000)],
+    )
+
+
+def test_observer_skips_pruned_rule(tmp_path: Path):
+    obs = _saturating_obs()
+    # Baseline: lru-saturation fires.
+    base = KaizenObserver(shard_urls=[], queue_paths=[], proposal_path=tmp_path / "p.ndjson")
+    assert any(p.rule_id == "lru-saturation" for p in base.run_rules(obs))
+
+    # With a reflector that has pruned lru-saturation, the observer skips it.
+    led = RuleFitnessLedger(tmp_path / "fit.json")
+    for _ in range(6):
+        led.record_outcome("lru-saturation", False)  # humans kept rejecting it
+    refl = MetaReflector(led, min_samples=5, prune_below=0.34)
+    assert "lru-saturation" in refl.disabled_rules()
+    obsvr = KaizenObserver(shard_urls=[], queue_paths=[], proposal_path=tmp_path / "p2.ndjson",
+                           meta_reflector=refl)
+    assert not any(p.rule_id == "lru-saturation" for p in obsvr.run_rules(obs))
+
+
+def test_resolve_outcomes_updates_ledger(tmp_path: Path):
+    outcomes = tmp_path / "observer.outcomes.ndjson"
+    append_pending_outcome(outcomes, rule_id="sweep-latency-p95", pr_url="u/1", branch="b1")
+    append_pending_outcome(outcomes, rule_id="sweep-latency-p95", pr_url="u/2", branch="b2")
+    append_pending_outcome(outcomes, rule_id="mood-concentration", pr_url="u/3", branch="b3")
+
+    # merged → accept; closed → reject; open → stays pending
+    states = {"u/1": "merged", "u/2": "closed", "u/3": "open"}
+    led = RuleFitnessLedger(tmp_path / "fit.json")
+    res = resolve_outcomes(outcomes, led, lambda rec: states[rec["prUrl"]])
+
+    assert res == {"resolved": 2, "accepted": 1, "rejected": 1, "pending": 1}
+    assert led.samples("sweep-latency-p95") == 2  # 1 accept + 1 reject
+    # the open one stays pending in the file
+    assert "u/3" in outcomes.read_text()
+    assert "u/1" not in outcomes.read_text()
+
+
+def test_full_meta_loop_prunes_a_rejected_rule(tmp_path: Path):
+    """End-to-end meta-loop: a rule whose PRs are all rejected gets pruned, so
+    the observer stops emitting it."""
+    led = RuleFitnessLedger(tmp_path / "fit.json")
+    refl = MetaReflector(led, min_samples=5, prune_below=0.34)
+    outcomes = tmp_path / "observer.outcomes.ndjson"
+    # Simulate 5 lru-saturation PRs that all got rejected by humans.
+    for i in range(5):
+        append_pending_outcome(outcomes, rule_id="lru-saturation", pr_url=f"u/{i}", branch=f"b{i}")
+    resolve_outcomes(outcomes, led, lambda rec: "closed")  # all rejected
+
+    obsvr = KaizenObserver(shard_urls=[], queue_paths=[], proposal_path=tmp_path / "p.ndjson",
+                           meta_reflector=refl)
+    fired = {p.rule_id for p in obsvr.run_rules(_saturating_obs())}
+    assert "lru-saturation" not in fired  # pruned by its own rejected-PR history


### PR DESCRIPTION
The missing meta-layer: the self-evolution loop now **scores and prunes itself**, learning from its own PR outcomes (it previously had no feedback from merge/reject — rules were static, never retired).

**Active-inference-flavored belief loop** (belief→observe→update→policy):
- `kaizen/fitness.py`: per-rule **Beta(α,β) belief** over "do my proposals get merged?". `RuleFitnessLedger` (JSON on the shared hostPath) → fitness = posterior mean. `MetaReflector` policy = disable rules with ≥min_samples evidence whose fitness < threshold.
- `append_pending_outcome` / `resolve_outcomes`: pr-agent records a pending outcome on real PR; resolution maps PR state (merged→accept / closed→reject) into the ledger.

**Wiring** (closed loop across the two resident pods sharing the hostPath):
- `KaizenObserver.run_rules` skips pruned rules.
- `kaizen_cell_main` builds the reflector (env: `KAIZEN_META_REFLECT`/`KAIZEN_PRUNE_MIN_SAMPLES`/`KAIZEN_PRUNE_BELOW`).
- `kaizen_pr_agent_main` resolves outcomes via `gh pr view` each cycle.

Answers the design question directly: **score** = rule fitness, **prune** = low-fitness disable, **active inference** = Beta belief update from PR outcomes driving policy. 5 new fitness tests; 74 kaizen+entry tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)