### PR TITLE
perf(server): current_db_for_graph serves from the resident datomic_live_slot

### DIFF
--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -2259,11 +2259,6 @@ fn db_from_kqe_datoms(datoms: Vec<kotoba_kqe::Datom>) -> kotoba_datomic::Db {
     kotoba_datomic::Db::from_datoms(datoms, basis_t)
 }
 
-fn db_from_datomic_history(datoms: Vec<kotoba_datomic::Datom>) -> kotoba_datomic::Db {
-    let basis_t = datoms.last().map(|d| d.t.clone());
-    kotoba_datomic::Db::from_datoms(datoms, basis_t)
-}
-
 pub(crate) fn distributed_graph_ipns_name(graph_cid: &kotoba_core::cid::KotobaCid) -> String {
     format!("k51-kotoba-{}", graph_cid.to_multibase())
 }
@@ -3218,17 +3213,70 @@ pub(crate) async fn current_db_for_graph(
     state: &KotobaState,
     graph_cid: &kotoba_core::cid::KotobaCid,
 ) -> Result<kotoba_datomic::Db, (StatusCode, String)> {
-    let reader = DistributedDatomReader::new(&*state.block_store, &*state.ipns_registry);
-    let distributed_history = reader
-        .history_for_name(&distributed_graph_ipns_name(graph_cid))
-        .map_err(|e| {
-            (
+    // Resident fast path (read-side completion of the kotoba#19 / ADR-2605302130
+    // write-scaling fix): every consumer of this helper (cc.status, search.web,
+    // kg.*, media, email, attestation, mcp — 20 call sites) previously paid a
+    // FULL commit-chain replay (`history_for_name` → O(total-history) block
+    // reads + Db rebuild) on EVERY request, while `datomic.transact` and
+    // `datomic.q` already served from the per-graph resident `datomic_live_slot`.
+    // Empirically (2026-06-11, ADR-2606111900): at ~30k datoms cc.status took
+    // 325 s and search.web 333 s, CPU-bound in this cold load.
+    //
+    // On a head match we clone the resident current-state Db (O(state) memcpy,
+    // ms); on a miss we pay ONE `db_from_head` (CEAVT covering-index fast path,
+    // O(state) not O(history)) and re-seed the slot, so the next read — and the
+    // next transact's `db_before` — are cache hits. The cached Db is the same
+    // `db_from_head` value the transact path maintains, so the slot stays
+    // coherent across both paths.
+    //
+    // Semantics: callers only consume the CURRENT view (`db.datoms()` — see all
+    // 20 call sites); none call `db.history()` (history consumers go through
+    // `require_distributed_datomic_history_db`). `Db::datoms()` nets retractions
+    // via `current_datoms`, so a Db built from the netted CEAVT scan and one
+    // built from full history yield the identical current view.
+    let ipns_name = distributed_graph_ipns_name(graph_cid);
+    match state.ipns_registry.resolve(&IpnsName::new(ipns_name)) {
+        Ok(head_record) => {
+            if let Some(head_cid) =
+                kotoba_core::cid::KotobaCid::from_multibase(&head_record.value)
+            {
+                let graph_mb = graph_cid.to_multibase();
+                let live_slot = state.datomic_live_slot(&graph_mb);
+                // Held across read-or-rebuild + reseed so a concurrent transact
+                // on the same graph serialises against us (same discipline as
+                // `try_resident_datomic_q` and the transact db_before section).
+                let mut live_guard = live_slot.lock().await;
+                if let Some(live) = live_guard.as_ref() {
+                    if live.head == head_cid {
+                        return Ok(live.db.clone());
+                    }
+                }
+                state
+                    .datomic_cold_db_loads
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let reader =
+                    DistributedDatomReader::new(&*state.block_store, &*state.ipns_registry);
+                let db = reader.db_from_head(&head_cid).map_err(|e| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        format!("distributed datomic read: {e}"),
+                    )
+                })?;
+                *live_guard = Some(crate::server::LiveDatomicGraph {
+                    head: head_cid,
+                    db: db.clone(),
+                });
+                return Ok(db);
+            }
+        }
+        // No committed head yet — fall through to the local QuadStore view.
+        Err(IpnsRegistryError::NotFound(_)) => {}
+        Err(e) => {
+            return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("distributed datomic read: {e}"),
-            )
-        })?;
-    if !distributed_history.is_empty() {
-        return Ok(db_from_datomic_history(distributed_history));
+                format!("ipns resolve: {e}"),
+            ))
+        }
     }
 
     let mut datoms = state
@@ -10732,6 +10780,90 @@ mod tests {
         }
         assert_ne!(c1, c2);
         assert_ne!(c2, c3);
