### PR TITLE
feat(social): retainer allocation (§6) + end-to-end loop example + verification

### DIFF
--- a/crates/kotoba-kqe/examples/social_capital_loop.rs
+++ b/crates/kotoba-kqe/examples/social_capital_loop.rs
@@ -1,0 +1,139 @@
+//! End-to-end demonstration of the Mishmar social-capital economic loop
+//! (ADR-2606082100). Runnable proof that the deterministic core closes the loop:
+//!
+//!   validated acts → mint engine → social/mint|burn Datoms
+//!        → SocialCapitalView (decayed balances) → SC_root
+//!        → retainer allocation (donation pool split by social capital)
+//!
+//! Run: `cargo run --example social_capital_loop -p kotoba-kqe`
+
+use kotoba_core::cid::KotobaCid;
+use kotoba_kqe::delta::Delta;
+use kotoba_kqe::social::{
+    allocate_retainer, Falsification, MintParams, PinOrigin, SocialCapitalView,
+    ValidatedDisclosure, ValidatedWellbecoming, SCALE,
+};
+
+fn did(s: &str) -> KotobaCid {
+    KotobaCid::from_bytes(s.as_bytes())
+}
+
+fn pts(smic: i64) -> String {
+    format!("{:.3} pts", smic as f64 / SCALE as f64)
+}
+
+fn main() {
+    let params = MintParams::default();
+    let graph = did("g:social:2026-12");
+    println!("== Mishmar social-capital loop (ADR-2606082100) ==");
+    println!(
+        "params: w_disclosure={:.1} w_wellbecoming={:.1} citation_bonus={:.1}/hit \
+         burn_mult={:.1} half_life={}d\n",
+        params.w_disclosure_milli as f64 / 1000.0,
+        params.w_wellbecoming_milli as f64 / 1000.0,
+        params.citation_bonus_milli as f64 / 1000.0,
+        params.burn_falsified_mult_milli as f64 / 1000.0,
+        params.half_life_epochs,
+    );
+
+    let alice = did("did:key:alice");
+    let bob = did("did:key:bob");
+    let carol = did("did:key:carol");
+
+    // ── 1. Validated value-acts at epoch 0 (validation gates enforced by type) ──
+    // alice: 2 validated disclosures + 8 citation hits  → 1.0·2 + 0.1·8 = 2.8 pts
+    let alice_disc = ValidatedDisclosure::new(alice.clone(), 0, 2, 8, true, true)
+        .expect("terminal-honest escrow + witness quorum");
+    // alice: Council-attested wellbecoming Δ=+5 → 2.0·5 = 10.0 pts
+    let alice_wb = ValidatedWellbecoming::new(alice.clone(), 0, 5, true).expect("council-attested");
+    // bob: 1 disclosure, 0 citations → 1.0 pt
+    let bob_disc = ValidatedDisclosure::new(bob.clone(), 0, 1, 0, true, true).unwrap();
+    // carol: wellbecoming HARM Δ=-3 (Council-attested) → burn 6.0 pts (no prior balance → clamp 0)
+    let carol_harm = ValidatedWellbecoming::new(carol.clone(), 0, -3, true).unwrap();
+
+    // an UNVALIDATED disclosure cannot even be constructed → cannot mint (spec §7)
+    assert!(ValidatedDisclosure::new(bob.clone(), 0, 9, 9, false, true).is_none());
+    println!("validation gate: unvalidated disclosure → None (cannot mint). ✓\n");
+
+    // ── 2. Mint engine → Datoms ──
+    let mut datoms = Vec::new();
+    datoms.extend(alice_disc.mint_datom(&params, &graph));
+    datoms.extend(alice_wb.datom(&params, &graph));
+    datoms.extend(bob_disc.mint_datom(&params, &graph));
+    datoms.extend(carol_harm.datom(&params, &graph));
+    println!("minted {} social Datoms at epoch 0:", datoms.len());
+    for d in &datoms {
+        let v = match &d.v {
+            kotoba_kqe::datom::Value::Integer(n) => pts(*n),
+            _ => "?".into(),
+        };
+        println!("  {}  {}  = {v}", &d.e.to_string()[..20.min(d.e.to_string().len())], d.a);
+    }
+
+    // ── 3. SocialCapitalView reducer (decayed balances over the Datom stream) ──
+    let deltas: Vec<Delta> = datoms.into_iter().map(Delta::assert_datom).collect();
+    let mut view = SocialCapitalView::new();
+    view.apply(&deltas);
+
+    println!("\ncapital @ epoch 0:");
+    for (name, d) in [("alice", &alice), ("bob", &bob), ("carol", &carol)] {
+        println!("  {name:6} = {}", pts(view.capital(d, 0)));
+    }
+    // alice = 2.8 + 10.0 = 12.8; bob = 1.0; carol = 0 (harm clamped, no prior balance)
+
+    // ── 4. Retainer allocation (donation pool split by social capital, §6) ──
+    // Three pins; alice originated rootA, bob rootB, alice+bob co-originated rootC.
+    let pins = [
+        PinOrigin { pin_id: did("pinA"), root_cid: did("rootA"), origin_dids: vec![alice.clone()] },
+        PinOrigin { pin_id: did("pinB"), root_cid: did("rootB"), origin_dids: vec![bob.clone()] },
+        PinOrigin {
+            pin_id: did("pinC"),
+            root_cid: did("rootC"),
+            origin_dids: vec![alice.clone(), bob.clone()],
+        },
+    ];
+    let pool_mkoto = 1_000_000; // the epoch's donation-funded retainer pool
+
+    let (shares, remainder) = allocate_retainer(&pins, &view, 0, pool_mkoto);
+    println!("\nretainer allocation @ epoch 0 (pool = {pool_mkoto} mKOTO):");
+    for (s, p) in shares.iter().zip(pins.iter()) {
+        let root = &p.root_cid.to_string()[..16.min(p.root_cid.to_string().len())];
+        println!(
+            "  {root}…  SC_root={:>8}  → {:>7} mKOTO",
+            pts(s.sc_root),
+            s.retainer_mkoto
+        );
+    }
+    println!("  undistributed remainder (rolls over) = {remainder} mKOTO");
+    let total: i64 = shares.iter().map(|s| s.retainer_mkoto).sum();
+    println!("  conservation: Σ shares + remainder = {} == pool ✓", total + remainder);
+
+    // ── 5. Decay re-weights allocation over time ──
+    // 30 days (one half-life) later, with no new acts, every balance ~halves —
+    // the RELATIVE allocation is stable, but a freshly-minting agent would gain.
+    let bob_fresh = ValidatedDisclosure::new(bob.clone(), 30, 5, 0, true, true).unwrap(); // +5 pts at e30
+    let mut datoms2 = Vec::new();
+    datoms2.extend(bob_fresh.mint_datom(&params, &graph));
+    let deltas2: Vec<Delta> = datoms2.into_iter().map(Delta::assert_datom).collect();
+    view.apply(&deltas2);
+
+    println!("\ncapital @ epoch 30 (one half-life later; bob mints +5.0 fresh):");
+    for (name, d) in [("alice", &alice), ("bob", &bob)] {
+        println!("  {name:6} = {}", pts(view.capital(d, 30)));
+    }
+    let (shares30, _) = allocate_retainer(&pins, &view, 30, pool_mkoto);
+    println!("retainer @ epoch 30 (pool = {pool_mkoto} mKOTO):");
+    for (s, p) in shares30.iter().zip(pins.iter()) {
+        let root = &p.root_cid.to_string()[..16.min(p.root_cid.to_string().len())];
+        println!("  {root}…  SC_root={:>8}  → {:>7} mKOTO", pts(s.sc_root), s.retainer_mkoto);
+    }
+
+    // sanity: a falsification burns more than it earned (asymmetric 嘘で損)
+    let f = Falsification { did: alice.clone(), epoch: 30, count: 2 };
+    println!(
+        "\nfalsification burn (alice, 2 claims): {} (> the 2.0 pts they'd have earned) ✓",
+        pts(f.burn_smic(&params))
+    );
+
+    println!("\n== loop verified: acts → mint → view → SC_root → retainer ==");
+}

