### PR TITLE
feat(social): XRPC read surface — social.capital (ADR-2606082100 §5)

### DIFF
--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -24,6 +24,7 @@ pub mod realtime;
 pub mod server;
 pub mod signal_xrpc;
 pub mod social;
+pub mod social_xrpc;
 pub mod xrpc;
 
 use axum::{
@@ -1194,6 +1195,10 @@ pub fn build_router(state: Arc<KotobaState>) -> Router {
             post(kotobase_xrpc::handle_pre_revoke),
         )
         // ── Common Crawl vector search / RAG ───────────────────────────────
+        .route(
+            &format!("/xrpc/{}", social_xrpc::NSID_SOCIAL_CAPITAL),
+            get(social_xrpc::social_capital),
+        )
         .route(
             &format!("/xrpc/{}", cc_xrpc::NSID_CC_SEARCH),
             get(cc_xrpc::cc_search),

--- a/crates/kotoba-server/src/social_xrpc.rs
+++ b/crates/kotoba-server/src/social_xrpc.rs
@@ -1,0 +1,79 @@
+//! XRPC read surface for the social-capital ledger (ADR-2606082100 §5).
+//!
+//! `GET /xrpc/com.etzhayyim.apps.kotoba.social.capital?graph=<cid>&did=<cid>&epoch=<n>`
+//! → the decayed social capital of a DID at `epoch`. Read-only: it cold-scans the
+//! entity's `social/mint|burn` Datoms from the canonical log and folds them through
+//! [`SocialCapitalView`] (non-social Datoms are ignored by the reducer). `did` is
+//! the DID's entity CID (multibase); `graph` is the social graph CID.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::Deserialize;
+use serde_json::json;
+
+use kotoba_core::cid::KotobaCid;
+use kotoba_kqe::datom::Datom;
+use kotoba_kqe::delta::Delta;
+use kotoba_kqe::social::{SocialCapitalView, SCALE};
+
+use crate::server::KotobaState;
+
+pub const NSID_SOCIAL_CAPITAL: &str = "com.etzhayyim.apps.kotoba.social.capital";
+
+#[derive(Deserialize)]
+pub struct SocialCapitalQuery {
+    /// social graph CID (multibase).
+    pub graph: String,
+    /// the DID's entity CID (multibase).
+    pub did: String,
+    /// epoch to read the decayed balance at (default 0).
+    #[serde(default)]
+    pub epoch: u64,
+}
+
+pub async fn social_capital(
+    State(state): State<Arc<KotobaState>>,
+    Query(q): Query<SocialCapitalQuery>,
+) -> impl IntoResponse {
+    let Some(graph) = KotobaCid::from_multibase(&q.graph) else {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "invalid graph cid"}))).into_response();
+    };
+    let Some(did) = KotobaCid::from_multibase(&q.did) else {
+        return (StatusCode::BAD_REQUEST, Json(json!({"error": "invalid did cid"}))).into_response();
+    };
+
+    let quads = match state.quad_store.get_entity_quads_cold(&graph, &did).await {
+        Ok(qs) => qs,
+        Err(e) => {
+            return (StatusCode::INTERNAL_SERVER_ERROR, Json(json!({"error": e.to_string()})))
+                .into_response();
+        }
+    };
+
+    // Fold the entity's Datoms through the reducer; it keeps only social/mint|burn.
+    let deltas: Vec<Delta> = quads
+        .into_iter()
+        .map(|qd| Delta::assert_datom(Datom::from_legacy_quad(qd, true)))
+        .collect();
+    let mut view = SocialCapitalView::new();
+    view.apply(&deltas);
+    let smic = view.capital(&did, q.epoch);
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "did": q.did,
+            "graph": q.graph,
+            "epoch": q.epoch,
+            "capital_smic": smic,
+            "capital_points": smic as f64 / SCALE as f64,
+        })),
+    )
+        .into_response()
+}


### PR DESCRIPTION
## What
The read surface for the social-capital ledger:

`GET /xrpc/com.etzhayyim.apps.kotoba.social.capital?graph=<cid>&did=<cid>&epoch=<n>`
→ `{ did, graph, epoch, capital_smic, capital_points }`

Read-only: cold-scans the entity's `social/mint|burn` Datoms (`QuadStore::get_entity_quads_cold`) and folds them through `SocialCapitalView` (non-social Datoms are ignored by the reducer). Registered alongside the other `com.etzhayyim.apps.kotoba.*` routes.

## Verification
build + clippy warning-free; 421 server tests pass.

⚠️ One failing server test — `pre_proxy::operator_trusted_pre_roundtrip_end_to_end` (HPKE `reencrypt_for` at `pre_proxy.rs:409`) — is **pre-existing and unrelated**: `pre_proxy.rs` is byte-identical to `main` and this change is purely additive (new `social_xrpc` module + one route). Confirmed it fails in isolation independent of this diff (environmental HPKE issue in the sandbox).

## Loop status — now externally readable
`observe/decode → mint job → social/* Datoms → SocialCapitalView → SC_root → retainer → settle → Econ wallet`, with **`social.capital` XRPC** exposing the capital read. Remaining: live `eth_getLogs` RPC dispatch + KaizenObserver feed (running endpoints), and the `did ↔ cid` bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)