### PR TITLE
fix(turn): commit missing kotoba-turn crate files (origin/main build was broken)

### DIFF
--- a/crates/kotoba-turn/Cargo.toml
+++ b/crates/kotoba-turn/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kotoba-turn"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Kotoba TURN relay — ephemeral-credential auth core (HMAC-SHA1, coturn use-auth-secret scheme). See docs/ADR-turn-relay.md."
+
+[dependencies]
+hmac      = { workspace = true }
+sha1      = { workspace = true }
+base64    = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/kotoba-turn/src/lib.rs
+++ b/crates/kotoba-turn/src/lib.rs
@@ -1,0 +1,134 @@
+//! TURN relay — ephemeral-credential authentication core.
+//!
+//! Implements the coturn `use-auth-secret` scheme (the de-facto WebRTC standard,
+//! RFC-7635 flavored) used by `kotoba` real-media calls. A short-lived credential
+//! is an expiry-prefixed, room/player-scoped username signed with a shared secret:
+//!
+//! ```text
+//! username   = "<expiry_unix>:<room>:<player>"
+//! credential = base64( HMAC_SHA1( RT_TURN_SECRET, username ) )
+//! ```
+//!
+//! This is the SAME wire format the browser SDK mints in
+//! `@etzhayyim/kami-engine-sdk/call` (`mintTurnCredential` / `verifyTurnCredential`);
+//! the RFC 2202 test vector below pins both implementations to identical bytes, so
+//! a credential minted in the control plane verifies here and vice versa.
+//!
+//! v0 scope: the auth core only. STUN/TURN message codec, allocations, and the
+//! UDP/TCP/TLS listeners are deferred to a later phase (see `docs/ADR-turn-relay.md`).
+
+use base64::Engine as _;
+use hmac::{Hmac, Mac};
+use sha1::Sha1;
+
+type HmacSha1 = Hmac<Sha1>;
+
+const B64: base64::engine::general_purpose::GeneralPurpose = base64::engine::general_purpose::STANDARD;
+
+/// HMAC-SHA1 of `message` under `secret`, base64 (standard alphabet, padded).
+pub fn hmac_sha1_base64(secret: &str, message: &str) -> String {
+    let mut mac = HmacSha1::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+    mac.update(message.as_bytes());
+    B64.encode(mac.finalize().into_bytes())
+}
+
+/// A minted TURN credential, ready to hand to a client's `iceServers`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Credential {
+    pub username: String,
+    pub credential: String,
+    /// Absolute expiry, unix seconds.
+    pub expires_at: u64,
+}
+
+/// Mint a credential valid until `expires_at` (unix seconds). Server-side only —
+/// `secret` must never reach a browser.
+pub fn mint(secret: &str, room: &str, player: u32, expires_at: u64) -> Credential {
+    let username = format!("{expires_at}:{room}:{player}");
+    let credential = hmac_sha1_base64(secret, &username);
+    Credential { username, credential, expires_at }
+}
+
+/// The room/player a verified credential authorizes.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Scope {
+    pub room: String,
+    pub player: u32,
+    pub expires_at: u64,
+}
+
+/// Why a credential was rejected. Mirrors the SDK's `VerifyTurnResult.reason`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum AuthError {
+    #[error("malformed username")]
+    Malformed,
+    #[error("bad expiry")]
+    BadExpiry,
+    #[error("expired")]
+    Expired,
+    #[error("bad signature")]
+    BadSignature,
+}
+
+/// Verify a credential exactly as the relay's `Allocate` handler must: structure,
+/// expiry, then a constant-time HMAC check. `now` is unix seconds.
+pub fn verify(secret: &str, username: &str, credential: &str, now: u64) -> Result<Scope, AuthError> {
+    let parts: Vec<&str> = username.split(':').collect();
+    if parts.len() != 3 {
+        return Err(AuthError::Malformed);
+    }
+    let expires_at: u64 = parts[0].parse().map_err(|_| AuthError::BadExpiry)?;
+    let player: u32 = parts[2].parse().map_err(|_| AuthError::Malformed)?;
+    if expires_at < now {
+        return Err(AuthError::Expired);
+    }
+    // Constant-time: decode the presented MAC and let `verify_slice` compare.
+    let presented = B64.decode(credential).map_err(|_| AuthError::BadSignature)?;
+    let mut mac = HmacSha1::new_from_slice(secret.as_bytes()).map_err(|_| AuthError::BadSignature)?;
+    mac.update(username.as_bytes());
+    mac.verify_slice(&presented).map_err(|_| AuthError::BadSignature)?;
+    Ok(Scope { room: parts[1].to_string(), player, expires_at })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hmac_matches_rfc2202_and_the_js_sdk() {
+        // RFC 2202 §3 case 2: key="Jefe", data="what do ya want for nothing?".
+        // Identical base64 to the SDK's turn.test.ts — pins cross-impl interop.
+        assert_eq!(
+            hmac_sha1_base64("Jefe", "what do ya want for nothing?"),
+            "7/zfauXrL6LSdBbV8YTfnCWafHk=",
+        );
+    }
+
+    #[test]
+    fn mint_then_verify_recovers_scope() {
+        let c = mint("k", "room-1", 7, 1_700_000_600);
+        assert_eq!(c.username, "1700000600:room-1:7");
+        let scope = verify("k", &c.username, &c.credential, 1_700_000_000).unwrap();
+        assert_eq!(scope, Scope { room: "room-1".into(), player: 7, expires_at: 1_700_000_600 });
+    }
+
+    #[test]
+    fn rejects_expired() {
+        let c = mint("k", "r", 1, 1_700_000_060);
+        assert_eq!(verify("k", &c.username, &c.credential, 1_700_000_061), Err(AuthError::Expired));
+    }
+
+    #[test]
+    fn rejects_tampered_and_wrong_secret() {
+        let c = mint("k", "r", 1, 1_700_000_600);
+        let tampered = format!("{}A", c.credential);
+        assert_eq!(verify("k", &c.username, &tampered, 1_700_000_000), Err(AuthError::BadSignature));
+        assert_eq!(verify("WRONG", &c.username, &c.credential, 1_700_000_000), Err(AuthError::BadSignature));
+    }
+
+    #[test]
+    fn rejects_malformed_username() {
+        assert_eq!(verify("k", "no-colons", "x", 0), Err(AuthError::Malformed));
+        assert_eq!(verify("k", "1700000600:r", "x", 0), Err(AuthError::Malformed));
+    }
+}

