### PR TITLE
feat(evm): kotoba-EVM R3 — Base anchor payload + logs/receipts/getLogs

### DIFF
--- a/crates/kotoba-evm/src/anchor.rs
+++ b/crates/kotoba-evm/src/anchor.rs
@@ -1,0 +1,108 @@
+//! kotoba-EVM R3 — Base L1 anchor payload (ADR-2606091500). Builds the
+//! `AnchorBridge.commitRoot(bytes32 rootHash, bytes ipfsCid, uint64 batchSize)`
+//! calldata that anchors a kotoba-EVM block's state root to Base L1 for
+//! tamper-evidence / fork-choice (reuses the existing `AnchorBridge`, ADR-2605172300).
+//!
+//! kotoba stays **read+verify**: it CONSTRUCTS the anchor calldata; the actual tx
+//! signing + Base submission is the operating-entity side (the relayer), exactly
+//! as `AnchorBridge`'s permissionless-commit + off-chain-relayer model intends.
+
+use kotoba_auth::eth::keccak256;
+use kotoba_core::cid::KotobaCid;
+
+/// `commitRoot(bytes32,bytes,uint64)` selector.
+pub fn commit_root_selector() -> [u8; 4] {
+    let h = keccak256(b"commitRoot(bytes32,bytes,uint64)");
+    [h[0], h[1], h[2], h[3]]
+}
+
+fn pad32(out: &mut Vec<u8>, bytes: &[u8]) {
+    // right-pad to a 32-byte word (ABI dynamic-tail data padding).
+    out.extend_from_slice(bytes);
+    let rem = bytes.len() % 32;
+    if rem != 0 {
+        out.extend(std::iter::repeat_n(0u8, 32 - rem));
+    }
+}
+
+fn word_u64(n: u64) -> [u8; 32] {
+    let mut w = [0u8; 32];
+    w[24..32].copy_from_slice(&n.to_be_bytes());
+    w
+}
+
+/// ABI-encode `commitRoot(rootHash, ipfsCid, batchSize)` calldata.
+///
+/// `root_hash` is the 32-byte state-root commitment (the low 32 bytes of the
+/// block's state-root CID hash); `ipfs_cid` is the block CID's raw multibase
+/// bytes (the DA pointer); `batch_size` is the tx count.
+pub fn commit_root_calldata(root_hash: &[u8; 32], ipfs_cid: &[u8], batch_size: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(4 + 32 * 4 + ipfs_cid.len());
+    out.extend_from_slice(&commit_root_selector());
+    // head (3 words, param order): rootHash, offset→ipfsCid tail, batchSize
+    out.extend_from_slice(root_hash); // word 0: bytes32
+    out.extend_from_slice(&word_u64(0x60)); // word 1: offset to dynamic tail = 3*32
+    out.extend_from_slice(&word_u64(batch_size)); // word 2: uint64
+    // tail: len(ipfsCid) + padded data
+    out.extend_from_slice(&word_u64(ipfs_cid.len() as u64));
+    pad32(&mut out, ipfs_cid);
+    out
+}
+
+/// Convenience: build the anchor calldata for a block from its state-root CID +
+/// block CID. The state-root commitment is the low 32 bytes of the CID's 36-byte
+/// content hash (`KotobaCid.0` = 4-byte prefix + 32-byte hash).
+pub fn anchor_block_calldata(state_root: &KotobaCid, block_cid: &KotobaCid, batch_size: u64) -> Vec<u8> {
+    let mut root_hash = [0u8; 32];
+    root_hash.copy_from_slice(&state_root.0[4..36]);
+    commit_root_calldata(&root_hash, block_cid.to_multibase().as_bytes(), batch_size)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selector_is_stable() {
+        // keccak256("commitRoot(bytes32,bytes,uint64)")[0..4]
+        let s = commit_root_selector();
+        // recompute independently to pin it.
+        let h = keccak256(b"commitRoot(bytes32,bytes,uint64)");
+        assert_eq!(s, [h[0], h[1], h[2], h[3]]);
+    }
+
+    #[test]
+    fn calldata_layout_is_abi_correct() {
+        let root = [0x11u8; 32];
+        let cid = b"bafyblock"; // 9 bytes
+        let data = commit_root_calldata(&root, cid, 7);
+
+        // 4 selector + 3 head words + 1 len word + 1 padded data word = 4 + 32*5
+        assert_eq!(data.len(), 4 + 32 * 5);
+        // head word 0 = rootHash
+        assert_eq!(&data[4..36], &root);
+        // head word 1 = offset 0x60
+        assert_eq!(data[4 + 32 + 31], 0x60);
+        // head word 2 = batchSize 7
+        assert_eq!(data[4 + 32 * 3 - 1], 7);
+        // tail len word = 9
+        assert_eq!(data[4 + 32 * 3 + 31], 9);
+        // tail data = the cid bytes, right-padded
+        assert_eq!(&data[4 + 32 * 4..4 + 32 * 4 + 9], cid);
+        assert!(data[4 + 32 * 4 + 9..].iter().all(|&b| b == 0), "zero padding");
+    }
+
+    #[test]
+    fn anchor_block_calldata_uses_state_root_hash() {
+        let sr = KotobaCid::from_bytes(b"state-root");
+        let blk = KotobaCid::from_bytes(b"block-1");
+        let data = anchor_block_calldata(&sr, &blk, 3);
+        // rootHash word = low 32 bytes of the state-root CID.
+        assert_eq!(&data[4..36], &sr.0[4..36]);
+        // ipfsCid tail = the block CID multibase bytes.
+        let mb = blk.to_multibase();
+        let len = mb.as_bytes().len();
+        assert_eq!(data[4 + 32 * 3 + 31] as usize, len);
+        assert_eq!(&data[4 + 32 * 4..4 + 32 * 4 + len], mb.as_bytes());
+    }
+}