+    }
+
+    /// Read-side resident cache (ADR-2606111900 finding): `current_db_for_graph`
+    /// — the helper behind cc.status / search.web / kg.* / media / attestation —
+    /// must serve from the same per-graph `datomic_live_slot` the transact path
+    /// maintains, paying at most ONE cold `db_from_head` after a restart instead
+    /// of a full commit-chain replay on EVERY request (measured 325 s cc.status /
+    /// 333 s search.web at ~30k datoms before this fix).
+    #[tokio::test]
+    async fn current_db_for_graph_serves_from_resident_cache() {
+        use std::sync::atomic::Ordering;
+        std::env::set_var("KOTOBA_IPFS", "off");
+        std::env::set_var("KOTOBA_IPNS_REQUIRE_SIGNATURE", "false");
+        let state = Arc::new(KotobaState::new(None).unwrap());
+        let graph = KotobaCid::from_bytes(b"read-resident-cache-graph");
+        let graph_mb = graph.to_multibase();
+
+        let c1 = run_transact_for_cache_test(
+            &state,
+            &graph_mb,
+            r#"[[:db/add "alice" :person/name "Alice"]]"#,
+        )
+        .await;
+
+        // Simulate a restart: IPNS head + blocks survive, resident cache is gone.
+        state.datomic_live.lock().unwrap().clear();
+        let cold_before = state.datomic_cold_db_loads.load(Ordering::Relaxed);
+
+        // First read after restart: exactly one cold load, slot re-seeded.
+        let db = crate::xrpc::current_db_for_graph(&state, &graph).await.unwrap();
+        assert!(
+            db.datoms()
+                .iter()
+                .any(|d| d.a == ":person/name"
+                    && d.v == kotoba_edn::EdnValue::string("Alice")),
+            "read must surface the committed datom"
+        );
+        assert_eq!(
+            state.datomic_cold_db_loads.load(Ordering::Relaxed),
+            cold_before + 1,
+            "first read after restart pays exactly one cold load"
+        );
+        {
+            let slot = state.datomic_live_slot(&graph_mb);
+            let g = slot.lock().await;
+            assert_eq!(
+                g.as_ref().expect("read must re-seed the slot").head.to_multibase(),
+                c1
+            );
+        }
+
+        // Second read: resident HIT — no new cold load.
+        let db = crate::xrpc::current_db_for_graph(&state, &graph).await.unwrap();
+        assert!(db
+            .datoms()
+            .iter()
+            .any(|d| d.v == kotoba_edn::EdnValue::string("Alice")));
+        assert_eq!(
+            state.datomic_cold_db_loads.load(Ordering::Relaxed),
+            cold_before + 1,
+            "warm read must hit the resident cache"
+        );
+
+        // A transact advances the head AND the slot (write path re-seeds);
+        // the next read must see the new state with still no extra cold load.
+        let c2 = run_transact_for_cache_test(
+            &state,
+            &graph_mb,
+            r#"[[:db/add "bob" :person/name "Bob"]]"#,
+        )
+        .await;
+        assert_ne!(c1, c2);
+        let db = crate::xrpc::current_db_for_graph(&state, &graph).await.unwrap();
+        assert!(
+            db.datoms()
+                .iter()
+                .any(|d| d.v == kotoba_edn::EdnValue::string("Bob")),
+            "read after transact must see the advanced head"
+        );
+        assert_eq!(
+            state.datomic_cold_db_loads.load(Ordering::Relaxed),
+            cold_before + 1,
+            "read after a local transact stays a cache hit (slot re-seeded by the write path)"
+        );
     }
 
     /// ADR-2605302130 startup-warm: prove the resident `db_before` cache can be


### PR DESCRIPTION
## Problem

`current_db_for_graph` — the helper behind `cc.status`, `search.web`, `kg.*`, media, email, attestation and mcp reads (**20 call sites**) — paid a FULL commit-chain replay (`history_for_name` → O(total-history) block reads + Db rebuild) on **every request**, while `datomic.transact` and `datomic.q` already served from the per-graph resident `datomic_live_slot` (kotoba#19 / ADR-2605302130 — that fix covered the write path and `datomic.q` only).

Measured on a live node at ~30k datoms (etzhayyim ADR-2606111900, 2026-06-11): **`cc.status` 325 s, `search.web` 333 s**, commits degrading 21 ms → 9 s as the corpus grew.

## Fix

Resolve the IPNS head locally (registry lookup); on a slot head match return a clone of the resident current-state Db (O(state) memcpy, ms); on a miss pay **one** `db_from_head` (CEAVT covering-index fast path — O(state), not O(history)) and re-seed the slot. Same lock discipline as `try_resident_datomic_q` and the transact `db_before` critical section, so reads, writes, and `datomic.q` now share one coherent resident cache. Graphs with no committed head fall through to the local QuadStore view unchanged.

**Semantics**: all 20 call sites consume only the current view (`db.datoms()`, which nets retractions via `current_datoms`); `.history()` consumers go through `require_distributed_datomic_history_db` and are untouched. `db_from_datomic_history` became unused and is removed.

## Tests

- New `current_db_for_graph_serves_from_resident_cache`: exactly one cold load after a simulated restart (cache cleared, IPNS + blocks intact), warm reads hit, reads after a local transact remain hits (write path re-seeds).
- `kotoba-server --lib`: **420 passed**, 1 failed = `pre_proxy::operator_trusted_pre_roundtrip_end_to_end` (`PreKey(Access(Expired))`) — pre-existing time-dependent flake, **fails identically on the base commit** (verified via stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)