--- a/docs/ADR-turn-relay.md
+++ b/docs/ADR-turn-relay.md
@@ -1,0 +1,153 @@
+# ADR — Pure-Rust TURN relay for real-media calls (`kotoba-turn`)
+
+Status: **Proposed**
+Context: 1:1 real-media WebRTC calling shipped as `@etzhayyim/kami-engine-sdk/call`
+(browser owns the media plane; `kotoba-rt` relays SDP/ICE). STUN alone is not
+enough for production — this ADR specifies the relay that closes the gap.
+
+## 1. Problem
+
+A WebRTC call needs an ICE path between peers. With only STUN (host +
+server-reflexive candidates), ~10–20% of real-world pairs fail to connect:
+symmetric NAT, carrier-grade NAT (CGNAT), and restrictive corporate firewalls
+have no direct path. The fix is a **TURN relay** (RFC 8656 / RFC 5766): a server
+both peers can reach that forwards their media. It is the single biggest blocker
+to taking 1:1 calls beyond LAN/demo.
+
+`kotoba-net` already runs a libp2p **QUIC** stack, but that is the data/graph
+transport — it does not speak STUN/TURN and a browser `RTCPeerConnection` cannot
+use it as an ICE server. TURN is its own UDP/TCP/TLS protocol and must be served
+as such.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- A pure-Rust TURN server crate `kotoba-turn` (no coturn dependency), consistent
+  with the existing Rust/WASM stack and our supply-chain story.
+- Short-lived, per-room credentials so a leaked credential cannot relay forever.
+- Deployable on a `donated-mesh` supernode (the same tier that would later host
+  an SFU), not required to be browser-local.
+- A clean client contract: the call SDK receives `iceServers` (incl. TURN) and
+  needs no other change.
+
+**Non-goals**
+- Not an SFU. TURN only relays a peer-to-peer flow; multi-party fan-out is a
+  separate ADR (pure-Rust SFU).
+- Not PSTN/SIP media. Telecom interconnect stays a separate track.
+- No TURN-over-QUIC experiment in v1 (RFC interest exists; defer).
+
+## 3. Design
+
+### 3.1 Crate `kotoba-turn`
+
+```
+crates/kotoba-turn/
+  src/
+    stun.rs       # RFC 8489 message codec (types, attributes, MESSAGE-INTEGRITY, FINGERPRINT)
+    auth.rs       # long-term credential + ephemeral HMAC credential (RFC-7635 style)
+    allocation.rs # 5-tuple allocations, relay-address pool, permissions, channels
+    server.rs     # UDP + TCP listeners, allocation lifecycle, refresh/timeout
+    lib.rs
+```
+
+Recommended base: build on the well-audited **`webrtc-rs/turn`** + `stun`
+crates rather than hand-rolling the STUN codec (matches the pure-Rust SFU choice
+of `str0m`/`webrtc-rs`). `kotoba-turn` wraps them with our auth and config.
+
+### 3.2 Transports
+
+- **UDP** `:3478` — primary relay transport.
+- **TCP** `:3478` — fallback for UDP-blocked networks.
+- **TLS (TURNS)** `:5349` — required to traverse firewalls that only allow 443;
+  reuse the node's existing TLS cert. (`turns:host:443?transport=tcp` is the
+  candidate that gets through almost everywhere.)
+
+### 3.3 Authentication — ephemeral credentials
+
+Do **not** ship static TURN passwords. Mirror the coturn `use-auth-secret`
+scheme (the de-facto WebRTC standard, RFC 7635 flavored), keyed off the SAME
+shared secret the realtime control plane already uses:
+
+```
+username  = "<expiry_unix>:<room>:<player>"     # expiry-prefixed, room/player scoped
+password  = base64( HMAC_SHA1( RT_TURN_SECRET, username ) )
+```
+
+The Worker (or node) that already mints room tokens (`RT_TOKEN_SECRET`) gains a
+sibling `RT_TURN_SECRET` and a tiny endpoint returning
+`{ urls, username, credential, ttl }`. `kotoba-turn` validates the HMAC and the
+expiry on every allocation — no per-user state, no database. A credential is
+typically valid for the call's lifetime + slack (e.g. ttl 1h).
+
+### 3.4 Allocation lifecycle
+
+Standard TURN: `Allocate` → `CreatePermission` / `ChannelBind` → relayed data →
+`Refresh` (keepalive) → timeout/`Refresh(lifetime=0)` to free. Enforce per-node:
+- max allocations, max bytes/s and total bytes per allocation (anti-abuse),
+- idle timeout (default 600 s, refreshed by client keepalive),
+- relay-port range bounded to a configured pool.
+
+## 4. Client contract (call SDK)
+
+Already supported — `createKotobaCall({ iceServers })`. The app fetches
+ephemeral creds and passes:
+
+```ts
+const { urls, username, credential } = await fetch('/xrpc/…turn.creds').then(r => r.json());
+const call = createKotobaCall({
+  endpoint, room, player, token,
+  iceServers: [
+    { urls: 'stun:stun.l.google.com:19302' },
+    { urls, username, credential }, // e.g. ["turn:node:3478","turns:node:443?transport=tcp"]
+  ],
+});
+```
+
+`iceTransportPolicy: 'relay'` can be set to force-test the TURN path in CI/staging.
+
+## 5. Deployment
+
+- Runs on a public-IP `donated-mesh` supernode (needs a routable address; pure
+  browser-local nodes cannot serve TURN).
+- One relay per region keeps RTT low; the creds endpoint returns the nearest.
+- Metrics: active allocations, relayed bytes, allocation failures, auth
+  rejections → existing observability.
+
+## 6. Phasing
+
+0. **v0 auth core — DONE.** `crates/kotoba-turn` ships `mint` / `verify` /
+   `hmac_sha1_base64` (HMAC-SHA1, expiry + scope, constant-time check). A shared
+   RFC 2202 vector pins it byte-for-byte to the SDK's `mintTurnCredential`, so a
+   credential minted in either runtime verifies in the other. No network layer
+   yet (deps: `hmac` + `sha1` + `base64` only).
+1. **v0 listeners** — wrap `webrtc-rs/turn`, UDP + TCP, wire the auth core into
+   the `Allocate` handler, single node, env-configured. Creds endpoint in the
+   control plane.
+2. **v1** — TLS/TURNS on 443, quotas + idle GC, metrics, multi-region creds.
+3. **v2** — co-locate with the pure-Rust SFU supernode; shared auth + deploy.
+
+## 7. Testing
+
+- Unit: STUN codec round-trips; HMAC cred accept/reject incl. expiry.
+- Integration: spin `kotoba-turn` in-process; drive an `Allocate` →
+  `ChannelBind` → relayed datagram loopback over UDP and TCP.
+- E2E: two headless Chromium with `iceTransportPolicy:'relay'` forced to the
+  local relay — proves the SDK ↔ relay contract end to end.
+
+## 8. Security
+
+- Constant-time HMAC verify; reject expired/wrong-room/wrong-player usernames.
+- Bind relay ports to the configured pool only; never relay to private/loopback
+  ranges (SSRF guard).
+- Per-allocation byte/rate quotas to bound abuse; alarm on auth-reject spikes.
+- `RT_TURN_SECRET` is node-side only; rotate independently of `RT_TOKEN_SECRET`.
+
+## 9. Alternatives considered
+
+- **coturn** — battle-tested but a C dependency that breaks the pure-Rust /
+  supply-chain story; rejected for the default path (still a valid stop-gap).
+- **TURN over the existing QUIC stack** — appealing reuse, but browsers can't
+  use it as an ICE server today; deferred.
+- **Public/managed TURN (Twilio, Cloudflare Calls)** — fastest to working
+  calls; acceptable interim, but recurring cost and an external dependency the
+  donated-mesh model is meant to avoid.


### PR DESCRIPTION
## What
`origin/main`'s workspace `Cargo.toml` lists **`crates/kotoba-turn`** as a member, but the crate files (`Cargo.toml` + `src/lib.rs`) and `docs/ADR-turn-relay.md` were **never committed** — leaving them untracked. A fresh checkout therefore **fails to build**:
```
error: failed to load manifest for workspace member `crates/kotoba-turn`
```
This commits the missing files to complete the half-landed change and restore a buildable `origin/main`.

`kotoba-turn` = pure-Rust TURN relay ephemeral-credential auth core (HMAC-SHA1, coturn `use-auth-secret`) per `docs/ADR-turn-relay.md`.

## Verification
`cargo build -p kotoba-turn` ✓, **5 tests green**, clippy clean. Scoped to exactly the two untracked paths (no other working-tree changes swept in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)