### PR TITLE
feat(kaizen): pluggable GitRemote — GitHub-independent self-evolution via kotoba git push

### DIFF
--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/git_remote.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/git_remote.py
@@ -1,0 +1,129 @@
+"""GitRemote — pluggable target for the Kaizen actuator's change-publishing.
+
+Decouples the self-evolution loop from GitHub. The pr-agent commits the patch on
+a branch (host-agnostic), then hands the branch to a GitRemote which publishes
+the change and later reports its outcome:
+
+  - GithubRemote: `gh auth setup-git` → `git push` → `gh pr create --head` (PR
+    URL); outcome via `gh pr view --json state` (merged / closed / open).
+  - KotobaRemote: GitHub-INDEPENDENT. Pushes the committed branch into kotoba's
+    content-addressed Datom store via the kotoba-git write surface (the
+    `kotoba git import` CLI), so the loop self-evolves with NO GitHub / GHCR /
+    token dependency. The "change" is a kotoba ref; its outcome is a kotoba
+    approval marker (Council / operator), not a GitHub merge.
+
+Selected by env ``KAIZEN_GIT_REMOTE`` (github | kotoba; default github).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Protocol
+
+logger = logging.getLogger("kotodama.organism.kaizen.git_remote")
+
+
+class GitRemote(Protocol):
+    name: str
+
+    def open_change(
+        self, *, repo_root: Path, branch: str, title: str, body: str, labels: list[str]
+    ) -> str:
+        """Publish the already-committed `branch` as a reviewable change.
+        Returns a reference (PR URL for GitHub, kotoba ref/CID for kotoba)."""
+        ...
+
+    def change_state(self, ref_or_branch: str, *, repo_root: Path) -> str:
+        """Resolve a published change to: merged | closed | open | unknown.
+        merged → accepted (positive fitness), closed → rejected."""
+        ...
+
+
+class GithubRemote:
+    """Opens a real GitHub PR (the original actuator behavior)."""
+
+    name = "github"
+
+    def open_change(
+        self, *, repo_root: Path, branch: str, title: str, body: str, labels: list[str]
+    ) -> str:
+        # Authenticate git pushes via the gh credential helper (GH_TOKEN).
+        subprocess.run(["gh", "auth", "setup-git"], check=True, cwd=repo_root, capture_output=True)
+        subprocess.run(
+            ["git", "push", "-u", "origin", branch], check=True, cwd=repo_root, capture_output=True
+        )
+        cmd = ["gh", "pr", "create", "--head", branch, "--title", title, "--body", body]
+        for lb in labels:
+            cmd += ["--label", lb]
+        result = subprocess.run(cmd, check=True, cwd=repo_root, capture_output=True, text=True)
+        out = result.stdout.strip()
+        return out.splitlines()[-1] if out else "PR created"
+
+    def change_state(self, ref_or_branch: str, *, repo_root: Path) -> str:
+        try:
+            out = subprocess.run(
+                ["gh", "pr", "view", ref_or_branch, "--json", "state", "--jq", ".state"],
+                cwd=repo_root, capture_output=True, text=True, timeout=20,
+            )
+            s = (out.stdout or "").strip().upper()
+        except Exception:  # noqa: BLE001
+            return "unknown"
+        return {"MERGED": "merged", "CLOSED": "closed", "OPEN": "open"}.get(s, "unknown")
+
+
+class KotobaRemote:
+    """GitHub-independent: push the committed branch into kotoba's content-
+    addressed Datom store via the kotoba-git write surface (no GitHub).
+
+    Mechanism (per the kotoba-git write API — GitStore.import_repo / put_ref):
+    shells the kotoba CLI `kotoba git import <repo>/.git --graph <graph>`, which
+    ingests the branch's objects + refs as content-addressed `:git/*` Datoms.
+    The command is configurable via ``KAIZEN_KOTOBA_GIT_CMD`` (default
+    "kotoba git import") so the binary path / subcommand can be pointed at the
+    operator's kotoba build. Returns the kotoba ref (refs/heads/<branch>).
+    """
+
+    name = "kotoba"
+
+    def __init__(self, *, graph: str | None = None, kotoba_cmd: str | None = None):
+        self.graph = graph or os.environ.get("KAIZEN_KOTOBA_GRAPH", "kaizen:self-evolution")
+        self.kotoba_cmd = (kotoba_cmd or os.environ.get("KAIZEN_KOTOBA_GIT_CMD", "kotoba git import")).split()
+
+    def open_change(
+        self, *, repo_root: Path, branch: str, title: str, body: str, labels: list[str]
+    ) -> str:
+        git_dir = str(Path(repo_root) / ".git")
+        cmd = [*self.kotoba_cmd, git_dir, "--graph", self.graph, "--ref", f"refs/heads/{branch}"]
+        logger.info("kotoba push: %s", " ".join(cmd))
+        # No GitHub, no token, no network egress to github.com — the change lands
+        # in the kotoba content-addressed Datom log on the fleet.
+        subprocess.run(cmd, check=True, cwd=repo_root, capture_output=True, text=True)
+        return f"kotoba:{self.graph}/refs/heads/{branch}"
+
+    def change_state(self, ref_or_branch: str, *, repo_root: Path) -> str:
+        # A kotoba ref is "accepted" when an operator/Council marks it (a
+        # :git.ref/approved Datom). Until that approval surface lands, treat it
+        # as open (pending). No GitHub call.
+        marker = os.environ.get("KAIZEN_KOTOBA_APPROVED_REFS", "")
+        approved = {r.strip() for r in marker.split(",") if r.strip()}
+        rejected_marker = os.environ.get("KAIZEN_KOTOBA_REJECTED_REFS", "")
+        rejected = {r.strip() for r in rejected_marker.split(",") if r.strip()}
+        if ref_or_branch in approved:
+            return "merged"
+        if ref_or_branch in rejected:
+            return "closed"
+        return "open"
+
+
+def select_remote(name: str | None = None) -> GitRemote:
+    """Resolve the GitRemote from name / KAIZEN_GIT_REMOTE env (default github)."""
+    n = (name or os.environ.get("KAIZEN_GIT_REMOTE", "github")).strip().lower()
+    if n == "kotoba":
+        return KotobaRemote()
+    return GithubRemote()
+
+
+__all__ = ["GitRemote", "GithubRemote", "KotobaRemote", "select_remote"]

--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/git_remote.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/git_remote.py
@@ -6,10 +6,12 @@ the change and later reports its outcome:
 
   - GithubRemote: `gh auth setup-git` → `git push` → `gh pr create --head` (PR
     URL); outcome via `gh pr view --json state` (merged / closed / open).
-  - KotobaRemote: GitHub-INDEPENDENT. Pushes the committed branch into kotoba's
-    content-addressed Datom store via the kotoba-git write surface (the
-    `kotoba git import` CLI), so the loop self-evolves with NO GitHub / GHCR /
-    token dependency. The "change" is a kotoba ref; its outcome is a kotoba
+  - KotobaRemote: GitHub-INDEPENDENT. `git push`es the committed branch over the
+    kotoba server's git smart-HTTP endpoint (`POST /git/<repo>/git-receive-pack`,
+    kotoba-server::git_http → kotoba_git::wire::receive_pack), so every object
+    lands as an IPFS block + `:git/*` Datom projection on the running kotoba node
+    — NO GitHub / GHCR dependency, a real git-protocol push into the content-
+    addressed Datom log. The "change" is a kotoba ref; its outcome is a kotoba
     approval marker (Council / operator), not a GitHub merge.
 
 Selected by env ``KAIZEN_GIT_REMOTE`` (github | kotoba; default github).
@@ -75,33 +77,51 @@ class GithubRemote:
 
 
 class KotobaRemote:
-    """GitHub-independent: push the committed branch into kotoba's content-
-    addressed Datom store via the kotoba-git write surface (no GitHub).
+    """GitHub-independent: `git push` the committed branch into kotoba's content-
+    addressed Datom store over the kotoba server's git smart-HTTP endpoint.
 
-    Mechanism (per the kotoba-git write API — GitStore.import_repo / put_ref):
-    shells the kotoba CLI `kotoba git import <repo>/.git --graph <graph>`, which
-    ingests the branch's objects + refs as content-addressed `:git/*` Datoms.
-    The command is configurable via ``KAIZEN_KOTOBA_GIT_CMD`` (default
-    "kotoba git import") so the binary path / subcommand can be pointed at the
-    operator's kotoba build. Returns the kotoba ref (refs/heads/<branch>).
+    Mechanism — a *real git push* (no GitHub):
+      git push <KAIZEN_KOTOBA_GIT_URL>/git/<repo> refs/heads/<b>:refs/heads/<b>
+    hits `POST /git/<repo>/git-receive-pack` (kotoba-server::git_http), which runs
+    `kotoba_git::wire::receive_pack` → every object becomes an IPFS block + a
+    `:git/*` Datom projection, then `git_persist` snapshots the oid↔cid index +
+    refs. The push gate (`push_gate`) authenticates via an operator Bearer JWT
+    (``KAIZEN_KOTOBA_GIT_TOKEN``, operator-injected — no platform key, same model
+    as GH_TOKEN), or anonymously when the node runs KOTOBA_GIT_ALLOW_ANON_PUSH=1
+    (set ``KAIZEN_KOTOBA_GIT_ANON=1`` to skip the auth header).
+
+    Env:
+      KAIZEN_KOTOBA_GIT_URL    kotoba server base (default http://127.0.0.1:8080)
+      KAIZEN_KOTOBA_REPO       per-repo git Connection name (default "root")
+      KAIZEN_KOTOBA_GIT_TOKEN  operator Bearer JWT for the push gate
+      KAIZEN_KOTOBA_GIT_ANON   "1" → no auth header (node allows anon push)
+    Returns the kotoba ref `kotoba:<repo>/refs/heads/<branch>`.
     """
 
     name = "kotoba"
 
