### PR TITLE
feat(social): mint job pipeline + server I/O orchestrator (#3)

### DIFF
--- a/crates/kotoba-kqe/src/social.rs
+++ b/crates/kotoba-kqe/src/social.rs
@@ -595,6 +595,90 @@ impl SocialCapitalView {
     }
 }
 
+// ── Mint job (validate → weigh → emit; the I/O entry of the loop, §3/§4) ──────
+//
+// `SocialMintJob` is the deterministic pipeline a server-side job runs each epoch:
+// RAW observations → validation gates (Validated*) → mint engine → social/* Datoms.
+// Observations that fail validation (not terminal-honest, no quorum, not
+// Council-attested) are silently dropped — never minted (spec §7). The actual I/O
+// that produces these observations (anchor-chain `eth_getLogs` for terminal escrow
+// state + slashes, the CitationLedger, the KaizenObserver wellbecoming feed) is a
+// server wrapper that fills these structs and calls `run_epoch` (follow-up).
+
+/// A raw observed disclosure (pre-validation). `terminal_honest` =
+/// Refunded/Upheld on the anchor-chain ClaimStakeEscrow; `witness_quorum_met` =
+/// ≥K-of-N kotoba-datomic attestation.
+#[derive(Clone, Debug)]
+pub struct ObservedDisclosure {
+    pub did: KotobaCid,
+    pub epoch: u64,
+    pub n_validated: i64,
+    pub citation_hits: i64,
+    pub terminal_honest: bool,
+    pub witness_quorum_met: bool,
+}
+
+/// A raw observed wellbecoming measurement (KaizenObserver Δ, pre-validation).
+#[derive(Clone, Debug)]
+pub struct ObservedWellbecoming {
+    pub did: KotobaCid,
+    pub epoch: u64,
+    pub delta: i64,
+    pub council_attested: bool,
+}
+
+/// The per-epoch mint pipeline. Holds the economic params + the social graph CID
+/// the emitted Datoms are written under.
+pub struct SocialMintJob {
+    params: MintParams,
+    graph: KotobaCid,
+}
+
+impl SocialMintJob {
+    pub fn new(params: MintParams, graph: KotobaCid) -> Self {
+        Self { params, graph }
+    }
+
+    pub fn params(&self) -> &MintParams {
+        &self.params
+    }
+
+    /// Validate + weigh one epoch's observations → the `social/mint|burn` Datoms to
+    /// commit. Drops any observation that fails its validation gate (no minting on
+    /// assertion alone). Falsifications (`Slashed` on the anchor chain) burn directly.
+    pub fn run_epoch(
+        &self,
+        disclosures: &[ObservedDisclosure],
+        wellbecomings: &[ObservedWellbecoming],
+        falsifications: &[Falsification],
+    ) -> Vec<Datom> {
+        let mut out = Vec::new();
+        for d in disclosures {
+            if let Some(v) = ValidatedDisclosure::new(
+                d.did.clone(),
+                d.epoch,
+                d.n_validated,
+                d.citation_hits,
+                d.terminal_honest,
+                d.witness_quorum_met,
+            ) {
+                out.extend(v.mint_datom(&self.params, &self.graph));
+            }
+        }
+        for w in wellbecomings {
+            if let Some(v) =
+                ValidatedWellbecoming::new(w.did.clone(), w.epoch, w.delta, w.council_attested)
+            {
+                out.extend(v.datom(&self.params, &self.graph));
+            }
+        }
+        for f in falsifications {
+            out.extend(f.burn_datom(&self.params, &self.graph));
+        }
+        out
+    }
+}
+
 // ── Retainer allocation (the downstream of the loop, ADR-2606082100 §6) ───────
 //
 // Social capital is the DENOMINATOR of the donation pool: the epoch's
