### PR TITLE
ci: add GitHub Actions workspace lib-test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,4 +24,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run workspace lib tests
-        run: cargo test --workspace --lib
+        # .cargo/config.toml pins build.target = aarch64-apple-darwin for local
+        # Apple Silicon dev; an explicit --target with the runner's host triple
+        # overrides that pin (and its target-scoped rustflags) so CI builds
+        # natively on any runner.
+        run: cargo test --workspace --lib --target "$(rustc -vV | sed -n 's/^host: //p')"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: test
+# First CI for this repo: build + run the workspace lib test suite (the same
+# scope ./scripts/coverage.sh measures — verified green at 78.75% line
+# coverage baseline, 2026-06-11). Integration tests that need a live Kubo
+# daemon stay out of scope here; fmt/clippy gates can be added once the tree
+# is clean for them.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lib-tests:
+    name: cargo test --workspace --lib
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run workspace lib tests
+        run: cargo test --workspace --lib


### PR DESCRIPTION
## Summary
First CI for this repo. The recent audit found the ~2,100-test suite was only ever run by hand — no regression detection at ~150 commits/week — and the coverage work in #104 flushed out a date-rot test failure that had been silently red locally since 2026-06-07. This adds a single path-light workflow:

- `cargo test --workspace --lib` on every PR and push to `main` (the same scope `./scripts/coverage.sh` measures, verified green at the 78.75%-line baseline)
- `Swatinem/rust-cache` so warm runs don't rebuild the full 31-crate workspace
- concurrency-cancel on superseded pushes

Kubo-dependent integration tests and fmt/clippy gates are deliberate follow-ups (the tree isn't clean for fmt yet).

## Test plan
- `cargo test --workspace --lib` green locally (with #104's pre_proxy fix)
- This PR's own CI run exercises the workflow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)