### PR TITLE
feat(evm): contract creation + forge-create deploys to kotoba-EVM (R4-prep)

### DIFF
--- a/crates/kotoba-evm/src/lib.rs
+++ b/crates/kotoba-evm/src/lib.rs
@@ -118,6 +118,8 @@ pub struct ExecOutcome {
     pub output: Vec<u8>,
     /// Event logs emitted (for receipts / `eth_getLogs`).
     pub logs: Vec<EvmLog>,
+    /// For a contract-creation tx: the deployed contract address.
+    pub created: Option<[u8; 20]>,
 }
 
 /// Execute a message call (`from` → `to`, `value`, `data`) against the
@@ -162,7 +164,55 @@ pub fn apply_call(
 
     let logs: Vec<EvmLog> = result.logs().iter().map(EvmLog::from_revm).collect();
     let datoms = state_to_datoms(&state, graph);
-    Ok(ExecOutcome { success, gas_used, datoms, output, logs })
+    Ok(ExecOutcome { success, gas_used, datoms, output, logs, created: None })
+}
+
+/// Execute a **contract-creation** tx (`from` deploys `init_code`) against the
+/// Datom state (the `eth_sendRawTransaction` CREATE path / `forge create`). Returns
+/// the deployed contract address in `ExecOutcome.created` + the `evm/*` state diff
+/// (which includes the new contract's code + the deployer's nonce/balance).
+#[allow(clippy::too_many_arguments)]
+pub fn apply_create(
+    view: &EvmStateView,
+    from: [u8; 20],
+    value: U256,
+    init_code: Vec<u8>,
+    nonce: u64,
+    gas_limit: u64,
+    graph: &KotobaCid,
+) -> Result<ExecOutcome, String> {
+    let db = DatomDatabase::new(view);
+    let mut evm = Evm::builder()
+        .with_ref_db(db)
+        .modify_tx_env(|tx| {
+            tx.caller = Address::from(from);
+            tx.transact_to = TxKind::Create;
+            tx.value = value;
+            tx.data = Bytes::from(init_code);
+            tx.gas_limit = gas_limit;
+            tx.gas_price = U256::ZERO;
+            tx.nonce = Some(nonce);
+            tx.chain_id = None;
+        })
+        .build();
+
+    let ResultAndState { result, state } = evm.transact().map_err(|e| format!("{e:?}"))?;
+
+    let (success, gas_used, output, created) = match &result {
+        ExecutionResult::Success { gas_used, output, .. } => {
+            let created = match output {
+                revm::primitives::Output::Create(_, Some(a)) => Some(a.into_array()),
+                _ => None,
+            };
+            (true, *gas_used, output.data().to_vec(), created)
+        }
+        ExecutionResult::Revert { gas_used, output } => (false, *gas_used, output.to_vec(), None),
+        ExecutionResult::Halt { gas_used, .. } => (false, *gas_used, Vec::new(), None),
+    };
+
+    let logs: Vec<EvmLog> = result.logs().iter().map(EvmLog::from_revm).collect();
+    let datoms = state_to_datoms(&state, graph);
+    Ok(ExecOutcome { success, gas_used, datoms, output, logs, created })
 }
 
 /// Convert revm's post-execution state into `evm/*` Datoms (the block's state diff).

--- a/crates/kotoba-evm/src/tx.rs
+++ b/crates/kotoba-evm/src/tx.rs
@@ -214,17 +214,28 @@ pub fn apply_raw_tx(
     graph: &KotobaCid,
 ) -> Result<(RecoveredTx, ExecOutcome), String> {
     let tx = decode_and_recover(raw)?;
-    let to = tx.to.ok_or_else(|| "contract creation not supported at R1b".to_string())?;
-    let out = crate::apply_call(
-        view,
-        tx.from,
-        to,
-        tx.value,
-        tx.input.clone(),
-        tx.nonce,
-        tx.gas_limit,
-        graph,
-    )?;
+    let out = match tx.to {
+        Some(to) => crate::apply_call(
+            view,
+            tx.from,
+            to,
+            tx.value,
+            tx.input.clone(),
+            tx.nonce,
+            tx.gas_limit,
+            graph,
+        )?,
+        // contract creation (`to` empty) → deploy init_code (R4 / forge create).
+        None => crate::apply_create(
+            view,
+            tx.from,
+            tx.value,
+            tx.input.clone(),
+            tx.nonce,
+            tx.gas_limit,
+            graph,
+        )?,
+    };
     Ok((tx, out))
 }
 

