### PR TITLE
feat(kotodama): seigyo R1 provisional gate values — Council/baseline via merged PR review

### DIFF
--- a/crates/kotoba-kotodama/cells/seigyo_historian_aggregate/cell.py
+++ b/crates/kotoba-kotodama/cells/seigyo_historian_aggregate/cell.py
@@ -20,8 +20,17 @@ Charter Rider §2(a)(c): LOW (read + aggregate only; no actuation path).
 
 from __future__ import annotations
 
-COUNCIL_FLEET_ATTESTATION_TX_HASH: str | None = None
-SILEN_SEIGYO_BASELINE_REVIEW_CID: str | None = None
+# Provisional gate values per etzhayyim-root CLAUDE.md operational premise
+# (2026-06-11): Council attestation = PR review; merged-PR merge commits
+# stand in for on-chain tx hash / IPFS CID until Base testnet migration.
+#   charter + R1 ADRs ratified: etzhayyim/root#1635
+#   baseline review (verdict: approved): etzhayyim/root#1641
+COUNCIL_FLEET_ATTESTATION_TX_HASH: str | None = (
+    "pr:etzhayyim/root#1635@9144cf64434402678a23dbbc4d885ada98c3cef0"
+)
+SILEN_SEIGYO_BASELINE_REVIEW_CID: str | None = (
+    "pr:etzhayyim/root#1641@d3060afbb2f90213caf905afc781db163848b96a"
+)
 
 if (
     COUNCIL_FLEET_ATTESTATION_TX_HASH is None

--- a/crates/kotoba-kotodama/cells/seigyo_interlock_attestation/cell.py
+++ b/crates/kotoba-kotodama/cells/seigyo_interlock_attestation/cell.py
@@ -20,8 +20,17 @@ Charter Rider §2(a)(c): HIGH (safety-of-life adjacency — attestation only).
 
 from __future__ import annotations
 
-COUNCIL_FLEET_ATTESTATION_TX_HASH: str | None = None
-SILEN_SEIGYO_BASELINE_REVIEW_CID: str | None = None
+# Provisional gate values per etzhayyim-root CLAUDE.md operational premise
+# (2026-06-11): Council attestation = PR review; merged-PR merge commits
+# stand in for on-chain tx hash / IPFS CID until Base testnet migration.
+#   charter + R1 ADRs ratified: etzhayyim/root#1635
+#   baseline review (verdict: approved): etzhayyim/root#1641
+COUNCIL_FLEET_ATTESTATION_TX_HASH: str | None = (
+    "pr:etzhayyim/root#1635@9144cf64434402678a23dbbc4d885ada98c3cef0"
+)
+SILEN_SEIGYO_BASELINE_REVIEW_CID: str | None = (
+    "pr:etzhayyim/root#1641@d3060afbb2f90213caf905afc781db163848b96a"
+)
 CONTROLS_ENGINEER_REGISTRY_CID: str | None = None  # ADR-2606111100 §3 SME gate
 
 if (
@@ -30,7 +39,8 @@ if (
     or CONTROLS_ENGINEER_REGISTRY_CID is None
 ):
     raise RuntimeError(
-        "seigyo_interlock_attestation cell scaffold-only — HIGH risk category. "
-        "Council fleet.toml + silen-seigyo baseline + controls-engineer SME "
-        "not attested per ADR-2606111000 §6 + ADR-2606111100 §2-§3."
+        "seigyo_interlock_attestation cell R1-gated — controls-engineer SME "
+        "(CONTROLS_ENGINEER_REGISTRY_CID) not registered per "
+        "ADR-2606111100 §3. Council + baseline gates satisfied "
+        "provisionally via PR review (root#1635 / root#1641)."
     )

--- a/crates/kotoba-kotodama/cells/seigyo_opcua_bridge/cell.py
+++ b/crates/kotoba-kotodama/cells/seigyo_opcua_bridge/cell.py
@@ -22,8 +22,17 @@ Charter Rider §2(a)(c): MEDIUM (setpoint writes within attested envelopes).
 
 from __future__ import annotations
 
-COUNCIL_FLEET_ATTESTATION_TX_HASH: str | None = None
-SILEN_SEIGYO_BASELINE_REVIEW_CID: str | None = None
+# Provisional gate values per etzhayyim-root CLAUDE.md operational premise
+# (2026-06-11): Council attestation = PR review; merged-PR merge commits
+# stand in for on-chain tx hash / IPFS CID until Base testnet migration.
+#   charter + R1 ADRs ratified: etzhayyim/root#1635
+#   baseline review (verdict: approved): etzhayyim/root#1641
+COUNCIL_FLEET_ATTESTATION_TX_HASH: str | None = (
+    "pr:etzhayyim/root#1635@9144cf64434402678a23dbbc4d885ada98c3cef0"
+)
+SILEN_SEIGYO_BASELINE_REVIEW_CID: str | None = (
+    "pr:etzhayyim/root#1641@d3060afbb2f90213caf905afc781db163848b96a"
+)
 
 if (
     COUNCIL_FLEET_ATTESTATION_TX_HASH is None

--- a/crates/kotoba-kotodama/cells/seigyo_plc_program_lifecycle/cell.py
+++ b/crates/kotoba-kotodama/cells/seigyo_plc_program_lifecycle/cell.py
@@ -21,8 +21,17 @@ Charter Rider §2(a)(c): HIGH (controls physical actuation logic).
 
 from __future__ import annotations
 
-COUNCIL_FLEET_ATTESTATION_TX_HASH: str | None = None
-SILEN_SEIGYO_BASELINE_REVIEW_CID: str | None = None
+# Provisional gate values per etzhayyim-root CLAUDE.md operational premise
+# (2026-06-11): Council attestation = PR review; merged-PR merge commits
+# stand in for on-chain tx hash / IPFS CID until Base testnet migration.
+#   charter + R1 ADRs ratified: etzhayyim/root#1635
+#   baseline review (verdict: approved): etzhayyim/root#1641
+COUNCIL_FLEET_ATTESTATION_TX_HASH: str | None = (
+    "pr:etzhayyim/root#1635@9144cf64434402678a23dbbc4d885ada98c3cef0"
+)
+SILEN_SEIGYO_BASELINE_REVIEW_CID: str | None = (
+    "pr:etzhayyim/root#1641@d3060afbb2f90213caf905afc781db163848b96a"
+)
 CONTROLS_ENGINEER_REGISTRY_CID: str | None = None  # ADR-2606111100 §3 SME gate
 
 if (
@@ -31,7 +40,8 @@ if (
     or CONTROLS_ENGINEER_REGISTRY_CID is None
 ):
     raise RuntimeError(
-        "seigyo_plc_program_lifecycle cell scaffold-only — HIGH risk category. "
-        "Council fleet.toml + silen-seigyo baseline + controls-engineer SME "
-        "not attested per ADR-2606111000 §6 + ADR-2606111100 §2-§3."
+        "seigyo_plc_program_lifecycle cell R1-gated — controls-engineer SME "
+        "(CONTROLS_ENGINEER_REGISTRY_CID) not registered per "
+        "ADR-2606111100 §3. Council + baseline gates satisfied "
+        "provisionally via PR review (root#1635 / root#1641)."
     )

--- a/crates/kotoba-kotodama/cells/seigyo_scada_gateway/cell.py
+++ b/crates/kotoba-kotodama/cells/seigyo_scada_gateway/cell.py
@@ -19,8 +19,17 @@ Charter Rider §2(a)(c): MEDIUM (supervisory visibility; no direct actuation).
 
 from __future__ import annotations
 
-COUNCIL_FLEET_ATTESTATION_TX_HASH: str | None = None
-SILEN_SEIGYO_BASELINE_REVIEW_CID: str | None = None
+# Provisional gate values per etzhayyim-root CLAUDE.md operational premise
+# (2026-06-11): Council attestation = PR review; merged-PR merge commits
+# stand in for on-chain tx hash / IPFS CID until Base testnet migration.
+#   charter + R1 ADRs ratified: etzhayyim/root#1635
+#   baseline review (verdict: approved): etzhayyim/root#1641
+COUNCIL_FLEET_ATTESTATION_TX_HASH: str | None = (
+    "pr:etzhayyim/root#1635@9144cf64434402678a23dbbc4d885ada98c3cef0"
+)
+SILEN_SEIGYO_BASELINE_REVIEW_CID: str | None = (
+    "pr:etzhayyim/root#1641@d3060afbb2f90213caf905afc781db163848b96a"
+)
 
 if (
     COUNCIL_FLEET_ATTESTATION_TX_HASH is None


### PR DESCRIPTION
## Council 付議 — seigyo セルゲートへの暫定値設定(R1 部分活性化)

> **この PR の review approval = 本変更の Council attestation です。**

## What

etzhayyim-root CLAUDE.md に記録した運用前提(2026-06-11: Council attestation = PR review、merge 済み PR の merge commit を `COUNCIL_*_TX_HASH` / `*_REVIEW_CID` の暫定値として参照可)に基づき、5つの `seigyo_*` セルのゲート定数を設定:

- `COUNCIL_FLEET_ATTESTATION_TX_HASH` := `pr:etzhayyim/root#1635@9144cf64…`(R0 憲章 + R1 ADR の ratification)
- `SILEN_SEIGYO_BASELINE_REVIEW_CID` := `pr:etzhayyim/root#1641@d3060afb…`(Lexicon 9件 + verdict: approved のレビュー記録)

## Resulting state(import 検証済み)

| Cell | Risk | State |
|---|---|---|
| `seigyo_scada_gateway` | MEDIUM | ✅ ACTIVE |
| `seigyo_opcua_bridge` | MEDIUM | ✅ ACTIVE |
| `seigyo_historian_aggregate` | LOW | ✅ ACTIVE |
| `seigyo_plc_program_lifecycle` | HIGH | 🔒 GATED — controls-engineer SME のみ残置 |
| `seigyo_interlock_attestation` | HIGH | 🔒 GATED — 同上 |

HIGH リスク 2 セルは **人間の controls engineer の DID 登録(`CONTROLS_ENGINEER_REGISTRY_CID`、ADR-2606111100 §3)** が唯一の残ゲートです — これは PR review では代替できません。ゲートメッセージも残ゲートのみを指すよう更新済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)