--- a/crates/kotoba-evm/src/block.rs
+++ b/crates/kotoba-evm/src/block.rs
@@ -14,7 +14,9 @@ use kotoba_kqe::datom::Datom;
 use kotoba_kqe::delta::Delta;
 use kotoba_kqe::evm_state::EvmStateView;
 
+use crate::logs::logs_bloom;
 use crate::tx::apply_raw_tx;
+use crate::EvmLog;
 
 /// An EVM block header (content-addressed; `block_cid` is the block hash).
 #[derive(Debug, Clone)]
@@ -34,6 +36,10 @@ pub struct EvmBlock {
 pub struct ProducedBlock {
     pub block: EvmBlock,
     pub datoms: Vec<Datom>,
+    /// event logs emitted across the block's txs (for receipts / `eth_getLogs`).
+    pub logs: Vec<EvmLog>,
+    /// 2048-bit bloom over `logs` (block-level).
+    pub logs_bloom: [u8; 256],
     /// (index, reason) for each tx that failed to decode/execute (excluded).
     pub rejected: Vec<(usize, String)>,
 }
@@ -57,6 +63,7 @@ pub fn produce_block(
     );
 
     let mut diff: Vec<Datom> = Vec::new();
+    let mut logs: Vec<EvmLog> = Vec::new();
     let mut rejected: Vec<(usize, String)> = Vec::new();
     let mut applied = 0usize;
 
@@ -66,12 +73,14 @@ pub fn produce_block(
                 // fold this tx's diff into the evolving view so the next tx sees it.
                 view.apply(&out.datoms.iter().cloned().map(Delta::assert_datom).collect::<Vec<_>>());
                 diff.extend(out.datoms);
+                logs.extend(out.logs);
                 applied += 1;
             }
             Ok((_tx, out)) => rejected.push((i, format!("reverted (gas {})", out.gas_used))),
             Err(e) => rejected.push((i, e)),
         }
     }
+    let bloom = logs_bloom(&logs);
 
     let state_root = view.state_root();
     let parent_tag = parent.as_ref().map(|c| c.to_multibase()).unwrap_or_default();
@@ -84,6 +93,8 @@ pub fn produce_block(
     ProducedBlock {
         block: EvmBlock { number, parent, timestamp, tx_count: applied, state_root, block_cid },
         datoms: diff,
+        logs,
+        logs_bloom: bloom,
         rejected,
     }
 }

--- a/crates/kotoba-evm/src/lib.rs
+++ b/crates/kotoba-evm/src/lib.rs
@@ -10,8 +10,10 @@
 //! diff. Signed-tx RLP decode + sender recovery (`eth_sendRawTransaction`) and block
 //! production / DA / L1 anchor are R1b/R2+ (ADR roadmap).
 
+pub mod anchor;
 pub mod block;
 pub mod chain;
+pub mod logs;
 pub mod tx;
 
 use kotoba_core::cid::KotobaCid;
@@ -84,6 +86,24 @@ impl<'a> DatabaseRef for DatomDatabase<'a> {
     }
 }
 
