### PR TITLE
docs(deps): deprecate KSE Journal — CommitDag is the canonical chain

### DIFF
--- a/deps.toml
+++ b/deps.toml
@@ -57,7 +57,7 @@ notes          = "BlockStore: BudgetedBlockStore<MemoryBlockStore> hot (KOTOBA_H
 [runtime_dependencies.object_storage]
 kind = "blob-store"
 provider = "b2"
-notes = "Journal (kotoba/journal/), BlockStore (kotoba/blocks/), Vault (kotoba/vault/) — all in bucket etzhayyim-nats"
+notes = "Journal (kotoba/journal/ — DEPRECATED 2026-06-11, CommitDag is canonical; bucket prefix retained for legacy replay only), BlockStore (kotoba/blocks/), Vault (kotoba/vault/) — all in bucket etzhayyim-nats"
 
 [runtime_dependencies.libp2p]
 kind = "p2p-transport"
@@ -85,7 +85,8 @@ notes = "ProllyTree: build_tree(entries, store)→root_cid (commit), get(root, k
 [subdirs."crates/kotoba-kse"]
 role = "stream-engine"
 tier = "alpha"
-notes = "Full IPLD migration 2026-05-26: Journal (Merkle WAL blocks on Arc<dyn BlockStore>, head JSON file, traverse_chain() cold-path), Vault (file-type chunking: Single<128KB / FixedLen 512KB for video/audio/binary / gear-hash CDC ~256KB for text/JSON / CBOR-item-boundary for dag-cbor; BlobManifest CID for multi-chunk blobs; Vault::flush_as_car() → CAR v1 Bytes), SecureVault (backed via Vault::with_block_store). sled named trees 'journal'/'vault'/'email-vault' removed from server.rs — all KSE shares single block_store. 38 tests pass (chunker + journal + vault + secure_vault + store + sync_window + shelf). PreKeyRegistry (2026-05-26): maps (owner_did, accessor_did) → AES-GCM-wrapped re-encryption key stored in BlockStore; grant()/revoke()/get_rekey_authed(chain)/list_accessors(); re-key = raw data_key (Hybrid PRE: PRE applied only to 32B key, not blob — cost 5ms fixed regardless of blob size); CACAO verification via DelegationChain::verify(owner_did, 'quad:read') before key delivery; AAD = 'owner_did:accessor_did'; 3 tests: roundtrip / revoke / list_accessors. Security fix (2026-05-26): get_rekey_authed and unwrap_rekey now return Zeroizing<Vec<u8>> — data_key bytes are wiped on drop (memset_s equivalent, compiler-optimization-resistant). Security hardening run-2 (2026-05-26): [fix-2] PreKeyRegistry Shelf persistence — with_shelf(Arc<Shelf>) constructor loads index+revocation on startup; grant/revoke persist immediately; Vec<[String;3]>/(Vec<[String;2]>) array-of-tuples format avoids DID colon split_once collision; revoked set checked in get_rekey_authed before BlockStore access; 7 tests: roundtrip/revoke/list_accessors + shelf_persistence_survives_restart + revoked_pair_rejected + emit_warrant_returns_evidence_cid + apply_revocation_warrant_revokes_locally; [fix-7-partial] revoke_emit_warrant() → CBOR RekeyRevocationRecord → block_store.put → evidence KotobaCid; apply_revocation_warrant() deserializes peer warrant and calls revoke_inner(); RULE_REKEY_REVOKED=7 constant exported; [fix-9] SecureVault::put_with_policy(key, plaintext, policy_cid) → (BlobRef, DataPolicy::Encrypted{ct_cid=blob_ref.cid, policy_cid}) — atomically binds ciphertext CID to policy; put_with_policy test added; total 54 tests pass (run-3: +reencrypt_blob / rotate_and_reencrypt_blob_is_accessible_with_new_key)."
+status = "journal-deprecated"
+notes = "DEPRECATED COMPONENT (2026-06-11): the KSE Journal (WAL/event stream) is deprecated as a canonical/accountability structure — the CommitDag (kotoba-datomic DistributedDatomCommit: content-addressed, parents hash-chain, author-attributed, IPNS-headed, anchorable via audit.anchorPayload) is THE canonical chain. Do not build new features on Journal. Remaining Journal users to migrate to CommitDag-based equivalents: startup WAL replay (replay_from_journal → commit-chain replay), firehose egress (Journal events → CommitDag tx feed), journal_assert_ephemeral in commit_protocol_datoms (drop the double write; KOTOBA_JOURNAL_WAL=off already opts out). Vault/SecureVault/Shelf/PreKeyRegistry in this crate are NOT deprecated. — Full IPLD migration 2026-05-26: Journal (Merkle WAL blocks on Arc<dyn BlockStore>, head JSON file, traverse_chain() cold-path), Vault (file-type chunking: Single<128KB / FixedLen 512KB for video/audio/binary / gear-hash CDC ~256KB for text/JSON / CBOR-item-boundary for dag-cbor; BlobManifest CID for multi-chunk blobs; Vault::flush_as_car() → CAR v1 Bytes), SecureVault (backed via Vault::with_block_store). sled named trees 'journal'/'vault'/'email-vault' removed from server.rs — all KSE shares single block_store. 38 tests pass (chunker + journal + vault + secure_vault + store + sync_window + shelf). PreKeyRegistry (2026-05-26): maps (owner_did, accessor_did) → AES-GCM-wrapped re-encryption key stored in BlockStore; grant()/revoke()/get_rekey_authed(chain)/list_accessors(); re-key = raw data_key (Hybrid PRE: PRE applied only to 32B key, not blob — cost 5ms fixed regardless of blob size); CACAO verification via DelegationChain::verify(owner_did, 'quad:read') before key delivery; AAD = 'owner_did:accessor_did'; 3 tests: roundtrip / revoke / list_accessors. Security fix (2026-05-26): get_rekey_authed and unwrap_rekey now return Zeroizing<Vec<u8>> — data_key bytes are wiped on drop (memset_s equivalent, compiler-optimization-resistant). Security hardening run-2 (2026-05-26): [fix-2] PreKeyRegistry Shelf persistence — with_shelf(Arc<Shelf>) constructor loads index+revocation on startup; grant/revoke persist immediately; Vec<[String;3]>/(Vec<[String;2]>) array-of-tuples format avoids DID colon split_once collision; revoked set checked in get_rekey_authed before BlockStore access; 7 tests: roundtrip/revoke/list_accessors + shelf_persistence_survives_restart + revoked_pair_rejected + emit_warrant_returns_evidence_cid + apply_revocation_warrant_revokes_locally; [fix-7-partial] revoke_emit_warrant() → CBOR RekeyRevocationRecord → block_store.put → evidence KotobaCid; apply_revocation_warrant() deserializes peer warrant and calls revoke_inner(); RULE_REKEY_REVOKED=7 constant exported; [fix-9] SecureVault::put_with_policy(key, plaintext, policy_cid) → (BlobRef, DataPolicy::Encrypted{ct_cid=blob_ref.cid, policy_cid}) — atomically binds ciphertext CID to policy; put_with_policy test added; total 54 tests pass (run-3: +reencrypt_blob / rotate_and_reencrypt_blob_is_accessible_with_new_key)."
 
 [subdirs."crates/kotoba-kqe"]
 role = "query-engine"