-    def __init__(self, *, graph: str | None = None, kotoba_cmd: str | None = None):
-        self.graph = graph or os.environ.get("KAIZEN_KOTOBA_GRAPH", "kaizen:self-evolution")
-        self.kotoba_cmd = (kotoba_cmd or os.environ.get("KAIZEN_KOTOBA_GIT_CMD", "kotoba git import")).split()
+    def __init__(self, *, base_url: str | None = None, repo: str | None = None):
+        self.base_url = (base_url or os.environ.get("KAIZEN_KOTOBA_GIT_URL", "http://127.0.0.1:8080")).rstrip("/")
+        self.repo = repo or os.environ.get("KAIZEN_KOTOBA_REPO", "root")
 
     def open_change(
         self, *, repo_root: Path, branch: str, title: str, body: str, labels: list[str]
     ) -> str:
-        git_dir = str(Path(repo_root) / ".git")
-        cmd = [*self.kotoba_cmd, git_dir, "--graph", self.graph, "--ref", f"refs/heads/{branch}"]
-        logger.info("kotoba push: %s", " ".join(cmd))
-        # No GitHub, no token, no network egress to github.com — the change lands
-        # in the kotoba content-addressed Datom log on the fleet.
+        remote_url = f"{self.base_url}/git/{self.repo}"
+        refspec = f"refs/heads/{branch}:refs/heads/{branch}"
+        cmd = ["git", "push", remote_url, refspec]
+        # Operator-injected Bearer JWT for the kotoba push gate (no platform key).
+        token = os.environ.get("KAIZEN_KOTOBA_GIT_TOKEN", "")
+        anon = os.environ.get("KAIZEN_KOTOBA_GIT_ANON", "") == "1"
+        if token and not anon:
+            # -c http.extraHeader injects the gate credential without writing it
+            # to disk; the URL carries no secret.
+            cmd = ["git", "-c", f"http.extraHeader=Authorization: Bearer {token}", *cmd[1:]]
+        logger.info("kotoba git push: %s %s", remote_url, refspec)
+        # No GitHub, no github.com egress — a real git-protocol push lands the
+        # branch in the kotoba content-addressed Datom log on the fleet.
         subprocess.run(cmd, check=True, cwd=repo_root, capture_output=True, text=True)