+/// An EVM event log emitted during execution (for receipts / `eth_getLogs`, R3).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EvmLog {
+    pub address: [u8; 20],
+    pub topics: Vec<[u8; 32]>,
+    pub data: Vec<u8>,
+}
+
+impl EvmLog {
+    fn from_revm(log: &revm::primitives::Log) -> Self {
+        Self {
+            address: log.address.into_array(),
+            topics: log.data.topics().iter().map(|t| (*t).into()).collect(),
+            data: log.data.data.to_vec(),
+        }
+    }
+}
+
 /// Outcome of executing one message-call transaction over the Datom state.
 pub struct ExecOutcome {
     pub success: bool,
@@ -92,6 +112,8 @@ pub struct ExecOutcome {
     pub datoms: Vec<Datom>,
     /// Return data (for `eth_call`).
     pub output: Vec<u8>,
+    /// Event logs emitted (for receipts / `eth_getLogs`).
+    pub logs: Vec<EvmLog>,
 }
 
 /// Execute a message call (`from` → `to`, `value`, `data`) against the
@@ -134,8 +156,9 @@ pub fn apply_call(
         ExecutionResult::Halt { gas_used, .. } => (false, *gas_used, Vec::new()),
     };
 
+    let logs: Vec<EvmLog> = result.logs().iter().map(EvmLog::from_revm).collect();
     let datoms = state_to_datoms(&state, graph);
-    Ok(ExecOutcome { success, gas_used, datoms, output })
+    Ok(ExecOutcome { success, gas_used, datoms, output, logs })
 }
 
 /// Convert revm's post-execution state into `evm/*` Datoms (the block's state diff).
@@ -252,5 +275,25 @@ mod tests {
         assert_eq!(info.balance, U256::from(500u64));
         // unknown account → None
         assert!(db.basic_ref(Address::from(addr(0x99))).unwrap().is_none());
+    }
+
+    #[test]
+    fn contract_call_captures_logs() {
+        // bytecode: PUSH1 0x00, PUSH1 0x00, LOG0, STOP — emits one empty log.
+        let code = vec![0x60, 0x00, 0x60, 0x00, 0xa0, 0x00];
+        let codehash = kotoba_auth::eth::keccak256(&code);
+        let c = addr(0xC0);
+        let caller = addr(0xAA);
+
+        let mut datoms = mk_account(&caller, 0, &u256(1_000_000), None, &graph());
+        datoms.extend(mk_account(&c, 1, &u256(0), Some((&codehash, &code)), &graph()));
+        let view = view_with(datoms);
+
+        let out = apply_call(&view, caller, c, U256::ZERO, vec![], 0, 100_000, &graph())
+            .expect("contract call");
+        assert!(out.success, "LOG0 contract call should succeed");
+        assert_eq!(out.logs.len(), 1, "LOG0 emits exactly one log");
+        assert_eq!(out.logs[0].address, c, "log emitted by the contract");
+        assert!(out.logs[0].topics.is_empty(), "LOG0 → no topics");
     }
 }

