### PR TITLE
docs(deps): record kotoba sparql CLI default-graph quirk

### DIFF
--- a/deps.toml
+++ b/deps.toml
@@ -372,6 +372,34 @@ affects_files = [
 ]
 references    = ["F-3", "F-4"]
 
+[knowledge.sparql-cli-default-graph-mismatch]
+discovered_on = "2026-06-09"
+category      = "limitation"
+severity      = "low"
+status        = "open"
+summary       = "`kotoba sparql` CLI subcommand returns empty against kg.ingest/demo data — it resolves the default graph differently than `kotoba demo`'s internal sparql_req."
+details       = """
+`kotoba demo` (run_demo) ingests via `kg.ingest` into the authenticated kg
+graph (`kotobase-kg-v1`) and queries it with a JWT-shaped operator token
+(`demo_token()`), so its SELECT/ASK/DESCRIBE/CONSTRUCT return data. The
+standalone `kotoba sparql` subcommand (run_sparql) posts `graph: None` to
+`/xrpc/com.etzhayyim.apps.kotoba.graph.sparql`; with a non-JWT or absent
+token the server resolves the default graph to the empty PUBLIC graph
+instead of `kotobase-kg-v1`, so the query returns `"quads": []` even before
+any restart. This is a client-side default-graph + token-shape issue, NOT a
+persistence/query-engine fault — verified 2026-06-09: server B reloaded the
+committed head (`warm: resident db_before cache seeded graph=kotobase-kg-v1
+head=<commit-cid>`) on restart, and `kotoba demo` queries return the data.
+Repro: serve (KOTOBA_DEFAULT_VISIBILITY=public) → kotoba demo (count=1) →
+kotoba sparql 'SELECT * WHERE { ?s <kg/claim/role> ?o }' → empty.
+"""
+workaround    = "Use `kotoba demo` (self-authenticates) or pass a JWT-shaped operator token AND the explicit kg graph CID to `kotoba sparql --token <jwt> --graph <cid>`. Fix: run_sparql should default to the authenticated kg graph (kotobase-kg-v1) and/or upgrade a non-JWT token via demo_token() like sparql_req does."
+affects_files = [
+    "crates/kotoba-cli/src/main.rs",
+    "crates/kotoba-server/src/server.rs",
+]
+references    = ["run_sparql", "run_demo/sparql_req", "demo_token"]
+
 [knowledge.prolly-incremental-commit-and-diff]
 discovered_on = "2026-06-01"
 category      = "optimization"


### PR DESCRIPTION
Knowledge entry found during the 2026-06-09 persistence/query live verification.

`kotoba sparql` (run_sparql) posts `graph: None` and, with a non-JWT/absent token, the server resolves the default graph to the empty **public** graph instead of the authenticated `kotobase-kg-v1` — so it returns `"quads": []` against `kg.ingest`/`demo` data **even before any restart**. `kotoba demo`'s internal `sparql_req` instead targets `kotobase-kg-v1` with a JWT-shaped `demo_token()` and returns data.

This is a **client-side default-graph + token-shape issue, not a persistence/query-engine fault** — verified that server B reloaded the committed head (`warm: resident db_before cache seeded graph=kotobase-kg-v1 head=<commit-cid>`) on restart and `kotoba demo` queries return the data.

Adds `[knowledge.sparql-cli-default-graph-mismatch]` (severity low) with repro + workaround + suggested fix (run_sparql should default to the kg graph and/or upgrade non-JWT tokens like `sparql_req`). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)