@@ -186,6 +187,31 @@ notes = "Stable Ed25519+X25519 keypair for agent DID; prevents ephemeral DID rot
 # Single-session 27-fix push that turned kotoba.etzhayyim.com into a
 # Datomic-over-IPFS substrate + WASM Python LangGraph host.
 # ADR: 90-docs/adr/2605301045-kotoba-durability-chain-wasm-langgraph-host.md
+
+[knowledge.journal-deprecation]
+discovered_on = "2026-06-11"
+category      = "architecture-decision"
+severity      = "info"
+status        = "accepted"
+summary       = "KSE Journal DEPRECATED as canonical chain — CommitDag is the single source of truth (founder decision, 2026-06-11)."
+details       = """
+Decision context: R2b (signed chains for non-repudiation, ADR-sealed-cold-tier)
+asked where per-DID accountability chains live.  Answer: the CommitDag, NOT the
+Journal.  DistributedDatomCommit already has everything but the signature —
+content-addressed, parents: Vec<KotobaCid> hash chain, author DID, IPNS heads
+(Ed25519 head-signing already implemented opt-in via ipns_signing_key), and
+the audit graph head anchors to Base via audit.anchorPayload.  Building signed
+chains on the Journal would duplicate that structure with weaker guarantees
+(node-local WAL, not canonical, not anchored).  Therefore the Journal is
+deprecated wholesale: no new features on it; its three remaining roles migrate
+to CommitDag-based equivalents (startup replay, firehose egress, the ephemeral
+double-write in commit_protocol_datoms — KOTOBA_JOURNAL_WAL=off is the opt-out
+that becomes the default).  Per-DID chains = CommitDag filtered by author;
+equivocation resistance comes from anchoring, not a separate journal.
+"""
+impact        = "Direction-setting only; no code removed yet. New accountability work (R2b commit signatures, access/cacao-cid receipts) targets DistributedDatomCommit."
+affects_files = ["crates/kotoba-kse/src/journal.rs", "crates/kotoba-datomic/src/distributed.rs", "crates/kotoba-server/src/xrpc.rs"]
+references    = ["ADR-sealed-cold-tier", "ADR-2606112200"]
 
 [knowledge.kubo-block-store-connection-pool]
 discovered_on = "2026-05-30"


### PR DESCRIPTION
## What

Records the 2026-06-11 founder decision in `deps.toml`: **the KSE Journal is deprecated; the CommitDag is THE canonical chain.**

- `[subdirs."crates/kotoba-kse"]` — `status = "journal-deprecated"` + a DEPRECATED header at the front of notes: no new features on Journal; the three remaining users (startup WAL replay, firehose egress, the `commit_protocol_datoms` ephemeral double-write — `KOTOBA_JOURNAL_WAL=off` is the existing opt-out) migrate to CommitDag-based equivalents. Vault/SecureVault/Shelf/PreKeyRegistry in the crate are explicitly NOT deprecated.
- `[knowledge.journal-deprecation]` — the decision record with rationale: `DistributedDatomCommit` already carries everything but a per-commit signature (content-addressed, `parents` hash chain, author DID, opt-in Ed25519-signed IPNS heads, Base-anchorable via `audit.anchorPayload`); building signed chains on the Journal would duplicate that with weaker guarantees. Per-DID chains = CommitDag filtered by author; equivocation resistance comes from anchoring.
- `[runtime_dependencies.object_storage]` — B2 `kotoba/journal/` prefix marked legacy-replay-only.

Docs-only; TOML validated; no code removed. R2b (commit `author_sig` + `access/cacao-cid` receipts) targets the CommitDag accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)