### PR TITLE
docs: expand engine acronyms (KQE/KSE/KDHT/KVM/KAIS) + align docs with Journal deprecation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,14 +13,14 @@ KOTOBA ≝ Datom[CID/T] × EAVT[KSE Topic] × Pregel[BSP] × Datalog[Δ]
 
 | crate | 役割 |
 |---|---|
-| kotoba-core | CIDv1 blake3, KAIS 8-bit frame, Prolly Tree |
-| kotoba-kse | Journal (Merkle WAL on Arc<dyn BlockStore>, head JSON, Merkle chain cold-path), Vault (file-type chunking: Single/FixedLen 512KB/CDC gear-hash/CodecAware CBOR-item; BlobManifest CID; flush_as_car() CAR v1 batch), SecureVault, Topic, Shelf, chunker.rs **[IPLD-only 2026-05-26]**; **AgentIdentity** (Ed25519+X25519 keypair, from_env/generate_ephemeral); **SovereignCrypto** (AgentCrypto impl: vault key gen→HPKE wrap→BlockStore; load_or_genesis; rotate; key-ref JSON pointer in KseStore) **[2026-05-26]** |
-| kotoba-kqe | Datalog engine, Arrangement, Delta, MV (KQE) |
-| kotoba-dht | Source Chain, Warrant, Neighborhood (KDHT) |
+| kotoba-core | CIDv1 blake3, KAIS 8-bit frame (**KAIS = Kotoba Instruction Set Architecture**), Prolly Tree |
+| kotoba-kse | **KSE = Kotoba Stream Engine**. **⚠ Journal DEPRECATED as canonical chain (2026-06-11, #115 — `[knowledge.journal-deprecation]`)**: canonical/accountability chain = **CommitDag** (kotoba-datomic `DistributedDatomCommit`); Journal の残存役割は ephemeral live-tail (`publish_ephemeral` — broadcast+ring, block 永続なし) のみ、durable replay は `sync.eventsFromCommits`; startup WAL replay 撤去済み・double-write は ephemeral 化済み; **Vault/SecureVault/Shelf/PreKeyRegistry は deprecated 対象外**。 Journal (Merkle WAL on Arc<dyn BlockStore>, head JSON, Merkle chain cold-path — legacy replay only), Vault (file-type chunking: Single/FixedLen 512KB/CDC gear-hash/CodecAware CBOR-item; BlobManifest CID; flush_as_car() CAR v1 batch), SecureVault, Topic, Shelf, chunker.rs **[IPLD-only 2026-05-26]**; **AgentIdentity** (Ed25519+X25519 keypair, from_env/generate_ephemeral); **SovereignCrypto** (AgentCrypto impl: vault key gen→HPKE wrap→BlockStore; load_or_genesis; rotate; key-ref JSON pointer in KseStore) **[2026-05-26]** |
+| kotoba-kqe | **KQE = Kotoba Query Engine** — Datalog engine, Arrangement (4-index EAVT/AEVT/AVET/VAET), Delta, MV |
+| kotoba-dht | **KDHT = Kotoba Distributed Hash Table** — Source Chain, Warrant, Neighborhood |
 | kotoba-net | libp2p QUIC/Noise/GossipSub |
 | kotoba-auth | CACAO chain verification, DID Document; **EVM read+verify surface** (`eth.rs` + `eth/{abi,token,caip,eip1271}.rs`, 2026-05-30); **Bitcoin read+verify surface** (`btc.rs` + `btc/{address,caip,bip322}.rs`, BIP-122/CAIP-2/10/19 + Base58Check/bech32/bech32m + legacy signmessage verify, 2026-06-03, ADR-2606035800) |
 | kotoba-graph | Quad API, SPARQL→Datalog, Commit DAG |
-| kotoba-vm | Invoke/Result ChainEntry, CALL_FOREIGN bridge (KVM) |
+| kotoba-vm | **KVM = Kotoba Virtual Machine** — Invoke/Result ChainEntry, CALL_FOREIGN bridge, Pregel BSP hosts |
 | kotoba-llm | Weight blob (FP8), LoRA Delta, KV-cache, inference, WebGPU training (embed+lm_head), WebGPU inference (full transformer, Gemma 4 E2B/E4B) |
 | kotoba-runtime | WASM Component Model host: WasmExecutor + UdfExecutor + WIT bindings |
 | kotoba-clj | **Clojure/EDN-subset → WebAssembly compiler** (ADR `docs/ADR-clojure-wasm.md`, 2026-06-08). Reuses `kotoba-edn` as reader → typed AST → two-pass codegen via `wasm-encoder` → real core wasm module; `run` feature instantiates on workspace-pinned wasmtime. Subset: `def`/`defn`/`ns`, `if`/`when`/`let`/`do`, `+ - * / mod`, `= < > <= >=`, `and or not`, **string literals + `str-len`/`byte-at`** (strings = packed `(off<<32)\|len` handles), user-fn calls incl. (mutual) recursion; each `defn` exported by name; `def` const-folded + inlined. Every module also exports linear `memory` + `cabi_realloc` bump allocator. **kais-binding workstream** (5 steps): ✅1 memory+realloc ✅2 str/bytes values ✅3 `list<u8>` in/out **Component** export via `wit-component` (`(defn run [input] …)` → `run: func(list<u8>)->list<u8>`, hand-emitted canonical-ABI wrapper, instantiated via `wasmtime::component`; smoke-tested wit-component 0.221 ↔ wasmtime 22) ⬜4 CBOR-decode `InvokeContext` — **blocked on language growth (loops + byte-building)** ✅5 emit `kotoba-node` `run` — **runs on kotoba-runtime**: `compile_kais_component_str` targets the REAL `kotoba-node` world (`run: func(list<u8>)->result<list<u8>,string>`, 12-byte ok-variant return area) via `Resolve::push_dir` over `kotoba-runtime/wit`; `assert_loads` confirms the `ProgramStore` compile path, and `tests/kais_invoke.rs` drives the runtime's own `WasmExecutor` (binds all kotoba:kais imports) to invoke `run(ctx)` end-to-end + lift the result (validates the hand-emitted variant layout at runtime). **Phase boundary**: compiled Clojure runs on kotoba-runtime, but the wrapper passes raw ctx-cbor **undecoded** → meaningfully reading ctx/args is gated on step 4 (loops + bytes). Tests (27+doctest): factorial/fib/mutual-rec/const-inline + str-len/byte-at/UTF-8 + allocator(align/monotonic/non-overlap/growth) + component(echo/binary/empty/data-seg-literal/len-branch) + kais-load + kais-invoke(WasmExecutor: fixed/ctx-echo/len-branch) all green. **langgraph workstream (A–E)**: ✅A `loop`/`recur`+`cond`+byte-builder ✅B heap vector/map prelude ✅C-1 host-import plumbing (`has-capability?`) ✅C-2 `llm-infer` (return-area ABI) ✅C-3/C-4 in-guest CBOR decode/encode (closes step 4) ✅D `defgraph` DSL + add-messages/override reducers ✅**C-5 kqe host builtins (2026-06-11)** — `kqe-assert!`/`kqe-retract!`/`kqe-get-objects`/`kqe-query` lower to `kotoba:kais/kqe` imports (flattened quad record + indirect results; host lifts lists via guest `cabi_realloc`); `KQE_PRELUDE` reads lifted arrays in-language (`kqe-count`/`kqe-obj-nth`/`kqe-quad-*`); `tests/kqe.rs` 9 live WasmExecutor tests incl. read-modify-write agent + **Datomic loop** (agent-asserted quads → `kotoba_kqe::Datom` → `kotoba_datomic::Datom::from_kqe` → `Db::from_datoms` → queried back as EDN) ✅**E Pregel/BSP (2026-06-11)** — `tests/pregel.rs` drives the compiled `defgraph` agent through `kotoba-vm::WasmPregelRunner`: CBOR ctx → defgraph node asserts a Datom + bumps counter → `{"status":"continue"\|"done"}` self-loop; 4 supersteps / 4 Datoms / gas accumulation / `max_supersteps` cap verified. **Compiled Clojure agent = langgraph defgraph × kqe Datom writes × Pregel BSP, end-to-end** |
@@ -173,7 +173,7 @@ bytemuck = { version = "1",  features = ["derive"], optional = true }
 - `CommitDag::Commit` に `index_roots: HashMap<String, KotobaCid>` 追加 (`serde(default, skip_serializing_if)` で旧 commit CID 安定)
 - `QuadStore::commit()` は EAVT/AEVT/AVET/VAET を **4 並列 64MB スタックスレッド** で同時ビルド (各スレッドは `CapturingBlockStore` でブロックを記録); 完了後 `CarBundleWriter` で全ブロックを単一 CAR ファイルにパック → ブロックストアに 1 PUT。実測: 3.1–3.8s/1Mquad commit (serial 4.7s → **28% 高速化**; MemoryBlockStore, M4 Mac)
 - `QuadStore::get_entity_quads_cold()`: hot Arrangement clear 後の cold 読み取り。ProllyTree `scan_prefix(subject_bytes)` → EAVT エントリ再構成。実測コスト: kubo LAN (1ms/GET) 3.1ms / kubo WAN (80ms/GET) 169ms / S3 same-AZ (2ms/GET) 5.9ms (1K entries, 2 tree levels)
-- Journal: 4 トピック SPO + PSO + POS + OSP に publish
+- Journal: 4 トピック SPO + PSO + POS + OSP に publish **[Journal deprecated 2026-06-11 — live-tail broadcast のみ; durable record は CommitDag]**
 
 ## TieredBlockStore / KuboBlockStore
 
@@ -604,7 +604,7 @@ CAR bundle: **total 7–9s で S3 flush 完了保証**。
 - `advance(new_head, seq, store)` → 旧 head アンピン → 新 head ピン
 - `unpin_from(store)` → セッション終了時に解放
 
-### Journal Selective Replay (persistent fallback 含む)
+### Journal Selective Replay (persistent fallback 含む) **[DEPRECATED 2026-06-11 #115 — legacy データの replay 専用; 新規 durable replay は CommitDag `sync.eventsFromCommits`]**
 - `Journal::read_since(seq)` → ring buffer から `seq` 以降を返す。`seq < oldest_ring_seq` かつ store が Some なら `seq/{seq:020}` seq-index で persistent fallback
 - `Journal::trim_before(seq)` → ring buffer の古いエントリを解放
 - `Journal::with_capacity(n)` → ring buffer サイズをカスタマイズ (デフォルト 65,536)
@@ -783,6 +783,8 @@ EVM `bind_evm` の鏡写し。read-only **Esplora REST** (Blockstream / mempool.
 **honest R0**: full BIP-322 (P2TR/script 所有) 未 / chain 観測は Esplora REST 依存で SPV-trustless ではない / client-side BTC wallet 連携は ADR design-only。詳細 ADR-2606035800。
 
 ## Firehose Egress — D+E federation surface (2026-05-30)
+
+> **⚠ Journal deprecation (2026-06-11, #115)**: 本セクションの Journal ベース設計 (cursor == Journal seq) は **legacy live-tail surface**。durable replay は CommitDag ベースの `GET /xrpc/com.etzhayyim.apps.kotoba.sync.eventsFromCommits` が正 (CommitDag tx feed — `KOTOBA_JOURNAL_WAL=off` 状態でも完全な履歴を再生可能)。Journal への新機能追加は禁止。
 
 KSE Journal (seq 順序ログ + broadcast `subscribe()` + `read_since()` cold-fallback) を「同一 cursor の 2 シンク」に開く。cursor == Journal `seq`。
 

--- a/crates/kotoba-dht/src/lib.rs
+++ b/crates/kotoba-dht/src/lib.rs
@@ -1,3 +1,10 @@
+//! # kotoba-dht — **KDHT = Kotoba Distributed Hash Table**
+//!
+//! Agent-centric integrity layer of KOTOBA: per-agent [`source_chain`]s,
+//! [`warrant`]s (signed misbehaviour evidence), [`neighborhood`] validator
+//! assignment, [`gossip`], [`commit_chain`], [`audit`], and [`settlement`].
+//! No central master node — validation authority is distributed across
+//! DHT neighborhoods.
 pub mod audit;
 pub mod availability_proof;
 pub mod commit_chain;

--- a/crates/kotoba-kqe/src/lib.rs
+++ b/crates/kotoba-kqe/src/lib.rs
@@ -1,3 +1,16 @@
+//! # kotoba-kqe — **KQE = Kotoba Query Engine**
+//!
+//! The Datalog query layer of KOTOBA: semi-naive Datalog evaluation
+//! ([`datalog`]), the 4-index in-memory [`arrangement`] (EAVT/AEVT/AVET/VAET),
+//! assert/retract [`delta`]s over the atomic [`datom::Datom`] 5-tuple
+//! `(E, A, V, T, Added)`, materialized views ([`mv`]), and citation-royalty
+//! accounting ([`citation`]).
+//!
+//! WASM guests reach this engine through the `kotoba:kais/kqe` WIT interface
+//! (ASSERT 0x1 / RETRACT 0xD / QUERY 0x2 frames); KAIS = Kotoba Instruction
+//! Set Architecture. Sibling engines: KSE (Kotoba Stream Engine,
+//! `kotoba-kse`), KDHT (Kotoba DHT, `kotoba-dht`), KVM (Kotoba VM,
+//! `kotoba-vm`).
 pub mod arrangement;
 pub mod citation;
 pub mod cypher;

--- a/crates/kotoba-kse/src/journal.rs
+++ b/crates/kotoba-kse/src/journal.rs
@@ -1,3 +1,16 @@
+//! KSE Journal — topic pub/sub event stream (Merkle WAL).
+//!
+//! ## ⚠ DEPRECATED as a canonical chain (2026-06-11, etzhayyim/kotoba#115)
+//!
+//! Accountability / signed chains live on the **CommitDag**
+//! (`kotoba-datomic` `DistributedDatomCommit`), not here. Do not build new
+//! features on the Journal. Sanctioned remaining use: the **ephemeral
+//! live-tail** ([`Journal::publish_ephemeral`] — broadcast + ring buffer, no
+//! block persist) feeding the firehose SSE tap; durable history replays from
+//! the CommitDag (`sync.eventsFromCommits`). The block-persisting
+//! [`Journal::publish`] path and `read_since` cold-fallback remain only for
+//! legacy replay of pre-deprecation data.
+
 use crate::topic::Topic;
 use bytes::Bytes;
 use kotoba_core::cid::KotobaCid;

--- a/crates/kotoba-kse/src/lib.rs
+++ b/crates/kotoba-kse/src/lib.rs
@@ -1,3 +1,22 @@
+//! # kotoba-kse — **KSE = Kotoba Stream Engine**
+//!
+//! Blob + key custody layer of KOTOBA: [`store`] (`KseStore`), [`chunker`] +
+//! Vault (file-type chunking → BlobManifest CID → CAR flush), [`secure_vault`],
+//! [`shelf`], [`pre_key_registry`] (hybrid PRE re-key delivery),
+//! [`agent_identity`] / [`sovereign_key`] (Ed25519+X25519 agent keys), and
+//! [`topic`] / [`journal`] (pub/sub event stream).
+//!
+//! ## ⚠ Journal deprecation (2026-06-11, etzhayyim/kotoba#115)
+//!
+//! The [`journal`] module is **deprecated as a canonical/accountability
+//! structure** — the CommitDag (`kotoba-datomic` `DistributedDatomCommit`:
+//! content-addressed, parent hash-chain, author DID, signed IPNS heads,
+//! Base-anchorable) is THE canonical chain. Do not build new features on the
+//! Journal. Its remaining sanctioned role is the **ephemeral live-tail**
+//! (`publish_ephemeral`: broadcast + ring buffer, no block persist); durable
+//! replay is served from the CommitDag (`sync.eventsFromCommits`).
+//! Vault / SecureVault / Shelf / PreKeyRegistry in this crate are **not**
+//! deprecated.
 pub mod agent_identity;
 pub mod chunker;
 pub mod journal;

--- a/crates/kotoba-vm/src/lib.rs
+++ b/crates/kotoba-vm/src/lib.rs
@@ -1,3 +1,12 @@
+//! # kotoba-vm — **KVM = Kotoba Virtual Machine**
+//!
+//! Execution hosts of KOTOBA on the Pregel BSP substrate: [`pregel`]
+//! (deterministic single-node BSP engine with Merkle-chained checkpoints),
+//! [`wasm_pregel`] (`WasmPregelRunner` — WASM Component programs as BSP
+//! vertices), [`distributed`] (`DistributedPregelRunner` — cross-node BSP via
+//! GossipSub), [`executor`] (`KotobaVm` — Datalog programs on BSP),
+//! [`state_graph`] (LangGraph-compatible `StateGraph`, ADR-2605250002),
+//! [`agent`] (ReAct runners), and [`foreign`] (CALL_FOREIGN 0xF bridge).
 pub mod agent;
 pub mod auth_actor;
 pub mod distributed;

--- a/deps.toml
+++ b/deps.toml
@@ -214,7 +214,7 @@ double-write in commit_protocol_datoms — KOTOBA_JOURNAL_WAL=off is the opt-out
 that becomes the default).  Per-DID chains = CommitDag filtered by author;
 equivocation resistance comes from anchoring, not a separate journal.
 """
-impact        = "Direction-setting only; no code removed yet. New accountability work (R2b commit signatures, access/cacao-cid receipts) targets DistributedDatomCommit."
+impact        = "Datomic commit path migrated (2026-06-11): startup WAL replay REMOVED (CommitDag is the durable record), commit_protocol_datoms double-write is ephemeral-only (no block persist), durable replay served by sync.eventsFromCommits. Remaining persistent Journal writers are legacy-only (quad paths journal_assert/assert_datom_compat, relay re-log in net_actor) — no new features on them. New accountability work (R2b commit signatures, access/cacao-cid receipts) targets DistributedDatomCommit."
 affects_files = ["crates/kotoba-kse/src/journal.rs", "crates/kotoba-datomic/src/distributed.rs", "crates/kotoba-server/src/xrpc.rs"]
 references    = ["ADR-sealed-cold-tier", "ADR-2606112200"]
 


### PR DESCRIPTION
## What

Two doc-only changes from today's discussion (no code behavior touched):

### 1. Acronym expansion — LLM/coder readability

The engine TLAs (kqe/kse — one letter apart) were nowhere expanded in the places agents actually read. Now:

- **CLAUDE.md component table**: KQE = Kotoba **Q**uery **E**ngine / KSE = Kotoba **S**tream **E**ngine / KDHT = Kotoba **D**istributed **H**ash **T**able / KVM = Kotoba **V**irtual **M**achine / KAIS = Kotoba **I**nstruction **S**et Architecture
- **New `//!` crate headers** for kotoba-kqe / kotoba-kse / kotoba-dht / kotoba-vm (none had one) with the expansion + a module map

### 2. Journal deprecation — docs catch up with the code

#115 decided it and the code already migrated (startup WAL replay removed, `commit_protocol_datoms` double-write is ephemeral-only, `sync.eventsFromCommits` serves durable replay) — but CLAUDE.md still described the Journal as the live WAL. Now:

- CLAUDE.md kotoba-kse row / 4-index Journal line / Selective Replay subsection / Firehose section carry the deprecation boundary: **canonical chain = CommitDag**; Journal = ephemeral live-tail only; Vault/SecureVault/Shelf/PreKeyRegistry NOT deprecated
- `kotoba-kse/src/journal.rs` gets a `//!` header stating the same
- `deps.toml [knowledge.journal-deprecation]` impact updated to the actual migration state (remaining persistent writers = legacy quad paths `journal_assert`/`assert_datom_compat` + relay re-log in net_actor)

### Deliberately NOT in this PR

Crate renames (`kotoba-kqe` → `kotoba-query`, …): 9 in-flight branches would all conflict on a tree-wide rename. Recommended as a batched change in a quiet window — ideally together with the kse → vault split once Journal code is physically removed.

`cargo check -p kotoba-kse -p kotoba-kqe -p kotoba-dht -p kotoba-vm` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)