--- a/crates/kotoba-kqe/src/social.rs
+++ b/crates/kotoba-kqe/src/social.rs
@@ -595,6 +595,71 @@ impl SocialCapitalView {
     }
 }
 
+// ── Retainer allocation (the downstream of the loop, ADR-2606082100 §6) ───────
+//
+// Social capital is the DENOMINATOR of the donation pool: the epoch's
+// donation-funded retainer is split across pins proportional to the social
+// capital of each pin's originating agents. This is the precise sense in which
+// "how you generate social capital IS the economic system" — it literally decides
+// which rootCids the covenant pays to keep alive, and how much.
+
+/// One pin's origin set for retainer allocation (spec §6). `origin_dids` are the
+/// DIDs whose validated disclosure/wellbecoming produced the data under
+/// `root_cid` — sourced from `social/origin/<root_cid>` Datoms (an index built
+/// like [`SocialCapitalView`]; a follow-up). Here taken as input.
+#[derive(Clone, Debug)]
+pub struct PinOrigin {
+    pub pin_id: KotobaCid,
+    pub root_cid: KotobaCid,
+    pub origin_dids: Vec<KotobaCid>,
+}
+
+/// A pin's computed retainer share for an epoch.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RetainerShare {
+    pub pin_id: KotobaCid,
+    /// `SC_root(root_cid, epoch)` in smic — Σ social capital of the pin's origin DIDs.
+    pub sc_root: i64,
+    /// mKOTO retainer = `pool · sc_root / Σ sc_root` (floor).
+    pub retainer_mkoto: i64,
+}
+
+/// Allocate the epoch's donation-funded retainer pool (`pool_mkoto`) across `pins`
+/// **proportional to the social capital of each pin's originating agents** (spec §6):
+///
+/// `retainer(pin) = pool · SC_root(pin) / Σ SC_root`,  `SC_root = Σ_{did∈origins} SC(did,e)`.
+///
+/// Returns `(shares, remainder)`. Floor division is **conserving**:
+/// `Σ shares + remainder == pool_mkoto`; the undistributed `remainder` (dust)
+/// rolls to the next epoch — never minted (no inflation). When total social
+/// capital is 0, nothing is funded and the whole pool rolls over: data with no
+/// validated social value is not paid to be kept alive.
+pub fn allocate_retainer(
+    pins: &[PinOrigin],
+    view: &SocialCapitalView,
+    now_epoch: u64,
+    pool_mkoto: i64,
+) -> (Vec<RetainerShare>, i64) {
+    let sc: Vec<i64> = pins
+        .iter()
+        .map(|p| view.capital_sum(p.origin_dids.iter(), now_epoch))
+        .collect();
+    let total: i128 = sc.iter().map(|&x| x as i128).sum();
+    let mut distributed: i128 = 0;
+    let mut shares = Vec::with_capacity(pins.len());
+    for (p, &sc_root) in pins.iter().zip(sc.iter()) {
+        let r = if total > 0 {
+            sat_i64((pool_mkoto as i128) * (sc_root as i128) / total)
+        } else {
+            0
+        };
+        distributed += r as i128;
+        shares.push(RetainerShare { pin_id: p.pin_id.clone(), sc_root, retainer_mkoto: r });
+    }
+    let remainder = sat_i64(pool_mkoto as i128 - distributed);
+    (shares, remainder)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -911,5 +976,98 @@ mod tests {
         let p = MintParams::default();
         let w = ValidatedWellbecoming::new(did("did:key:z"), 0, 0, true).unwrap();
         assert!(w.datom(&p, &did("g")).is_none());
+    }
+
+    // ── Retainer allocation (the downstream of the loop) ──────────────────
+
+    fn pin(id: &str, root: &str, origins: &[&KotobaCid]) -> PinOrigin {
+        PinOrigin {
+            pin_id: did(id),
+            root_cid: did(root),
+            origin_dids: origins.iter().map(|d| (*d).clone()).collect(),
+        }
+    }
+
+    #[test]
+    fn retainer_is_proportional_to_social_capital() {
+        let a = did("did:key:a");
+        let b = did("did:key:b");
+        let mut v = SocialCapitalView::new();
+        v.apply(&[
+            mint_delta(&a, MintSource::Disclosure, 30 * SCALE, 0), // SC_root(pinA) = 30
+            mint_delta(&b, MintSource::Disclosure, 70 * SCALE, 0), // SC_root(pinB) = 70
+        ]);
+        let pins = [pin("pinA", "rootA", &[&a]), pin("pinB", "rootB", &[&b])];
+        let (shares, remainder) = allocate_retainer(&pins, &v, 0, 1_000);
+        assert_eq!(shares[0].retainer_mkoto, 300); // 1000 · 30/100
+        assert_eq!(shares[1].retainer_mkoto, 700); // 1000 · 70/100
+        assert_eq!(remainder, 0);
+    }
+
+    #[test]
+    fn retainer_conserves_pool() {
+        let a = did("did:key:a");
+        let b = did("did:key:b");
+        let c = did("did:key:c");
+        let mut v = SocialCapitalView::new();
+        // 1/1/1 split of a pool not divisible by 3 → dust remainder, conserved.
+        v.apply(&[
+            mint_delta(&a, MintSource::Disclosure, 1 * SCALE, 0),
+            mint_delta(&b, MintSource::Disclosure, 1 * SCALE, 0),
+            mint_delta(&c, MintSource::Disclosure, 1 * SCALE, 0),
+        ]);
+        let pins = [
+            pin("p1", "r1", &[&a]),
+            pin("p2", "r2", &[&b]),
+            pin("p3", "r3", &[&c]),
+        ];
+        let pool = 1_000;
+        let (shares, remainder) = allocate_retainer(&pins, &v, 0, pool);
+        let sum: i64 = shares.iter().map(|s| s.retainer_mkoto).sum();
+        assert_eq!(sum + remainder, pool, "Σ shares + remainder == pool (conserving)");
+        assert_eq!(remainder, 1); // 1000 = 333+333+333 + 1 dust
+    }
+
+    #[test]
+    fn retainer_zero_capital_funds_nothing_and_rolls_over() {
+        let v = SocialCapitalView::new(); // no capital minted
+        let pins = [pin("p1", "r1", &[&did("did:key:a")])];
+        let (shares, remainder) = allocate_retainer(&pins, &v, 0, 5_000);
+        assert_eq!(shares[0].retainer_mkoto, 0);
+        assert_eq!(remainder, 5_000, "whole pool rolls over when no validated social value");
+    }
+
+    #[test]
+    fn retainer_root_sums_multiple_origin_dids() {
+        let a = did("did:key:a");
+        let b = did("did:key:b");
+        let mut v = SocialCapitalView::new();
+        v.apply(&[
+            mint_delta(&a, MintSource::Disclosure, 20 * SCALE, 0),
+            mint_delta(&b, MintSource::Wellbecoming, 30 * SCALE, 0),
+        ]);
+        // one pin whose root was originated by BOTH a and b → SC_root = 50
+        let pins = [pin("p1", "r1", &[&a, &b])];
+        let (shares, _) = allocate_retainer(&pins, &v, 0, 999);
+        assert_eq!(shares[0].sc_root, 50 * SCALE);
+        assert_eq!(shares[0].retainer_mkoto, 999); // sole pin → whole pool
+    }
+
+    #[test]
+    fn retainer_tracks_decay_over_epochs() {
+        // As one agent's capital decays, its pin's share shrinks relative to a
+        // freshly-minting agent — the allocation re-weights toward current value.
+        let a = did("did:key:a");
+        let b = did("did:key:b");
+        let mut v = SocialCapitalView::new();
+        v.apply(&[mint_delta(&a, MintSource::Disclosure, 100 * SCALE, 0)]);
+        v.apply(&[mint_delta(&b, MintSource::Disclosure, 100 * SCALE, 30)]); // b mints a half-life later
+        let pins = [pin("pa", "ra", &[&a]), pin("pb", "rb", &[&b])];
+        // at epoch 30: a decayed to ~50, b is 100 → b gets ~2x a's share.
+        let (shares, _) = allocate_retainer(&pins, &v, 30, 3_000);
+        assert!(shares[1].retainer_mkoto > shares[0].retainer_mkoto, "fresh b > decayed a");
+        // a ≈ 1000, b ≈ 2000 (±rounding from the ~50/100 split)
+        assert!((shares[0].retainer_mkoto - 1_000).abs() <= 20, "a={}", shares[0].retainer_mkoto);
+        assert!((shares[1].retainer_mkoto - 2_000).abs() <= 20, "b={}", shares[1].retainer_mkoto);
     }
 }


