### PR TITLE
chore(coverage): add cargo-llvm-cov harness + fix pre_proxy date-rot test

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,17 @@ cargo test --workspace                  # ~1184 tests pass
 cargo build --release -p kotoba-cli     # final `kotoba` binary
 ```
 
+## Coverage
+
+```bash
+./scripts/coverage.sh        # per-crate + total line/region coverage (lib tests)
+./scripts/coverage.sh html   # browsable report at target/llvm-cov/html/index.html
+./scripts/coverage.sh lcov   # lcov.info for CI / codecov upload
+```
+
+Requires `cargo install cargo-llvm-cov` and a rustup toolchain (the script pins
+to `rustup run stable` because Homebrew rust ships no `llvm-tools`).
+
 ## ADR
 
 Design decisions live in

--- a/crates/kotoba-server/src/pre_proxy.rs
+++ b/crates/kotoba-server/src/pre_proxy.rs
@@ -374,7 +374,11 @@ mod tests {
                 iss: accessor_did.clone(),
                 aud: "kotoba://test".into(),
                 issued_at: "2026-05-31T00:00:00Z".into(),
-                expiry: None,
+                // Explicit far-future expiry → DelegationChain::verify takes the
+                // `exp` branch and skips the `issued_at` 7-day max-age cap, same as
+                // the happy-path fixture above (was a date-rot time bomb: started
+                // failing 2026-06-07 once `now` passed issued_at + MAX_CACAO_AGE_SECS).
+                expiry: Some("2099-12-31T23:59:59Z".into()),
                 nonce: "e2e-roundtrip-nonce".into(),
                 domain: "kotoba.test".into(),
                 statement: None,

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# kotoba workspace test coverage via cargo-llvm-cov
+# Usage:
+#   ./scripts/coverage.sh                 # summary table (per-crate + total, --lib tests)
+#   ./scripts/coverage.sh html            # + HTML report at target/llvm-cov/html/index.html
+#   ./scripts/coverage.sh lcov            # + lcov.info at target/llvm-cov/lcov.info (CI / codecov)
+#
+# Requires: cargo-llvm-cov (cargo install cargo-llvm-cov) + rustup llvm-tools.
+# NOTE: Homebrew rust has no llvm-tools component — we pin the run to the
+# rustup stable toolchain so llvm-cov/llvm-profdata versions match rustc.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+if ! command -v rustup >/dev/null; then
+  echo "error: rustup not found (Homebrew rust lacks llvm-tools; install rustup)" >&2
+  exit 1
+fi
+if ! rustup run stable cargo llvm-cov --version >/dev/null 2>&1; then
+  echo "error: cargo-llvm-cov not found — install with: cargo install cargo-llvm-cov" >&2
+  exit 1
+fi
+rustup component add llvm-tools-preview >/dev/null 2>&1 || true
+
+MODE="${1:-summary}"
+case "$MODE" in
+  summary)
+    exec rustup run stable cargo llvm-cov --workspace --lib --summary-only
+    ;;
+  html)
+    rustup run stable cargo llvm-cov --workspace --lib --html
+    echo "HTML report: target/llvm-cov/html/index.html"
+    ;;
+  lcov)
+    rustup run stable cargo llvm-cov --workspace --lib --lcov --output-path target/llvm-cov/lcov.info
+    echo "lcov report: target/llvm-cov/lcov.info"
+    ;;
+  *)
+    echo "usage: $0 [summary|html|lcov]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Adds `scripts/coverage.sh` — repeatable workspace coverage via cargo-llvm-cov with `summary` / `html` / `lcov` modes, pinned to `rustup run stable` (Homebrew rust has no llvm-tools). Documented in README §Coverage.
- First measured baseline (lib tests, 2026-06-11): **78.75% line / 79.37% region / 76.05% function**. Lowest spots: kotoba-clj, kotoba-ingest, and the b2_* store paths at 0% in lib-test scope; kubo_store 37%; wasm_pregel 47%; signal_xrpc 57%.
- Fixes a date-rot time bomb the measurement flushed out: the `pre_proxy::operator_trusted_pre_roundtrip_end_to_end` fixture used a hardcoded `issued_at: 2026-05-31` CACAO with no expiry, so the 7-day `MAX_CACAO_AGE_SECS` cap made it fail from 2026-06-07 onward. Applied the same far-future-expiry fix the happy-path fixture in this file already carries.

## Test plan
- `cargo test -p kotoba-server --lib pre_proxy` → 4/4 pass
- `./scripts/coverage.sh` → full workspace lib suite green, summary table produced

🤖 Generated with [Claude Code](https://claude.com/claude-code)