--- a/crates/kotoba-evm/tests/deploy_real_contract.rs
+++ b/crates/kotoba-evm/tests/deploy_real_contract.rs
@@ -1,0 +1,19 @@
+//! Integration: deploy a real solc-compiled contract (Hello.sol) via apply_create
+//! over the Datom-backed EVM — the same initcode `forge create` deploys (ADR-2606091500).
+
+#[test]
+fn deploys_real_solc_contract() {
+    use kotoba_core::cid::KotobaCid;
+    use kotoba_kqe::delta::Delta;
+    use kotoba_kqe::evm_state::{account_datoms, EvmStateView};
+    use kotoba_evm::{apply_create, RevmU256 as U256};
+    let g = KotobaCid::from_bytes(b"g:evm");
+    let mut from=[0u8;20]; from.copy_from_slice(&hex::decode("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266").unwrap());
+    let mut bal=[0u8;32]; bal[16..].copy_from_slice(&(10_000u128*1_000_000_000_000_000_000u128).to_be_bytes());
+    let mut v=EvmStateView::new();
+    v.apply(&account_datoms(&from,0,&bal,None,&g).into_iter().map(Delta::assert_datom).collect::<Vec<_>>());
+    let init=hex::decode("6080604052602a60005534801561001557600080fd5b50610184806100256000396000f3fe608060405234801561001057600080fd5b50600436106100365760003560e01c80630c55699c1461003b57806360fe47b114610059575b600080fd5b610043610075565b60405161005091906100d5565b60405180910390f35b610073600480360381019061006e9190610121565b61007b565b005b60005481565b806000819055507fdf7a95aebff315db1b7716215d602ab537373cdb769232aae6055c06e798425b816040516100b191906100d5565b60405180910390a150565b6000819050919050565b6100cf816100bc565b82525050565b60006020820190506100ea60008301846100c6565b92915050565b600080fd5b6100fe816100bc565b811461010957600080fd5b50565b60008135905061011b816100f5565b92915050565b600060208284031215610137576101366100f0565b5b60006101458482850161010c565b9150509291505056fea2646970667358221220c7505a77636d7eb0788e3a1a086c6985cad6d8fdf23855225a8498af77412ea664736f6c63430008170033").unwrap();
+    let out=apply_create(&v,from,U256::ZERO,init,0,30_000_000,&g).expect("exec");
+    eprintln!("deploy success={} gas={} created={:?} output_len={}", out.success, out.gas_used, out.created.map(hex::encode), out.output.len());
+    assert!(out.success, "deploy reverted");
+}

--- a/crates/kotoba-server/src/evm_rpc.rs
+++ b/crates/kotoba-server/src/evm_rpc.rs
@@ -15,7 +15,10 @@ use tokio::sync::RwLock;
 
 use kotoba_auth::eth::keccak256;
 use kotoba_core::cid::KotobaCid;