### PR DESCRIPTION
## What
Follow-up #4 to #78: closes the **downstream** of the economic loop. Social capital is the **denominator** of the donation pool (ADR-2606082100 §6; spec `docs/SOCIAL-CAPITAL-LEDGER.md`).

`allocate_retainer(pins, view, epoch, pool_mkoto)` splits the epoch's retainer proportional to each pin's **SC_root** (Σ social capital of its originating DIDs):

> `retainer(pin) = pool · SC_root(pin) / Σ SC_root`

- **Conserving**: floor division → `Σ shares + remainder == pool`; dust `remainder` rolls to next epoch (no inflation).
- **Zero total capital funds nothing**: the whole pool rolls over — data with no validated social value is not paid to be kept alive.
- `PinOrigin` / `RetainerShare` + 5 tests (proportional, conservation-with-dust, zero-capital roll-over, multi-origin SC_root, decay re-weighting).

## 動作検証 (operational verification)
`cargo run --example social_capital_loop -p kotoba-kqe` runs the **full loop** and prints live numbers:

```
capital @ epoch 0:  alice=12.800  bob=1.000  carol=0.000   (carol's harm burn clamped, no prior balance)
retainer @ epoch 0 (pool=1_000_000 mKOTO):
  rootA (alice)        SC_root=12.800 →  463768 mKOTO
  rootB (bob)          SC_root= 1.000 →   36231 mKOTO
  rootC (alice+bob)    SC_root=13.800 →  500000 mKOTO
  remainder = 1 mKOTO   conservation: Σ+remainder = 1_000_000 == pool ✓
epoch 30 (one half-life): alice 12.8→6.4, bob mints +5 fresh → re-weighted split
falsification burn (2 claims) = 3.000 pts > the 2.0 earned (asymmetric 嘘で損) ✓
```

The loop is verified end-to-end: **validated acts → mint engine → `social/*` Datoms → `SocialCapitalView` → SC_root → retainer**.

`kotoba-kqe`: **32 social tests green**; build + clippy warning-free.

## Follow-ups
- mKOTO L6 settlement consuming `RetainerShare` (ADR-2605260004).
- `social/origin/<rootCid>` index (like SocialCapitalView) feeding `PinOrigin`.
- server I/O job (`eth_getLogs` + CitationLedger + KaizenObserver → `Validated*`); XRPC read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)