-        return f"kotoba:{self.graph}/refs/heads/{branch}"
+        return f"kotoba:{self.repo}/refs/heads/{branch}"
 
     def change_state(self, ref_or_branch: str, *, repo_root: Path) -> str:
         # A kotoba ref is "accepted" when an operator/Council marks it (a

--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/git_remote.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/git_remote.py
@@ -123,17 +123,32 @@ class KotobaRemote:
         subprocess.run(cmd, check=True, cwd=repo_root, capture_output=True, text=True)
         return f"kotoba:{self.repo}/refs/heads/{branch}"
 
+    @staticmethod
+    def _branch_of(ref: str) -> str:
+        """Normalize either form to the bare branch name, so an operator marker
+        and the stored outcome match regardless of which form each carries:
+          kotoba:root/refs/heads/kaizen/x → kaizen/x
+          refs/heads/kaizen/x            → kaizen/x
+          kaizen/x                       → kaizen/x
+        """
+        s = ref.strip()
+        if ":" in s and "/refs/heads/" in s:  # kotoba:<repo>/refs/heads/<b>
+            s = s.split("/refs/heads/", 1)[1]
+        elif s.startswith("refs/heads/"):
+            s = s[len("refs/heads/"):]
+        return s
+
     def change_state(self, ref_or_branch: str, *, repo_root: Path) -> str:
         # A kotoba ref is "accepted" when an operator/Council marks it (a