-use kotoba_evm::{apply_call, tx::apply_raw_tx, RevmU256 as U256};
+use std::collections::HashMap;
+
+use kotoba_evm::logs::logs_bloom;
+use kotoba_evm::{apply_call, apply_create, tx::apply_raw_tx, RevmU256 as U256};
 use kotoba_kqe::delta::Delta;
 use kotoba_kqe::evm_state::{
     account_datoms, eth_chain_id, eth_get_balance, eth_get_code, eth_get_storage_at,
@@ -28,11 +31,13 @@ pub struct EvmNode {
     pub chain_id: u64,
     pub block_number: u64,
     graph: KotobaCid,
+    /// txhash → receipt JSON (so `forge` can poll `eth_getTransactionReceipt`).
+    receipts: HashMap<String, Value>,
 }
 
 impl EvmNode {
     pub fn new(chain_id: u64, graph: KotobaCid) -> Self {
-        Self { view: EvmStateView::new(), chain_id, block_number: 0, graph }
+        Self { view: EvmStateView::new(), chain_id, block_number: 0, graph, receipts: HashMap::new() }
     }
 
     pub fn default_node() -> Self {
@@ -62,6 +67,14 @@ fn parse_addr(v: &Value) -> Option<[u8; 20]> {
         a.copy_from_slice(&b);
         a
     })
+}
+
+/// A call object's calldata: accept both `input` (modern) and `data` (legacy alias).
+fn call_input(call: &Value) -> Vec<u8> {
+    call.get("input")
+        .or_else(|| call.get("data"))
+        .and_then(parse_hex_bytes)
+        .unwrap_or_default()
 }
 
 fn parse_hex_bytes(v: &Value) -> Option<Vec<u8>> {
@@ -116,7 +129,7 @@ pub fn dispatch(node: &mut EvmNode, method: &str, params: &Value) -> Result<Valu
             let to = parse_addr(call.get("to").unwrap_or(&Value::Null))
                 .ok_or_else(|| bad("eth_call: invalid 'to'"))?;
             let from = call.get("from").and_then(parse_addr).unwrap_or([0u8; 20]);
-            let data = call.get("data").and_then(parse_hex_bytes).unwrap_or_default();
+            let data = call_input(&call);
             let value = call
                 .get("value")
                 .and_then(parse_b32)
@@ -129,16 +142,104 @@ pub fn dispatch(node: &mut EvmNode, method: &str, params: &Value) -> Result<Valu
         }
         "eth_sendRawTransaction" => {
             let raw = parse_hex_bytes(&p(0)).ok_or_else(|| bad("invalid raw tx"))?;
-            let (_tx, out) =
+            let (tx, out) =
                 apply_raw_tx(&node.view, &raw, &node.graph).map_err(|e| (-32000, e))?;
             if !out.success {
-                return Err((-32000, "transaction reverted".into()));
+                return Err((
+                    -32000,
+                    format!(
+                        "tx failed (gas_used={}, gas_limit={}, output=0x{})",
+                        out.gas_used,
+                        tx.gas_limit,
+                        hex::encode(&out.output)
+                    ),
+                ));
             }
-            // persist the diff into the node state + advance the block number.
+            let txhash = format!("0x{}", hex::encode(keccak256(&raw)));
+            // persist the diff + advance the block; record a receipt for polling.
             node.apply(out.datoms);
             node.block_number += 1;
-            Ok(json!(format!("0x{}", hex::encode(keccak256(&raw))))) // tx hash
+            let block_number = node.block_number;
+            let log_json: Vec<Value> = out
+                .logs
+                .iter()
+                .enumerate()
+                .map(|(i, l)| {
+                    json!({
+                        "address": format!("0x{}", hex::encode(l.address)),
+                        "topics": l.topics.iter().map(|t| format!("0x{}", hex::encode(t))).collect::<Vec<_>>(),
+                        "data": format!("0x{}", hex::encode(&l.data)),
+                        "blockNumber": format!("0x{block_number:x}"),
+                        "transactionHash": txhash,
+                        "logIndex": format!("0x{i:x}"),
+                    })
+                })
+                .collect();
+            let receipt = json!({
+                "transactionHash": txhash,
+                "transactionIndex": "0x0",
+                "blockNumber": format!("0x{block_number:x}"),
+                "blockHash": format!("0x{block_number:064x}"),
+                "from": format!("0x{}", hex::encode(tx.from)),
+                "to": tx.to.map(|a| format!("0x{}", hex::encode(a))),
+                "contractAddress": out.created.map(|a| format!("0x{}", hex::encode(a))),
+                "cumulativeGasUsed": format!("0x{:x}", out.gas_used),
+                "gasUsed": format!("0x{:x}", out.gas_used),
+                "effectiveGasPrice": "0x0",
+                "status": "0x1",
+                "type": "0x0",
+                "logs": log_json,
+                "logsBloom": format!("0x{}", hex::encode(logs_bloom(&out.logs))),
+            });
+            node.receipts.insert(txhash.clone(), receipt);
+            Ok(json!(txhash))
         }
+        "eth_getTransactionReceipt" => {
+            let h = p(0);
+            let key = h.as_str().unwrap_or("");
+            Ok(node.receipts.get(key).cloned().unwrap_or(Value::Null))
+        }
+        "eth_estimateGas" => {
+            let call = p(0);
+            let from = call.get("from").and_then(parse_addr).unwrap_or([0u8; 20]);
+            let data = call_input(&call);
+            let value = call.get("value").and_then(parse_b32).map(U256::from_be_bytes).unwrap_or(U256::ZERO);
+            let nonce = node.view.nonce_of(&from);
+            let gas = match parse_addr(call.get("to").unwrap_or(&Value::Null)) {
+                Some(to) => apply_call(&node.view, from, to, value, data, nonce, 30_000_000, &node.graph),
+                None => apply_create(&node.view, from, value, data, nonce, 30_000_000, &node.graph),
+            }
+            .map(|o| o.gas_used)
+            .unwrap_or(21_000);
+            // 25% headroom (forge uses the estimate as the gas limit).
+            Ok(json!(format!("0x{:x}", gas + gas / 4 + 21_000)))
+        }
+        "eth_getBlockByNumber" | "eth_getBlockByHash" => {
+            let n = node.block_number;
+            Ok(json!({
+                "number": format!("0x{n:x}"),
+                "hash": format!("0x{n:064x}"),
+                "parentHash": format!("0x{:064x}", n.saturating_sub(1)),
+                "timestamp": "0x0",
+                "gasLimit": "0x1c9c380",
+                "gasUsed": "0x0",
+                "baseFeePerGas": "0x0",
+                "miner": "0x0000000000000000000000000000000000000000",
+                "difficulty": "0x0",
+                "totalDifficulty": "0x0",
+                "transactions": [],
+                "uncles": [],
+            }))
+        }
+        "eth_maxPriorityFeePerGas" => Ok(json!("0x0")),
+        "eth_accounts" => Ok(json!([])),
+        "eth_syncing" => Ok(json!(false)),
+        "eth_feeHistory" => Ok(json!({
+            "oldestBlock": format!("0x{:x}", node.block_number),
+            "baseFeePerGas": ["0x0", "0x0"],
+            "gasUsedRatio": [0.0],
+            "reward": [["0x0"]],
+        })),
         other => Err((-32601, format!("method not found: {other}"))),
     }
 }