--- a/crates/kotoba-evm/src/logs.rs
+++ b/crates/kotoba-evm/src/logs.rs
@@ -1,0 +1,121 @@
+//! kotoba-EVM R3 — receipts, logs bloom, and `eth_getLogs` filtering over the
+//! event logs revm emits during execution (ADR-2606091500).
+
+use kotoba_auth::eth::keccak256;
+
+use crate::EvmLog;
+
+/// A transaction receipt: status + gas + the logs it emitted + the per-receipt bloom.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Receipt {
+    pub success: bool,
+    pub gas_used: u64,
+    pub logs: Vec<EvmLog>,
+    pub logs_bloom: [u8; 256],
+}
+
+impl Receipt {
+    pub fn new(success: bool, gas_used: u64, logs: Vec<EvmLog>) -> Self {
+        let logs_bloom = logs_bloom(&logs);
+        Self { success, gas_used, logs, logs_bloom }
+    }
+}
+
+/// Ethereum 2048-bit logs bloom over a set of logs: every log address and every
+/// topic contributes 3 bits (derived from `keccak256(item)`), matching the
+/// yellow-paper `M3:2048` bloom so standard `eth_getLogs` bloom pre-filtering works.
+pub fn logs_bloom(logs: &[EvmLog]) -> [u8; 256] {
+    let mut bloom = [0u8; 256];
+    for log in logs {
+        add_to_bloom(&mut bloom, &log.address);
+        for t in &log.topics {
+            add_to_bloom(&mut bloom, t);
+        }
+    }
+    bloom
+}
+
+fn add_to_bloom(bloom: &mut [u8; 256], item: &[u8]) {
+    let h = keccak256(item);
+    // three 11-bit indices from the first three 16-bit big-endian pairs of the hash.
+    for pair in 0..3 {
+        let bit = (((h[pair * 2] as usize) << 8) | h[pair * 2 + 1] as usize) & 0x7ff;
+        // MSB-first: bit 0 → highest bit of the last byte (yellow-paper convention).
+        let byte_index = 256 - 1 - (bit / 8);
+        let bit_in_byte = bit % 8;
+        bloom[byte_index] |= 1u8 << bit_in_byte;
+    }
+}
+
+/// `eth_getLogs`-style filter over a block's logs: keep logs whose address matches
+/// (when `address` is `Some`) AND whose first topic matches (when `topic0` is `Some`).
+pub fn filter_logs<'a>(
+    logs: &'a [EvmLog],
+    address: Option<&[u8; 20]>,
+    topic0: Option<&[u8; 32]>,
+) -> Vec<&'a EvmLog> {
+    logs.iter()
+        .filter(|l| address.is_none_or(|a| &l.address == a))
+        .filter(|l| topic0.is_none_or(|t| l.topics.first() == Some(t)))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn addr(t: u8) -> [u8; 20] {
+        let mut a = [0u8; 20];
+        a[19] = t;
+        a
+    }
+    fn topic(t: u8) -> [u8; 32] {
+        let mut a = [0u8; 32];
+        a[31] = t;
+        a
+    }
+
+    #[test]
+    fn bloom_contains_logged_address_and_topic() {
+        let log = EvmLog { address: addr(0xAA), topics: vec![topic(0x01)], data: vec![] };
+        let bloom = logs_bloom(&[log]);
+        // a single-item bloom over the same address must match its own bits.
+        let mut probe = [0u8; 256];
+        add_to_bloom(&mut probe, &addr(0xAA));
+        for (i, &b) in probe.iter().enumerate() {
+            assert_eq!(bloom[i] & b, b, "address bits present in bloom at byte {i}");
+        }
+        // an unrelated address is (almost surely) not fully present.
+        let mut other = [0u8; 256];
+        add_to_bloom(&mut other, &addr(0xBB));
+        let fully = other.iter().enumerate().all(|(i, &b)| bloom[i] & b == b);
+        assert!(!fully, "unrelated address should not be fully set");
+    }
+
+    #[test]
+    fn filter_by_address_and_topic() {
+        let logs = vec![
+            EvmLog { address: addr(0x01), topics: vec![topic(0xAA)], data: vec![] },
+            EvmLog { address: addr(0x02), topics: vec![topic(0xBB)], data: vec![] },
+            EvmLog { address: addr(0x01), topics: vec![topic(0xBB)], data: vec![] },
+        ];
+        assert_eq!(filter_logs(&logs, Some(&addr(0x01)), None).len(), 2);
+        assert_eq!(filter_logs(&logs, None, Some(&topic(0xBB))).len(), 2);
+        assert_eq!(filter_logs(&logs, Some(&addr(0x01)), Some(&topic(0xBB))).len(), 1);
+        assert_eq!(filter_logs(&logs, None, None).len(), 3);
+        assert_eq!(filter_logs(&logs, Some(&addr(0x09)), None).len(), 0);
+    }
+
+    #[test]
+    fn receipt_carries_bloom() {
+        let logs = vec![EvmLog { address: addr(0xAA), topics: vec![], data: vec![] }];
+        let r = Receipt::new(true, 21000, logs.clone());
+        assert!(r.success);
+        assert_eq!(r.logs_bloom, logs_bloom(&logs));
+    }
+
+    #[test]
+    fn empty_logs_zero_bloom() {
+        assert_eq!(logs_bloom(&[]), [0u8; 256]);
+    }
+}


### PR DESCRIPTION
## What
The in-crate-verifiable half of R3 (the live Base tx send + the `eth_getLogs` RPC endpoint stay operating-entity/infra side):

- **`anchor.rs`** — `commit_root_calldata` / `anchor_block_calldata`: ABI-encodes the existing **`AnchorBridge.commitRoot(bytes32 rootHash, bytes ipfsCid, uint64 batchSize)`** calldata for a block (`rootHash` = low-32 of the state-root CID, `ipfsCid` = block CID multibase, `batchSize` = tx count). kotoba **builds** the payload; the relayer signs + submits to Base (read+verify boundary, matching AnchorBridge's permissionless-commit + off-chain-relayer model).
- **`logs.rs`** — revm event logs → `Receipt` + Ethereum **2048-bit `logs_bloom`** (yellow-paper M3:2048) + **`filter_logs`** (`eth_getLogs`-style address/topic0 filter).
- `ExecOutcome` / `ProducedBlock` now carry **logs** (+ block-level `logs_bloom`); `apply_call` captures `result.logs()`; `produce_block` aggregates per block.

## 動作検証
21 `kotoba-evm` tests green (8 new): anchor selector + ABI layout + block calldata; bloom membership; filter by addr/topic0; receipt bloom; empty bloom; and an **e2e LOG0-contract call that captures one log** (revm log capture verified). clippy clean.

## Roadmap
R0✅ R1✅ R1b✅ R2✅ R2.5✅ **R3 (payload+logs)✅** · remaining R3: live `AnchorBridge` submit (Base) + `eth_getLogs` over the chain via the RPC server → R4 redeploy escrows + retire geth-private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)