-        # :git.ref/approved Datom). Until that approval surface lands, treat it
-        # as open (pending). No GitHub call.
-        marker = os.environ.get("KAIZEN_KOTOBA_APPROVED_REFS", "")
-        approved = {r.strip() for r in marker.split(",") if r.strip()}
-        rejected_marker = os.environ.get("KAIZEN_KOTOBA_REJECTED_REFS", "")
-        rejected = {r.strip() for r in rejected_marker.split(",") if r.strip()}
-        if ref_or_branch in approved:
+        # :git.ref/approved Datom — env-bridged here until that surface lands).
+        # Match on the normalized branch name so the marker can be the bare
+        # branch OR the full kotoba ref. No GitHub call.
+        target = self._branch_of(ref_or_branch)
+        approved = {self._branch_of(r) for r in os.environ.get("KAIZEN_KOTOBA_APPROVED_REFS", "").split(",") if r.strip()}
+        rejected = {self._branch_of(r) for r in os.environ.get("KAIZEN_KOTOBA_REJECTED_REFS", "").split(",") if r.strip()}
+        if target in approved:
             return "merged"
-        if ref_or_branch in rejected:
+        if target in rejected:
             return "closed"
         return "open"
 

--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/pr_agent.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen/pr_agent.py
@@ -28,11 +28,20 @@ class KaizenPrAgent:
     """
     Consumes Kaizen proposals, creates branches, applies patches, and opens GitHub PRs.
     """
-    def __init__(self, proposal_queue_path: Path, repo_root: Path, dry_run: bool = True):
+    def __init__(self, proposal_queue_path: Path, repo_root: Path, dry_run: bool = True,
+                 remote: "Any | None" = None):
         self.proposal_queue_path = proposal_queue_path
         self.repo_root = repo_root
         self.dry_run = dry_run
-        self._verify_gh_auth()
+        # Pluggable change target (GitRemote). Default = GitHub (back-compat);
+        # KotobaRemote makes the loop GitHub-independent (push to kotoba).
+        if remote is None:
+            from kotodama.organism.kaizen.git_remote import GithubRemote
+            remote = GithubRemote()
+        self.remote = remote
+        # gh auth is only required for the GitHub remote; kotoba needs none.
+        if getattr(self.remote, "name", "github") == "github":
+            self._verify_gh_auth()
 
     def _verify_gh_auth(self):
         """Verifies that the GitHub CLI is authenticated."""
@@ -248,35 +257,20 @@ class KaizenPrAgent:
                 ["git", "commit", "-m", pr_title], check=True, cwd=self.repo_root, capture_output=True
             )
 
-            # 6. Open the PR.
+            # 6. Open the change via the pluggable GitRemote.
             if self.dry_run:
                 # Validate locally only — patch applied + committed on the branch.
-                # No push, no `gh pr create` (which would require a remote branch),
-                # so a dry run has zero remote side effects.
-                logging.info("Dry-run: patched + committed on %s (no push/PR).", branch_name)
+                # No push / no change opened → zero remote side effects.
+                logging.info("Dry-run: patched + committed on %s (no push).", branch_name)
                 pr_url = "Dry run successful."
             else:
-                # Push the branch first — `gh pr create` opens the PR from the
-                # pushed head (non-interactive contexts require the branch on the
-                # remote; `--head` makes the head explicit).
-                logging.info("Pushing %s and creating GitHub PR.", branch_name)
-                # Configure git to authenticate pushes via the gh credential
-                # helper (uses GH_TOKEN). An anonymous clone of a public repo has
-                # no push credentials, so a bare `git push` fails with exit 128;
-                # `gh auth setup-git` wires github.com to gh's token.
-                subprocess.run(
-                    ["gh", "auth", "setup-git"], check=True, cwd=self.repo_root, capture_output=True
+                # GithubRemote → push + `gh pr create`; KotobaRemote → push the
+                # branch into kotoba's content-addressed Datom store (no GitHub).
+                pr_url = self.remote.open_change(
+                    repo_root=self.repo_root, branch=branch_name,
+                    title=pr_title, body=pr_body, labels=labels,
                 )
-                subprocess.run(
-                    ["git", "push", "-u", "origin", branch_name],
-                    check=True, cwd=self.repo_root, capture_output=True,
-                )
-                gh_command = ["gh", "pr", "create", "--head", branch_name, "--title", pr_title, "--body", pr_body]
-                for label in labels:
-                    gh_command.extend(["--label", label])
-                result = subprocess.run(gh_command, check=True, cwd=self.repo_root, capture_output=True, text=True)
-                pr_url = result.stdout.strip().splitlines()[-1] if result.stdout.strip() else "PR created"
-            logging.info(f"PR result: {pr_url}")
+            logging.info(f"change opened via {getattr(self.remote, 'name', '?')}: {pr_url}")
 
             # 5b. Record a pending PR outcome so the meta-reflector can later
             # score this rule by whether the PR was merged or rejected (the loop

--- a/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen_pr_agent_main.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/organism/kaizen_pr_agent_main.py
@@ -58,9 +58,10 @@ def _dry_run() -> bool:
     return os.environ.get("KAIZEN_PR_AGENT_DRY_RUN", "true").lower() not in ("0", "false", "no")
 
 
-def _resolve_meta_outcomes(proposal_path: Path, repo_root: Path) -> dict[str, int]:
-    """Resolve pending PR outcomes (via `gh pr view`) into the shared rule-fitness
-    ledger, so the observer can prune rules whose PRs keep getting rejected."""
+def _resolve_meta_outcomes(proposal_path: Path, repo_root: Path, remote: Any) -> dict[str, int]:
+    """Resolve pending change outcomes into the shared rule-fitness ledger via the
+    active GitRemote (GitHub PR state, or kotoba ref-approval), so the observer
+    can prune rules whose changes keep getting rejected."""
     outcomes_path = proposal_path.parent / (proposal_path.stem + ".outcomes.ndjson")
     if not outcomes_path.exists():
         return {"resolved": 0}
@@ -75,14 +76,9 @@ def _resolve_meta_outcomes(proposal_path: Path, repo_root: Path) -> dict[str, in
         if not ref:
             return "unknown"
         try:
-            out = subprocess.run(
-                ["gh", "pr", "view", str(ref), "--json", "state", "--jq", ".state"],
-                cwd=repo_root, capture_output=True, text=True, timeout=20,
-            )
-            s = (out.stdout or "").strip().upper()
+            return remote.change_state(str(ref), repo_root=repo_root)
         except Exception:  # noqa: BLE001 — best-effort; leave pending on error
             return "unknown"
-        return {"MERGED": "merged", "CLOSED": "closed", "OPEN": "open"}.get(s, "unknown")
 
     try:
         return resolve_outcomes(outcomes_path, ledger, _state)
@@ -104,21 +100,28 @@ async def fire() -> dict[str, Any]:
 
     loop = asyncio.get_running_loop()
 
+    # Pluggable publish target: GitHub PR (default) or kotoba content-addressed
+    # Datom store (KAIZEN_GIT_REMOTE=kotoba → GitHub-independent self-evolution).
+    from kotodama.organism.kaizen.git_remote import select_remote
+    remote = select_remote()
+
     def _drain() -> dict[str, Any]:
         try:
-            agent = KaizenPrAgent(proposal_path, repo_root, dry_run=dry_run)
+            agent = KaizenPrAgent(proposal_path, repo_root, dry_run=dry_run, remote=remote)
         except KaizenPrAgentAuthError as exc:
             logger.warning("PR agent auth not ready — skipping cycle: %s", exc)
             return {"ok": False, "reason": "auth", "consumed": 0, "urls": []}
         urls = []
         if proposal_path.exists() and proposal_path.stat().st_size != 0:
             urls = agent.consume_all()
-        # Meta self-reflection: resolve any pending PR outcomes into the shared
-        # rule-fitness ledger (merged → accept, closed → reject). The observer
-        # reads the same ledger to prune rules humans keep rejecting — closing
+        # Meta self-reflection: resolve any pending change outcomes into the shared
+        # rule-fitness ledger (merged → accept, closed → reject), via the active
+        # remote (GitHub PR state, or kotoba ref-approval). The observer reads the
+        # same ledger to prune rules whose changes keep getting rejected — closing
         # the loop's self-scoring + self-pruning across the two resident pods.
-        meta = _resolve_meta_outcomes(proposal_path, repo_root)
-        return {"ok": True, "consumed": len(urls), "urls": urls, "dryRun": dry_run, "meta": meta}
+        meta = _resolve_meta_outcomes(proposal_path, repo_root, remote)
+        return {"ok": True, "consumed": len(urls), "urls": urls, "dryRun": dry_run,
+                "remote": getattr(remote, "name", "?"), "meta": meta}
 
     status = await loop.run_in_executor(None, _drain)
     logger.info(

--- a/crates/kotoba-kotodama/py/tests/organism/test_kaizen_git_remote.py
+++ b/crates/kotoba-kotodama/py/tests/organism/test_kaizen_git_remote.py
@@ -52,23 +52,43 @@ def test_github_change_state_maps_merged(mock_run):
 
 
 @patch("subprocess.run")
-def test_kotoba_open_change_shells_kotoba_import_no_github(mock_run, monkeypatch):
-    monkeypatch.setenv("KAIZEN_KOTOBA_GIT_CMD", "kotoba git import")
-    monkeypatch.setenv("KAIZEN_KOTOBA_GRAPH", "kaizen:self-evolution")
+def test_kotoba_open_change_git_pushes_to_kotoba_endpoint_no_github(mock_run, monkeypatch):
+    monkeypatch.setenv("KAIZEN_KOTOBA_GIT_URL", "http://127.0.0.1:8080")
+    monkeypatch.setenv("KAIZEN_KOTOBA_REPO", "root")
+    monkeypatch.setenv("KAIZEN_KOTOBA_GIT_TOKEN", "op.jwt.tok")
+    monkeypatch.delenv("KAIZEN_KOTOBA_GIT_ANON", raising=False)
     mock_run.return_value = MagicMock(stdout="", text=True)
     out = KotobaRemote().open_change(
         repo_root=Path("/repo"), branch="kaizen/x", title="t", body="b", labels=[]
     )
-    assert out == "kotoba:kaizen:self-evolution/refs/heads/kaizen/x"
+    assert out == "kotoba:root/refs/heads/kaizen/x"
     flat = [c.args[0] for c in mock_run.call_args_list]
-    # Exactly one shell-out: the kotoba import. No `gh`, no `git push`.
+    # Exactly one shell-out: a real `git push` to the kotoba smart-HTTP endpoint.
+    # No `gh`, no github.com.
     assert len(flat) == 1
     cmd = flat[0]
-    assert cmd[:3] == ["kotoba", "git", "import"]
-    assert "/repo/.git" in cmd
-    assert "--graph" in cmd and "kaizen:self-evolution" in cmd
-    assert "--ref" in cmd and "refs/heads/kaizen/x" in cmd
+    assert cmd[0] == "git" and "push" in cmd
+    # Operator Bearer JWT injected via -c http.extraHeader (no secret in URL/disk).
+    assert "-c" in cmd
+    assert any("http.extraHeader=Authorization: Bearer op.jwt.tok" == p for p in cmd)
+    assert "http://127.0.0.1:8080/git/root" in cmd
+    assert "refs/heads/kaizen/x:refs/heads/kaizen/x" in cmd
     assert not any("gh" == part for part in cmd)
+    assert not any("github.com" in str(part) for part in cmd)
+
+
+@patch("subprocess.run")
+def test_kotoba_open_change_anon_omits_auth_header(mock_run, monkeypatch):
+    monkeypatch.setenv("KAIZEN_KOTOBA_GIT_ANON", "1")
+    monkeypatch.setenv("KAIZEN_KOTOBA_GIT_TOKEN", "ignored.when.anon")
+    mock_run.return_value = MagicMock(stdout="", text=True)
+    KotobaRemote().open_change(
+        repo_root=Path("/repo"), branch="kaizen/y", title="t", body="b", labels=[]
+    )
+    cmd = mock_run.call_args_list[0].args[0]
+    # Anon push (node has KOTOBA_GIT_ALLOW_ANON_PUSH=1) → no Authorization header.
+    assert "-c" not in cmd
+    assert not any("Authorization" in str(p) for p in cmd)
 
 
 @patch("subprocess.run")

--- a/crates/kotoba-kotodama/py/tests/organism/test_kaizen_git_remote.py
+++ b/crates/kotoba-kotodama/py/tests/organism/test_kaizen_git_remote.py
@@ -1,0 +1,102 @@
+"""Tests for the pluggable GitRemote (GitHub vs kotoba) of the Kaizen actuator.
+
+Guards the GitHub-independence path: with KAIZEN_GIT_REMOTE=kotoba the loop
+publishes a committed branch into kotoba's content-addressed Datom store via the
+`kotoba git import` write surface — no `gh`, no github.com egress.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from kotodama.organism.kaizen.git_remote import (
+    GithubRemote,
+    KotobaRemote,
+    select_remote,
+)
+
+
+def test_select_remote_default_is_github(monkeypatch):
+    monkeypatch.delenv("KAIZEN_GIT_REMOTE", raising=False)
+    assert select_remote().name == "github"
+
+
+def test_select_remote_kotoba_by_env(monkeypatch):
+    monkeypatch.setenv("KAIZEN_GIT_REMOTE", "kotoba")
+    assert select_remote().name == "kotoba"
+
+
+def test_select_remote_explicit_name_overrides_env(monkeypatch):
+    monkeypatch.setenv("KAIZEN_GIT_REMOTE", "kotoba")
+    assert select_remote("github").name == "github"
+
+
+@patch("subprocess.run")
+def test_github_open_change_pushes_and_opens_pr(mock_run):
+    pr_url = "https://github.com/etzhayyim/root/pull/9"
+    mock_run.return_value = MagicMock(stdout=pr_url, text=True)
+    out = GithubRemote().open_change(
+        repo_root=Path("/repo"), branch="kaizen/x", title="t", body="b", labels=["kaizen"]
+    )
+    assert out == pr_url
+    flat = [c.args[0] for c in mock_run.call_args_list]
+    assert ["gh", "auth", "setup-git"] in flat
+    assert any(cmd[:2] == ["git", "push"] for cmd in flat)
+    gh = [cmd for cmd in flat if cmd[:3] == ["gh", "pr", "create"]]
+    assert gh and "--head" in gh[0] and "--label" in gh[0]
+
+
+@patch("subprocess.run")
+def test_github_change_state_maps_merged(mock_run):
+    mock_run.return_value = MagicMock(stdout="MERGED\n")
+    assert GithubRemote().change_state("kaizen/x", repo_root=Path("/repo")) == "merged"
+
+
+@patch("subprocess.run")
+def test_kotoba_open_change_shells_kotoba_import_no_github(mock_run, monkeypatch):
+    monkeypatch.setenv("KAIZEN_KOTOBA_GIT_CMD", "kotoba git import")
+    monkeypatch.setenv("KAIZEN_KOTOBA_GRAPH", "kaizen:self-evolution")
+    mock_run.return_value = MagicMock(stdout="", text=True)
+    out = KotobaRemote().open_change(
+        repo_root=Path("/repo"), branch="kaizen/x", title="t", body="b", labels=[]
+    )
+    assert out == "kotoba:kaizen:self-evolution/refs/heads/kaizen/x"
+    flat = [c.args[0] for c in mock_run.call_args_list]
+    # Exactly one shell-out: the kotoba import. No `gh`, no `git push`.
+    assert len(flat) == 1
+    cmd = flat[0]
+    assert cmd[:3] == ["kotoba", "git", "import"]
+    assert "/repo/.git" in cmd
+    assert "--graph" in cmd and "kaizen:self-evolution" in cmd
+    assert "--ref" in cmd and "refs/heads/kaizen/x" in cmd
+    assert not any("gh" == part for part in cmd)
+
+
+@patch("subprocess.run")
+def test_kotoba_change_state_env_markers(mock_run, monkeypatch):
+    ref = "kotoba:kaizen:self-evolution/refs/heads/kaizen/x"
+    # Default: pending (open) — no GitHub call made.
+    monkeypatch.delenv("KAIZEN_KOTOBA_APPROVED_REFS", raising=False)
+    monkeypatch.delenv("KAIZEN_KOTOBA_REJECTED_REFS", raising=False)
+    r = KotobaRemote()
+    assert r.change_state(ref, repo_root=Path("/repo")) == "open"
+    monkeypatch.setenv("KAIZEN_KOTOBA_APPROVED_REFS", ref)
+    assert r.change_state(ref, repo_root=Path("/repo")) == "merged"
+    monkeypatch.setenv("KAIZEN_KOTOBA_APPROVED_REFS", "")
+    monkeypatch.setenv("KAIZEN_KOTOBA_REJECTED_REFS", ref)
+    assert r.change_state(ref, repo_root=Path("/repo")) == "closed"
+    # kotoba state resolution must never call out to github.
+    mock_run.assert_not_called()
+
+
+@patch("subprocess.run")
+def test_pr_agent_kotoba_remote_needs_no_gh_auth(mock_run, tmp_path):
+    """A KotobaRemote-backed agent must construct without `gh auth status`."""
+    from kotodama.organism.kaizen.pr_agent import KaizenPrAgent
+
+    q = tmp_path / "q.ndjson"
+    q.write_text("")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    KaizenPrAgent(q, repo, dry_run=False, remote=KotobaRemote())
+    # No subprocess at all during construction (GithubRemote would `gh auth status`).
+    mock_run.assert_not_called()

--- a/crates/kotoba-kotodama/py/tests/organism/test_kaizen_git_remote.py
+++ b/crates/kotoba-kotodama/py/tests/organism/test_kaizen_git_remote.py
@@ -108,6 +108,24 @@ def test_kotoba_change_state_env_markers(mock_run, monkeypatch):
     mock_run.assert_not_called()
 
 
+def test_kotoba_change_state_normalizes_branch_vs_full_ref(monkeypatch):
+    """The outcome record stores the bare branch, but an operator may mark the
+    full kotoba ref (or vice-versa). Both must resolve to the same state —
+    regression guard for the pending-forever bug found in the live e2e run."""
+    r = KotobaRemote()
+    full = "kotoba:root/refs/heads/kaizen/x"
+    bare = "kaizen/x"
+    # marker is the full ref, lookup is the bare branch (the real ledger case):
+    monkeypatch.setenv("KAIZEN_KOTOBA_APPROVED_REFS", full)
+    monkeypatch.delenv("KAIZEN_KOTOBA_REJECTED_REFS", raising=False)
+    assert r.change_state(bare, repo_root=Path("/repo")) == "merged"
+    # and the reverse: marker is the bare branch, lookup is the full ref:
+    monkeypatch.setenv("KAIZEN_KOTOBA_APPROVED_REFS", bare)
+    assert r.change_state(full, repo_root=Path("/repo")) == "merged"
+    # refs/heads/<b> form also normalizes:
+    assert r.change_state("refs/heads/kaizen/x", repo_root=Path("/repo")) == "merged"
+
+
 @patch("subprocess.run")
 def test_pr_agent_kotoba_remote_needs_no_gh_auth(mock_run, tmp_path):
     """A KotobaRemote-backed agent must construct without `gh auth status`."""


### PR DESCRIPTION
## What

Decouples the Kaizen self-evolution actuator's change-publishing from GitHub via a pluggable `GitRemote`, and wires the **already-implemented** kotoba git smart-HTTP push as a first-class, GitHub-independent target.

### `GitRemote` abstraction (`kaizen/git_remote.py`)
- **`GithubRemote`** (default, back-compat): `gh auth setup-git` → `git push` → `gh pr create --head`; outcome via `gh pr view --json state`.
- **`KotobaRemote`** (`KAIZEN_GIT_REMOTE=kotoba`): a **real `git push`** to `POST /git/<repo>/git-receive-pack` (kotoba-server::git_http → `kotoba_git::wire::receive_pack`) — every object lands as an IPFS block + `:git/*` Datom projection on the running kotoba node, then `git_persist` snapshots the oid↔cid index. **No GitHub / GHCR dependency.**
- `select_remote()` resolves from `KAIZEN_GIT_REMOTE` (github|kotoba, default github).
- `kaizen_pr_agent_main` wires it through `consume_one` + delegates `_resolve_meta_outcomes` to `remote.change_state`, so the MetaReflector fitness ledger is fed by either GitHub PR state **or** kotoba ref-approval (`KAIZEN_KOTOBA_APPROVED_REFS`/`REJECTED_REFS` → merged/closed/open).

### Auth (no-server-key compliant)
Push gate via operator Bearer JWT (`KAIZEN_KOTOBA_GIT_TOKEN` — operator-injected, short-lived, **not** a platform key; same model as `GH_TOKEN`), or anon when the node runs `KOTOBA_GIT_ALLOW_ANON_PUSH=1`. The `-c http.extraHeader` injection keeps the credential off disk and out of the URL.

## Verification

- **Live e2e** (not just unit): built `kotoba-server`, ran it with anon push + `KOTOBA_IPFS=off`, `git push`ed a `kaizen/auto-test` branch → `* [new branch]` accepted, then `git clone` back from kotoba round-tripped both commits + exact file bytes (`76bc65f`, `1bd1128`). Zero GitHub involvement.
- `kotoba-git` wire suite **13/13** + `real_git_repo` **2/2** green.
- **9** new `git_remote` tests + **48** kaizen tests green; existing `test_consume_one_real_run` (GitHub path) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)