### PR DESCRIPTION
## What
**A real solc-compiled Solidity contract now deploys to geth-less kotoba-EVM via `forge create`.**

- **kotoba-evm**: `apply_create` (`TxKind::Create` over the Datom state → deployed address + `evm/*` diff incl. the new contract's code); `ExecOutcome.created`; `apply_raw_tx` routes `to=None` → CREATE. Integration test deploys the real `Hello.sol` initcode.
- **kotoba-server::evm_rpc**: `eth_sendRawTransaction` records a **receipt** (status / contractAddress / gasUsed / logs / logsBloom); adds `eth_getTransactionReceipt` / `eth_estimateGas` (runs the call/create to size gas) / `eth_getBlockByNumber` / `eth_maxPriorityFeePerGas` / `eth_feeHistory` / `eth_accounts` / `eth_syncing`. **Fix**: `eth_call`/`eth_estimateGas` read calldata from `input` OR `data` (forge uses `input`; reading only `data` mis-estimated CREATE gas → OOG).

## 動作検証 (live, end-to-end)
`forge create src/Hello.sol:Hello --legacy` against `cargo run --example evm_node`:
```
Deployed to:  0x5FbDB2315678afecb367f032d93F642f64180aa3
eth_getCode   → 0x6080604052…  (runtime bytecode)
cast call x() → 42
```
**solc → forge → kotoba Datom log → cast — no geth.** 21 kotoba-evm + 1 integration + 4 evm_rpc tests green; clippy clean.

## Roadmap
R0–R3 ✅ + JSON-RPC ✅ + node ✅ + **CREATE / forge-deploy ✅**. R4 is now mechanical: `forge create` GCC + the escrows against the node + genesis-seed, repoint the Mishmar tick, retire geth-private (ops). Remaining in-crate: live Base anchor submit; `eth_getLogs` over EvmChain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)