### PR TITLE
feat(social): live tick service + Murakumo fleet deployment (配線)

### DIFF
--- a/crates/kotoba-server/examples/social_economy_tick.rs
+++ b/crates/kotoba-server/examples/social_economy_tick.rs
@@ -1,0 +1,109 @@
+//! `social_economy_tick` — one cycle of the Mishmar social-capital loop, wired to
+//! live infrastructure (ADR-2606082100). Designed to run on a **Murakumo Mac mini
+//! fleet node** (which can reach the geth-private tunnel + the KaizenObserver feed),
+//! driven on a cadence by launchd (`deploy/social-economy/`).
+//!
+//! Run: `cargo run --example social_economy_tick -p kotoba-server`
+//!
+//! Env (live mode — all required, else it runs a built-in FAKE demo so the binary
+//! is always exercisable):
+//!   KOTOBA_EVM_RPC_URL          geth-private / Base L2 JSON-RPC (e.g. https://geth.etzhayyim.com)
+//!   KOTOBA_MISHMAR_ESCROW_ADDR  deployed MishmarBondEscrow address (0x…)
+//!   KOTOBA_SOCIAL_GRAPH_CID     social graph CID (multibase)
+//!   KOTOBA_KAIZEN_FEED_URL      KaizenObserver wellbecoming-Δ feed (provisional schema)
+//!   KOTOBA_RETAINER_POOL_MKOTO  this epoch's donation-funded retainer pool (default 1_000_000)
+//!   KOTOBA_OPERATOR_DID         operator DID for the Econ wallet (default did:web:etzhayyim.com)
+//!   KOTOBA_EVM_FROM_BLOCK/TO_BLOCK  log range (default 0x0 / latest)
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use kotoba_core::cid::KotobaCid;
+use kotoba_server::econ::Econ;
+use kotoba_server::social_economy::{fetch_kaizen_feed, live_evm_source, SocialEconomyDriver};
+use kotoba_kqe::social::MintParams;
+
+fn env(k: &str) -> Option<String> {
+    std::env::var(k).ok().filter(|s| !s.is_empty())
+}
+
+#[tokio::main]
+async fn main() {
+    let pool: i64 = env("KOTOBA_RETAINER_POOL_MKOTO")
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1_000_000);
+    let epoch = SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_secs() / 86_400).unwrap_or(0);
+    let operator = env("KOTOBA_OPERATOR_DID").unwrap_or_else(|| "did:web:etzhayyim.com".into());
+    let from_block = env("KOTOBA_EVM_FROM_BLOCK").unwrap_or_else(|| "0x0".into());
+    let to_block = env("KOTOBA_EVM_TO_BLOCK").unwrap_or_else(|| "latest".into());
+
+    let graph = env("KOTOBA_SOCIAL_GRAPH_CID")
+        .and_then(|s| KotobaCid::from_multibase(&s))
+        .unwrap_or_else(|| KotobaCid::from_bytes(b"g:social:default"));
+
+    println!("== social_economy_tick (epoch {epoch}, pool {pool} mKOTO) ==");
+
+    let live = live_evm_source(graph.clone());
+    let kaizen = fetch_kaizen_feed();
+
+    match (live, kaizen) {
+        (Some(evm), kaizen_feed) => {
+            // LIVE: observe chain + Kaizen, mint, settle, credit wallet.
+            let feed = kaizen_feed.unwrap_or_else(|| serde_json::json!([]));
+            let mut driver = SocialEconomyDriver::new(MintParams::default(), graph);
+            match driver.tick(&evm, &feed, &from_block, &to_block, epoch, pool) {
+                Ok((minted, result)) => {
+                    println!("LIVE: minted {} social Datoms; {} pinner credits; total {} mKOTO (remainder {})",
+                        minted.len(), result.credits.len(), result.total_mkoto, result.remainder_mkoto);
+                    let econ = Econ::from_env(operator);
+                    let credited = SocialEconomyDriver::settle_to_wallet(&econ, &result).await;
+                    println!("LIVE: credited {credited} mKOTO to the persisted wallet.");
+                    // NOTE: `minted` must be transacted to the canonical Datom log
+                    // (datomic.transact) so the view survives restart.
+                    println!("NOTE: transact {} minted Datoms to the log (datomic.transact).", minted.len());
+                }
+                Err(e) => {
+                    eprintln!("LIVE tick failed (is geth-private / the escrow reachable?): {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+        _ => {
+            // FAKE demo (no live env) — proves the binary runs; mirrors the unit test.
+            println!("(no KOTOBA_EVM_RPC_URL / escrow set — running FAKE demo)");
+            run_fake_demo(graph, epoch, pool).await;
+        }
+    }
+}
+
+async fn run_fake_demo(graph: KotobaCid, epoch: u64, pool: i64) {
+    use kotoba_kqe::datom::{Datom, Value};
+    use kotoba_kqe::social::{MintSource, ObservedDisclosure, SCALE};
+
+    let did = |s: &str| KotobaCid::from_bytes(s.as_bytes());
+    let cid_datom = |e: &KotobaCid, a: &str, v: &KotobaCid| {
+        Datom::assert(e.clone(), a.to_string(), Value::Cid(v.clone()), did("g"))
+    };
+    let a = did("did:key:a");
+    let peggy = did("did:key:peggy");
+
+    let mut driver = SocialEconomyDriver::new(MintParams::default(), graph);
+    driver.ingest_pins(&[
+        cid_datom(&did("pinA"), "mishmar/pin/pinner", &peggy),
+        cid_datom(&did("pinA"), "mishmar/pin/root", &did("rootA")),
+    ]);
+    driver.ingest_origins(&[cid_datom(&did("rootA"), "social/origin", &a)]);
+    driver.mint(
+        &[ObservedDisclosure { did: a.clone(), epoch, n_validated: 10, citation_hits: 0, terminal_honest: true, witness_quorum_met: true }],
+        &[],
+        &[],
+    );
+    let _ = MintSource::Disclosure;
+    let result = driver.settle(epoch, pool);
+    println!("FAKE: a's capital = {} pts; pinA → peggy gets {} mKOTO (remainder {})",
+        driver.view.capital(&a, epoch) / SCALE, result.total_mkoto, result.remainder_mkoto);
+    let econ = Econ::from_env("did:key:demo-operator".to_string());
+    let credited = SocialEconomyDriver::settle_to_wallet(&econ, &result).await;
+    println!("FAKE: credited {credited} mKOTO to peggy; balance now {}.",
+        econ.balance(&peggy.to_string()).await);
+    println!("== fake demo ok — set the KOTOBA_EVM_* env to run live on a fleet node ==");
+}

--- a/deploy/social-economy/README.md
+++ b/deploy/social-economy/README.md
@@ -1,0 +1,110 @@
+# Mishmar social-capital economy — Murakumo fleet deployment
+
+Runbook for wiring the social-capital economic loop (ADR-2606082100) to live
+infrastructure and running it on a **Murakumo Mac mini fleet node**. The node is
+the right host because it can reach (a) the geth-private tunnel and (b) the
+KaizenObserver feed; the loop is **read+verify only** (no inbound listener, no
+on-chain signing — settlement credits the internal mKOTO `Econ` wallet).
+
+```
+[geth-private 260425]──eth_getLogs──▶ Pinned/Slashed ──▶ PinIndex/OriginIndex
+[KaizenObserver]──feed (R0 schema)──▶ wellbecoming-Δ        did↔cid bridge attributes
+            └────────────────────┬──────────────────────────────┘
+   social_economy_tick:  SocialEconomyDriver.tick ─▶ mint ─▶ SocialCapitalView
+            ─▶ SC_root ─▶ retainer(§6) ─▶ settle ─▶ Econ wallet (persisted mKOTO)
+```
+
+## Status of the live endpoints (probe before deploying)
+
+```sh
+# geth-private RPC — expect {"result":"0x3f949"} (chainId 260425).
+curl -s -X POST https://geth.etzhayyim.com -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}'
+```
+
+As of 2026-06-09 this returned **HTTP 502** (CF Worker up, in-cluster geth /
+tunnel down). Bring geth-private back up (see
+`50-infra/vultr/geth-private/`) before the live tick can observe logs.
+
+## 1. Deploy `MishmarBondEscrow` to geth-private
+
+The contract is at `…/geth-private/contracts/src/MishmarBondEscrow.sol`
+(17 Foundry tests green). Constructor args:
+
+| arg | value (geth-private) |
+|---|---|
+| `bondToken` (GCC) | `0x8e9A5162b2800E0D19acC1708A531A3954900E21` |
+| `sbt` (Adherent SBT) | see `50-infra/etzhayyim-membership-contract/` deploy |
+| `charters` (compliance registry) | see `50-infra/etzhayyim-charters-compliance/` |
+| `retainerPool` | commons retainer Safe (Public Fund sub-account) |
+| `publicFund` | Public Fund Safe (`50-infra/etzhayyim-public-fund/`) |
+| `owner` | Council Safe |
+
+```sh
+cd 50-infra/vultr/geth-private/contracts
+SEALER=$(security find-generic-password -s "etzhayyim.private-chain" -a "SEALER_PRIV" -w)
+forge create src/MishmarBondEscrow.sol:MishmarBondEscrow \
+  --rpc-url https://geth.etzhayyim.com --private-key "$SEALER" \
+  --constructor-args \
+    0x8e9A5162b2800E0D19acC1708A531A3954900E21 \
+    <SBT_ADDR> <CHARTERS_ADDR> <RETAINER_POOL> <PUBLIC_FUND> <OWNER_SAFE>
+```
+
+Then register the witness set (`setWitness`, owner-only) — the Murakumo cell
+signer keys — and add `"storage-slash"` handling per the ADR. Record the
+deployed address in `…/geth-private/contracts/ADDRESSES.md`.
+
+> **Operator action.** This step uses the sealer key and writes on-chain — run it
+> yourself (it is intentionally not automated). The agent only prepared the
+> contract + tests + this runbook.
+
+## 2. Build the tick binary on the fleet node
+
+```sh
+cd <kotoba checkout>
+cargo build --release --example social_economy_tick -p kotoba-server
+install -m755 target/release/examples/social_economy_tick /Users/Shared/kotoba/bin/
+```
+
+## 3. Configure
+
+```sh
+mkdir -p /Users/Shared/kotoba/social-economy
+cp deploy/social-economy/social-economy.env.example /Users/Shared/kotoba/deploy/social-economy/social-economy.env
+# edit: KOTOBA_MISHMAR_ESCROW_ADDR (step 1), KOTOBA_SOCIAL_GRAPH_CID,
+#       KOTOBA_KAIZEN_FEED_URL, KOTOBA_TICK_BIN=/Users/Shared/kotoba/bin/social_economy_tick
+```
+
+Smoke-test one tick by hand (uses the env; falls back to a FAKE demo if unset):
+
+```sh
+KOTOBA_TICK_BIN=/Users/Shared/kotoba/bin/social_economy_tick \
+  sh deploy/social-economy/run-tick.sh
+```
+
+## 4. Install the launchd agent (one tick / epoch-day)
+
+```sh
+cp deploy/social-economy/run-tick.sh /Users/Shared/kotoba/deploy/social-economy/
+cp deploy/social-economy/com.etzhayyim.kotoba.social-economy.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.etzhayyim.kotoba.social-economy.plist
+# logs: /Users/Shared/kotoba/social-economy/tick.{log,err.log}
+```
+
+## 5. Verify
+
+- `tick.log` shows `LIVE: minted N social Datoms; … total … mKOTO`.
+- Read a DID's capital over XRPC (any kotoba node serving the graph):
+  `GET /xrpc/com.etzhayyim.apps.kotoba.social.capital?graph=<cid>&did=<cid>&epoch=<n>`.
+
+## Remaining R0 caveats
+
+- **KaizenObserver feed schema** (`KOTOBA_KAIZEN_FEED_URL`) is provisional —
+  reconcile `parse_kaizen_wellbecoming` against the live feed (ADR-2605240200).
+- **Disclosure/falsification observation** (ClaimStakeEscrow terminal events) is
+  not yet decoded — only pin observation + wellbecoming are wired; the tick passes
+  empty disclosures/falsifications until that decoder lands.
+- **Minted Datoms must be transacted** to the canonical Datom log (`datomic.transact`)
+  for the view to survive restart — the tick prints them; wire the transact next.
+- **eth_getLogs block range** is a full scan (`0x0..latest`); add a persisted
+  cursor for incremental observation at scale.

--- a/deploy/social-economy/com.etzhayyim.kotoba.social-economy.plist
+++ b/deploy/social-economy/com.etzhayyim.kotoba.social-economy.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  launchd agent for the Mishmar social-capital economy tick (ADR-2606082100),
+  to run on a Murakumo Mac mini fleet node (it can reach the geth-private tunnel
+  + the KaizenObserver feed). One tick per StartInterval (default 1 day = the
+  social-capital epoch); launchd owns the cadence, the binary is one-shot.
+
+  Install (per README.md):
+    cp com.etzhayyim.kotoba.social-economy.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.etzhayyim.kotoba.social-economy.plist
+  Edit the run-tick.sh path below to where this deploy/ dir lives on the node.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.etzhayyim.kotoba.social-economy</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/Shared/kotoba/deploy/social-economy/run-tick.sh</string>
+  </array>
+
+  <!-- one epoch = one day; launchd fires the one-shot tick on this cadence. -->
+  <key>StartInterval</key>
+  <integer>86400</integer>
+
+  <key>RunAtLoad</key>
+  <true/>
+
+  <key>StandardOutPath</key>
+  <string>/Users/Shared/kotoba/social-economy/tick.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/Shared/kotoba/social-economy/tick.err.log</string>
+
+  <!-- read+verify only; no inbound listener. -->
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>

--- a/deploy/social-economy/run-tick.sh
+++ b/deploy/social-economy/run-tick.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Wrapper for the launchd-driven social-economy tick (ADR-2606082100).
+# Sources the env file next to it, then execs the built tick binary.
+set -eu
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+ENV_FILE="${SOCIAL_ECONOMY_ENV:-$HERE/social-economy.env}"
+
+if [ -f "$ENV_FILE" ]; then
+  set -a
+  . "$ENV_FILE"
+  set +a
+else
+  echo "run-tick: no env file at $ENV_FILE — tick will run its FAKE demo" >&2
+fi
+
+BIN="${KOTOBA_TICK_BIN:-}"
+if [ -z "$BIN" ] || [ ! -x "$BIN" ]; then
+  echo "run-tick: KOTOBA_TICK_BIN not set / not executable ($BIN)" >&2
+  echo "  build it: cargo build --release --example social_economy_tick -p kotoba-server" >&2
+  exit 1
+fi
+
+exec "$BIN"

--- a/deploy/social-economy/social-economy.env.example
+++ b/deploy/social-economy/social-economy.env.example
@@ -1,0 +1,32 @@
+# Mishmar social-capital economy — tick service env (ADR-2606082100).
+# Copy to `social-economy.env` on the Murakumo Mac mini fleet node and fill in.
+# All KOTOBA_EVM_* + escrow + graph must be set for LIVE mode; otherwise the
+# tick binary runs a self-contained FAKE demo.
+
+# geth-private (chainId 260425) JSON-RPC, public tunnel. Base L2 for the anchor.
+KOTOBA_EVM_RPC_URL=https://geth.etzhayyim.com
+
+# Deployed MishmarBondEscrow address (see README — `forge create` step).
+KOTOBA_MISHMAR_ESCROW_ADDR=0x0000000000000000000000000000000000000000
+
+# Social graph CID (multibase) the social/* Datoms live under.
+KOTOBA_SOCIAL_GRAPH_CID=
+
+# KaizenObserver wellbecoming-Δ feed (PROVISIONAL schema — see parse_kaizen_wellbecoming).
+KOTOBA_KAIZEN_FEED_URL=
+
+# This epoch's donation-funded retainer pool (mKOTO). 1 KOTO = 1e9 mKOTO.
+KOTOBA_RETAINER_POOL_MKOTO=1000000
+
+# Operator DID for the persisted mKOTO wallet (Econ).
+KOTOBA_OPERATOR_DID=did:web:etzhayyim.com
+
+# eth_getLogs block range. R0 = full scan; replace with a persisted cursor later.
+KOTOBA_EVM_FROM_BLOCK=0x0
+KOTOBA_EVM_TO_BLOCK=latest
+
+# mKOTO wallet persistence dir (Econ writes econ-balances.json here).
+KOTOBA_STORE_PATH=/Users/Shared/kotoba/social-economy
+
+# Absolute path to the built tick binary (see README — `cargo build --release`).
+KOTOBA_TICK_BIN=/Users/Shared/kotoba/bin/social_economy_tick


### PR DESCRIPTION
## What (配線 — connect to running infrastructure)
The runnable wiring to live infrastructure, deployable on a **Murakumo Mac mini fleet node** (which can reach the geth-private tunnel + the KaizenObserver feed).

- **`examples/social_economy_tick.rs`** — one full loop cycle wired to live env (`live_evm_source` + `fetch_kaizen_feed` → `SocialEconomyDriver::tick` → `settle_to_wallet`). Falls back to a self-contained **FAKE demo** when env is unset, so the binary is always exercisable.
- **`deploy/social-economy/`** — launchd agent (one tick / epoch-day; `plutil`-valid) + `run-tick.sh` wrapper (sources env, execs binary) + `social-economy.env.example` + **README runbook** (deploy `MishmarBondEscrow` via `forge create` with the Keychain sealer key; configure; install launchd; verify via `social.capital` XRPC).

## Reachability probe (honest status)
- `geth.etzhayyim.com` `eth_chainId` → **HTTP 502** (CF Worker up, in-cluster geth / tunnel down). geth-private must come back up before live observation works.
- Murakumo LAN (`192.168.1.70:4000`) unreachable from the sandbox (not on the fleet LAN).

→ The live connection is an **on-fleet operator step**; this PR ships the artifact + runbook that runs there. The tick is **read+verify only** (no inbound listener, no on-chain signing — settlement credits the internal mKOTO `Econ`).

## 動作検証
- `social_economy_tick` runs end-to-end here (FAKE path): epoch from wall-clock (20613), `a` = 10 pts → pinA → peggy credited 1,000,000 mKOTO, persisted.
- `run-tick.sh` verified (sources env → execs binary); plist `plutil -lint` OK; clippy clean.

## Remaining (ops + R0 follow-ups, per README)
geth-private back up → deploy escrow → set env → install launchd. Plus: confirm KaizenObserver schema, decode ClaimStakeEscrow disclosure events, transact minted Datoms to the log, add a log-cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)