@@ -1033,6 +1117,59 @@ mod tests {
         let p = MintParams::default();
         let w = ValidatedWellbecoming::new(did("did:key:z"), 0, 0, true).unwrap();
         assert!(w.datom(&p, &did("g")).is_none());
+    }
+
+    // ── Mint job (validate → weigh → emit) ───────────────────────────────
+
+    #[test]
+    fn job_emits_datoms_for_valid_observations_only() {
+        let job = SocialMintJob::new(MintParams::default(), did("g:social"));
+        let a = did("did:key:a");
+        let b = did("did:key:b");
+        let disclosures = vec![
+            // valid: 2 validated + 5 hits = 2.5 pts
+            ObservedDisclosure {
+                did: a.clone(), epoch: 0, n_validated: 2, citation_hits: 5,
+                terminal_honest: true, witness_quorum_met: true,
+            },
+            // INVALID: no witness quorum → dropped
+            ObservedDisclosure {
+                did: b.clone(), epoch: 0, n_validated: 9, citation_hits: 9,
+                terminal_honest: true, witness_quorum_met: false,
+            },
+        ];
+        let wellbecomings = vec![
+            // valid +5 → 10 pts
+            ObservedWellbecoming { did: a.clone(), epoch: 0, delta: 5, council_attested: true },
+            // INVALID: not council-attested → dropped
+            ObservedWellbecoming { did: b.clone(), epoch: 0, delta: 99, council_attested: false },
+        ];
+        let datoms = job.run_epoch(&disclosures, &wellbecomings, &[]);
+        // only a's two valid acts emit (b dropped both)
+        assert_eq!(datoms.len(), 2);
+
+        let deltas: Vec<Delta> = datoms.into_iter().map(Delta::assert_datom).collect();
+        let mut v = SocialCapitalView::new();
+        v.apply(&deltas);
+        assert_eq!(v.capital(&a, 0), 12_500_000); // 2.5 + 10.0
+        assert_eq!(v.capital(&b, 0), 0); // all dropped
+    }
+
+    #[test]
+    fn job_falsification_burns() {
+        let job = SocialMintJob::new(MintParams::default(), did("g:social"));
+        let a = did("did:key:a");
+        // mint 5 pts then falsify 2 (burn 3) in the same epoch run
+        let disc = vec![ObservedDisclosure {
+            did: a.clone(), epoch: 0, n_validated: 5, citation_hits: 0,
+            terminal_honest: true, witness_quorum_met: true,
+        }];
+        let fals = vec![Falsification { did: a.clone(), epoch: 0, count: 2 }];
+        let datoms = job.run_epoch(&disc, &[], &fals);
+        let deltas: Vec<Delta> = datoms.into_iter().map(Delta::assert_datom).collect();
+        let mut v = SocialCapitalView::new();
+        v.apply(&deltas);
+        assert_eq!(v.capital(&a, 0), 2 * SCALE); // 5.0 minted − 3.0 burned
     }
 
     // ── Retainer allocation (the downstream of the loop) ──────────────────

--- a/crates/kotoba-server/src/social.rs
+++ b/crates/kotoba-server/src/social.rs
@@ -35,6 +35,36 @@ pub async fn settle_retainer_to_econ(econ: &Econ, credits: &[RetainerCredit]) ->
     total
 }
 
+use kotoba_kqe::datom::Datom;
+
+/// The I/O boundary for the social mint job (#3): a source that **observes** an
+/// epoch's validated social inputs. Real implementations call the anchor-chain
+/// `eth_getLogs` (terminal ClaimStakeEscrow state + slashes), the CitationLedger,
+/// and the KaizenObserver wellbecoming feed — all read-only (kotoba stays
+/// read+verify). This trait keeps `run_social_mint` testable with a fake source
+/// and isolates the (not-yet-wired) network I/O from the deterministic pipeline.
+pub trait SocialObservationSource {
+    fn disclosures(&self, epoch: u64) -> Vec<ObservedDisclosure>;
+    fn wellbecomings(&self, epoch: u64) -> Vec<ObservedWellbecoming>;
+    fn falsifications(&self, epoch: u64) -> Vec<Falsification>;
+}
+
+/// Server-side mint job orchestrator: observe an epoch via `src`, run the
+/// deterministic [`SocialMintJob`] pipeline (validate → weigh → emit), and return
+/// the `social/mint|burn` Datoms to commit. The caller transacts these into the
+/// Datom log — which feeds `SocialCapitalView` (the rest of the loop).
+pub fn run_social_mint(
+    job: &SocialMintJob,
+    src: &dyn SocialObservationSource,
+    epoch: u64,
+) -> Vec<Datom> {
+    job.run_epoch(
+        &src.disclosures(epoch),
+        &src.wellbecomings(epoch),
+        &src.falsifications(epoch),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -59,6 +89,44 @@ mod tests {
         assert_eq!(total, 1_000_000 - 1); // matches the example's settled total
         assert_eq!(econ.balance(&peggy.to_string()).await, 963_768);
         assert_eq!(econ.balance(&quinn.to_string()).await, 36_231);
+    }
+
+    /// Fake observation source — stands in for the (not-yet-wired) anchor-chain /
+    /// CitationLedger / KaizenObserver I/O so the orchestrator is testable.
+    struct FakeSource {
+        a: KotobaCid,
+    }
+    impl SocialObservationSource for FakeSource {
+        fn disclosures(&self, epoch: u64) -> Vec<ObservedDisclosure> {
+            vec![
+                ObservedDisclosure {
+                    did: self.a.clone(), epoch, n_validated: 2, citation_hits: 5,
+                    terminal_honest: true, witness_quorum_met: true,
+                },
+                // unvalidated → must be dropped by the pipeline
+                ObservedDisclosure {
+                    did: did("did:key:spam"), epoch, n_validated: 99, citation_hits: 0,
+                    terminal_honest: false, witness_quorum_met: false,
+                },
+            ]
+        }
+        fn wellbecomings(&self, epoch: u64) -> Vec<ObservedWellbecoming> {
+            vec![ObservedWellbecoming { did: self.a.clone(), epoch, delta: 5, council_attested: true }]
+        }
+        fn falsifications(&self, _epoch: u64) -> Vec<Falsification> {
+            vec![]
+        }
+    }
+
+    #[test]
+    fn run_social_mint_observes_validates_and_emits() {
+        let a = did("did:key:a");
+        let job = SocialMintJob::new(MintParams::default(), did("g:social"));
+        let src = FakeSource { a: a.clone() };
+        let datoms = run_social_mint(&job, &src, 0);
+        // a's valid disclosure (2.5) + wellbecoming (10.0) emit; spam dropped.
+        assert_eq!(datoms.len(), 2);
+        assert!(datoms.iter().all(|d| d.e == a)); // spam DID never emitted
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What
Follow-up #3 (with #5 already merged): the loop's **I/O entry** — RAW observations → validation gates → mint engine → `social/*` Datoms.

**kotoba-kqe (pure, deterministic):**
- `ObservedDisclosure` / `ObservedWellbecoming` — raw pre-validation observations.
- `SocialMintJob::run_epoch(disclosures, wellbecomings, falsifications) → Vec<Datom>` — drops anything failing its `Validated*` gate (no minting on assertion alone, §7); falsifications burn directly.

**kotoba-server (the I/O boundary):**
- `SocialObservationSource` trait — real impls call anchor-chain `eth_getLogs` (terminal escrow + slashes) + CitationLedger + KaizenObserver feed (read-only; the network wiring is a follow-up).
- `run_social_mint(job, src, epoch) → Datoms` to commit; the caller transacts them into the Datom log, which feeds `SocialCapitalView`.

## 動作検証
- kqe: valid observations emit (2.5 + 10.0 pts), an unvalidated one (no quorum / not council-attested) is **dropped**; falsification burns (5 minted − 3 burned = 2).
- server: a `FakeSource` (standing in for the network I/O) → `run_social_mint` observes → validates (drops spam) → emits exactly the valid agent's 2 Datoms.

kqe **38** + server **3** social tests green; build + clippy warning-free.

## Loop status
`observe (I/O) → run_social_mint → mint job → social/* Datoms → SocialCapitalView → SC_root → retainer → settle → Econ wallet`. Only the live network observation impls remain (endpoints not yet available).

🤖 Generated with [Claude Code](https://claude.com/claude-code)