### PR TITLE
feat(kotoba-clj): LangGraph echo agent — componentize-py → Clojure-WASM port

### DIFF
--- a/crates/kotoba-clj/tests/langgraph_echo.rs
+++ b/crates/kotoba-clj/tests/langgraph_echo.rs
@@ -1,0 +1,165 @@
+//! The **Clojure-WASM port of the componentize-py LangGraph echo agent**
+//! (`examples/kotoba-langgraph-echo-clj/agent.clj` ⇄
+//! `examples/kotoba-langgraph-echo/agent.py`) — the "Python LangGraph actor →
+//! Clojure WASM actor" migration path, proven end-to-end on the real host:
+//!
+//!   - the agent source is the *example file itself* (`include_str!`), compiled
+//!     with the full prelude to a `kotoba-node` component;
+//!   - `run(ctx)` receives the same CBOR `InvokeContext` the Python
+//!     `handle_invoke` decodes (`{"graph", "session_cid", "args": {"input",
+//!     "thread_id"}}`) and returns the same `{"ok": <JSON state>}` result;
+//!   - the `KotobaCheckpointer.save` write surfaces as a kqe Datom on
+//!     graph `lgraph/ckpt` with object-cbor `{"Text": <JSON state>}`.
+#![cfg(feature = "component")]
+
+use std::collections::HashMap;
+
+use ciborium::Value;
+use kotoba_clj::component::compile_kais_component_str;
+use kotoba_clj::prelude;
+use kotoba_runtime::host::WitQuad;
+use kotoba_runtime::{InvokeResult, WasmExecutor};
+
+const KAIS_WIT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../kotoba-runtime/wit");
+const GAS: u64 = 10_000_000;
+const AGENT_DID: &str = "did:key:z6MkLanggraphEchoClj";
+
+/// The example agent source — the file under `examples/` IS what runs here.
+const AGENT_CLJ: &str = include_str!("../../../examples/kotoba-langgraph-echo-clj/agent.clj");
+
+fn agent_component() -> Vec<u8> {
+    let src = format!("{}\n{}", prelude(), AGENT_CLJ);
+    compile_kais_component_str(&src, KAIS_WIT_DIR).expect("compile agent.clj to kotoba-node")
+}
+
+fn invoke(ctx: Vec<u8>) -> InvokeResult {
+    let exec = WasmExecutor::new(GAS).expect("executor");
+    exec.execute(
+        "clj-langgraph-echo",
+        &agent_component(),
+        AGENT_DID,
+        ctx,
+        Vec::<WitQuad>::new(),
+        HashMap::new(),
+    )
+    .expect("execute run(ctx)")
+}
+
+fn cbor(value: &Value) -> Vec<u8> {
+    let mut out = Vec::new();
+    ciborium::into_writer(value, &mut out).expect("cbor encode");
+    out
+}
+
+fn text(s: &str) -> Value {
+    Value::Text(s.to_string())
+}
+
+/// The InvokeContext wire format from `py/kotoba_langgraph/_entry.py`:
+/// `{"args": {"input": {"prompt": ..}, "thread_id": ..}, "graph": .., "session_cid": ..}`.
+fn invoke_ctx(prompt: &str, session_cid: &str, thread_id: Option<&str>) -> Vec<u8> {
+    let input = Value::Map(vec![(text("prompt"), text(prompt))]);
+    let mut args = vec![(text("input"), input)];
+    if let Some(t) = thread_id {
+        args.push((text("thread_id"), text(t)));
+    }
+    cbor(&Value::Map(vec![
+        (text("args"), Value::Map(args)),
+        (text("graph"), text("lgraph-def-cid")),
+        (text("session_cid"), text(session_cid)),
+    ]))
+}
+
+/// Decode the agent's output as the `{"ok": <json>}` map and return the json.
+fn ok_json(output_cbor: &[u8]) -> String {
+    let value: Value = ciborium::from_reader(output_cbor).expect("output is CBOR");
+    let map = value.as_map().expect("output is a CBOR map");
+    assert_eq!(map.len(), 1, "exactly the ok entry");
+    assert_eq!(map[0].0.as_text(), Some("ok"));
+    map[0].1.as_text().expect("ok holds a JSON string").to_string()
+}
+
+// ---- echo semantics: prompt round-trips to response ---------------------------
+
+#[test]
+fn prompt_round_trips_to_response() {
+    // The verified Python recipe: {"prompt": "hello kotoba wasm"} →
+    // OUTPUT {"response": "hello kotoba wasm"} — same bytes-level result here,
+    // including json.dumps' default separators and the EchoState key order.
+    let result = invoke(invoke_ctx("hello kotoba wasm", "sess-1", Some("t-1")));
+    assert_eq!(
+        ok_json(&result.output_cbor),
+        r#"{"prompt": "hello kotoba wasm", "response": "hello kotoba wasm"}"#
+    );
+}
+
+#[test]
+fn empty_prompt_when_input_has_no_prompt_key() {
+    // _echo: state.get("prompt", "") — a prompt-less input yields "".
+    let input = Value::Map(vec![(text("other"), text("x"))]);
+    let ctx = cbor(&Value::Map(vec![
+        (text("args"), Value::Map(vec![(text("input"), input)])),
+        (text("session_cid"), text("sess-2")),
+    ]));
+    let result = invoke(ctx);
+    assert_eq!(ok_json(&result.output_cbor), r#"{"prompt": "", "response": ""}"#);
+}
+
+#[test]
+fn prompt_falls_back_to_args_when_input_absent() {
+    // _entry.py: input_state = args.get("input", args) — without an "input"
+    // map the args dict itself is the input state.
+    let ctx = cbor(&Value::Map(vec![
+        (text("args"), Value::Map(vec![(text("prompt"), text("direct"))])),
+        (text("session_cid"), text("sess-3")),
+    ]));
+    let result = invoke(ctx);
+    assert_eq!(
+        ok_json(&result.output_cbor),
+        r#"{"prompt": "direct", "response": "direct"}"#
+    );
+}
+
+// ---- KotobaCheckpointer.save → kqe Datom ---------------------------------------
+
+#[test]
+fn checkpointer_persists_state_to_lgraph_ckpt() {
+    // checkpointer.py storage layout: graph "lgraph/ckpt" / subject thread_id /
+    // predicate "state" / object CBOR {"Text": json.dumps(state)}.
+    let result = invoke(invoke_ctx("hi", "sess-4", Some("thread-42")));
+    assert_eq!(result.assert_quads.len(), 1, "one checkpoint write per invoke");
+    let q = &result.assert_quads[0];
+    assert_eq!(q.graph, "lgraph/ckpt");
+    assert_eq!(q.subject, "thread-42");
+    assert_eq!(q.predicate, "state");
+    let expected_obj = cbor(&Value::Map(vec![(
+        text("Text"),
+        text(r#"{"prompt": "hi", "response": "hi"}"#),
+    )]));
+    assert_eq!(q.object_cbor, expected_obj);
+    // kqe.assert-quad charges gas, same as the Python actor's checkpoint write
+    assert!(result.gas_used >= 10, "gas charged for the assert, got {}", result.gas_used);
+}
+
+#[test]
+fn thread_id_defaults_to_session_cid() {
+    // _entry.py: thread_id = args.get("thread_id", session_cid).
+    let result = invoke(invoke_ctx("yo", "session-as-thread", None));
+    assert_eq!(result.assert_quads.len(), 1);
+    assert_eq!(result.assert_quads[0].subject, "session-as-thread");
+}
+
+// ---- size: the migration-path payoff -------------------------------------------
+
+#[test]
+fn component_is_orders_of_magnitude_smaller_than_componentize_py() {
+    // The componentize-py build of the same agent is ~18 MB (bundled CPython).
+    // The kotoba-clj component must stay under 64 KiB.
+    let component = agent_component();
+    println!("kotoba-clj echo component: {} bytes", component.len());
+    assert!(
+        component.len() < 64 * 1024,
+        "expected a tiny component, got {} bytes",
+        component.len()
+    );
+}

--- a/examples/kotoba-langgraph-echo-clj/README.md
+++ b/examples/kotoba-langgraph-echo-clj/README.md
@@ -1,0 +1,75 @@
+# kotoba-langgraph-echo-clj
+
+The **Clojure-WASM port** of the componentize-py LangGraph echo agent
+([`../kotoba-langgraph-echo/agent.py`](../kotoba-langgraph-echo/agent.py)) —
+the migration path off `py/kotoba_langgraph`. The same actor, compiled by the
+in-repo [`kotoba-clj`](../../crates/kotoba-clj) Clojure→WASM compiler instead
+of bundling CPython.
+
+## Graph
+
+```
+START → echo → END        ; echo: {"response": state["prompt"]}
+```
+
+`agent.clj` mirrors the Python actor piece by piece:
+
+| Python (`py/kotoba_langgraph`)                  | Clojure (`agent.clj`)                          |
+|--------------------------------------------------|------------------------------------------------|
+| `StateGraph(EchoState)` + `add_node`/`add_edge`  | `defgraph echo-graph :entry/:nodes/:edges`     |
+| `_echo` returns partial `{"response": prompt}`   | `echo` returns a partial update map            |
+| reducer-free TypedDict channels (override)       | `:state {:prompt :override :response :override}` |
+| `handle_invoke` CBOR `InvokeContext` decode      | `ctx-prompt` / `ctx-thread-id` (`cbor-map-seek`) |
+| `thread_id = args.get("thread_id", session_cid)` | `ctx-thread-id` fallback chain                 |
+| `input_state = args.get("input", args)`          | `ctx-prompt-via-input` → `ctx-prompt-direct`   |
+| `json.dumps(result)` → CBOR `{"ok": json}`       | `state-json` + `ok-result` (`cbor-enc-*`)      |
+| `KotobaCheckpointer.save` → kqe quad             | `ckpt-save!` → `kqe-assert!`                   |
+
+Both emit the identical wire bytes: input is the CBOR `InvokeContext`
+(`{"graph", "session_cid", "args": {"input": {"prompt"}, "thread_id"}}`),
+output is CBOR `{"ok": "{\"prompt\": \"…\", \"response\": \"…\"}"}` (including
+`json.dumps`' default separators and key order), and the checkpoint quad is
+`lgraph/ckpt / <thread_id> / state / {"Text": <JSON state>}`.
+
+## Build + run
+
+No componentize-py, no venv, no 18 MB CPython bundle — the test compiles the
+example source itself and drives it through the runtime's real `WasmExecutor`:
+
+```sh
+cargo test -p kotoba-clj --test langgraph_echo
+```
+
+(`compile_kais_component_str(prelude() + agent.clj)` → kotoba-node component →
+`WasmExecutor::execute` → `run(ctx_cbor)`.)
+
+## Size
+
+| build | component size |
+|---|---|
+| componentize-py (`../kotoba-langgraph-echo/agent.wasm`) | **18,481,059 bytes (~18 MB)** |
+| kotoba-clj (this agent + full prelude)                  | **4,811 bytes (~4.7 KB)** |
+
+≈ **3,840× smaller**, because the Clojure source compiles to wasm directly
+instead of shipping an interpreter.
+
+## Subset gaps vs the Python actor
+
+Faithful except where the kotoba-clj subset can't express it yet:
+
+- **No JSON string escaping** — `state-json` splices the prompt verbatim; a
+  prompt containing `"` or `\` would produce different (invalid) JSON than
+  `json.dumps`. Fine for the liveness-probe role.
+- **Checkpointer `load` is not implemented** — `KotobaCheckpointer.load` parses
+  the persisted JSON back into a dict; the subset has no JSON parser, so prior
+  thread state is not rehydrated. For the echo graph this is semantically
+  invisible (both channels are overwritten every turn); a stateful port would
+  persist the state as CBOR (decodable in-guest via `cbor-map-seek`) instead of
+  JSON. `save` (the `kqe-assert!` write) is fully implemented.
+- **No `{"err": traceback}` path** — Python wraps node exceptions into an
+  `{"err": …}` CBOR result; the compiled subset has no exceptions (a trap
+  surfaces as the executor's own error), so only the `{"ok": …}` shape is
+  emitted.
+- **`MAX_STEPS` / interrupts / `stream()`** — graph.py's step cap and streaming
+  API have no counterpart; the `defgraph` runner loops until the `:end`
+  terminator (irrelevant for a single-node linear graph).

--- a/examples/kotoba-langgraph-echo-clj/agent.clj
+++ b/examples/kotoba-langgraph-echo-clj/agent.clj
@@ -1,0 +1,122 @@
+;; kotoba-langgraph-echo-clj — the Clojure-WASM port of the componentize-py
+;; LangGraph echo agent (../kotoba-langgraph-echo/agent.py), compiled by the
+;; in-repo kotoba-clj Clojure→WASM compiler.
+;;
+;; Graph (identical to agent.py):
+;;   START → echo → END        ; echo: {"response": state["prompt"]}
+;;
+;; Wire format (identical to py/kotoba_langgraph/_entry.py handle_invoke):
+;;   in:  CBOR {"graph": str, "session_cid": str,
+;;              "args": {"input": {"prompt": str}, "thread_id": str}}
+;;   out: CBOR {"ok": "<JSON string of the final state>"}
+;;
+;; Checkpointer (identical layout to py/kotoba_langgraph/checkpointer.py):
+;;   kqe quad — graph "lgraph/ckpt" / subject <thread_id> / predicate "state"
+;;   / object CBOR {"Text": <JSON state>}.
+;;
+;; Compile with the kotoba-clj prelude prepended (containers + CBOR decode/
+;; encode + kqe accessors) via `compile_kais_component_str`; the `run` defn
+;; satisfies the kotoba-node world's
+;; `run: func(ctx-cbor: list<u8>) -> result<list<u8>, string>` export.
+;; See crates/kotoba-clj/tests/langgraph_echo.rs for the build + invoke recipe.
+
+;; ---- byte-builder helper -----------------------------------------------------
+
+;; append the raw bytes of string handle s to byte-builder b (returns b)
+(defn buf-str! [b s]
+  (loop [i 0]
+    (if (>= i (str-len s))
+      b
+      (do (byte-append! b (byte-at s i)) (recur (+ i 1))))))
+
+;; ---- the echo graph (agent.py: StateGraph(EchoState)) -------------------------
+
+;; _echo(state) -> {"response": state.get("prompt", "")} — a *partial update*;
+;; the defgraph :state merge applies it with override semantics, exactly like
+;; graph.py's _apply_update on a reducer-free EchoState TypedDict.
+(defn echo [state]
+  (let [u (map-make 2)]
+    (map-assoc! u "response" (map-get state "prompt"))))
+
+(defgraph echo-graph
+  :state {:prompt :override :response :override}
+  :entry :echo
+  :nodes {:echo echo}
+  :edges {:echo :end})
+
+;; ---- InvokeContext decode (py/kotoba_langgraph/_entry.py) ---------------------
+;; cbor-map-seek consumes the map as it scans, so each lookup walks a fresh
+;; reader over the same ctx bytes.
+
+;; session_cid = ctx.get("session_cid", "default")
+(defn ctx-session-cid [ctx]
+  (let [r (cbor-reader ctx)]
+    (if (= (cbor-map-seek r "session_cid") 1) (cbor-text r) "default")))
+
+;; thread_id = args.get("thread_id", session_cid)
+(defn ctx-thread-id [ctx]
+  (let [r (cbor-reader ctx)]
+    (if (= (cbor-map-seek r "args") 1)
+      (if (= (cbor-map-seek r "thread_id") 1)
+        (cbor-text r)
+        (ctx-session-cid ctx))
+      (ctx-session-cid ctx))))
+
+;; args.input.prompt — or the -1 sentinel when args has no "input" key
+(defn ctx-prompt-via-input [ctx]
+  (let [r (cbor-reader ctx)]
+    (if (= (cbor-map-seek r "args") 1)
+      (if (= (cbor-map-seek r "input") 1)
+        (if (= (cbor-map-seek r "prompt") 1) (cbor-text r) "")
+        -1)
+      -1)))
+
+;; input_state = args.get("input", args): no "input" → read prompt off args itself
+(defn ctx-prompt-direct [ctx]
+  (let [r (cbor-reader ctx)]
+    (if (= (cbor-map-seek r "args") 1)
+      (if (= (cbor-map-seek r "prompt") 1) (cbor-text r) "")
+      "")))
+
+(defn ctx-prompt [ctx]
+  (let [p (ctx-prompt-via-input ctx)]
+    (if (= p -1) (ctx-prompt-direct ctx) p)))
+
+;; ---- result serialisation (handle_invoke: json.dumps(result)) -----------------
+
+;; {"prompt": "<p>", "response": "<r>"} — json.dumps' default separators.
+;; Gap: no JSON string escaping (a prompt containing `"` or `\` differs from py).
+(defn state-json [prompt response]
+  (let [b (bytes-alloc (+ 48 (+ (str-len prompt) (str-len response))))]
+    (buf-str! b "{\"prompt\": \"")
+    (buf-str! b prompt)
+    (buf-str! b "\", \"response\": \"")
+    (buf-str! b response)
+    (buf-str! b "\"}")
+    (bytes-finish b)))
+
+;; CBOR {"ok": <json>} — handle_invoke's success wire format
+(defn ok-result [json]
+  (let [out (bytes-alloc (+ 16 (str-len json)))]
+    (cbor-enc-map-header! out 1)
+    (cbor-enc-text! out "ok")
+    (cbor-enc-text! out json)
+    (bytes-finish out)))
+
+;; ---- KotobaCheckpointer.save (py/kotoba_langgraph/checkpointer.py) ------------
+;; object = CBOR {"Text": <JSON state>} — the ciborium QuadObject::Text encoding
+(defn ckpt-save! [thread-id state-json]
+  (let [obj (bytes-alloc (+ 16 (str-len state-json)))]
+    (cbor-enc-map-header! obj 1)
+    (cbor-enc-text! obj "Text")
+    (cbor-enc-text! obj state-json)
+    (kqe-assert! "lgraph/ckpt" thread-id "state" (bytes-finish obj))))
+
+;; ---- WitWorld.run — the kotoba-node export -------------------------------------
+(defn run [ctx]
+  (let [s (map-make 8)]
+    (map-assoc! s "prompt" (ctx-prompt ctx))
+    (let [final (echo-graph s)
+          json (state-json (map-get final "prompt") (map-get final "response"))]
+      (ckpt-save! (ctx-thread-id ctx) json)
+      (ok-result json))))


### PR DESCRIPTION
## What

Ports the Python (componentize-py) LangGraph echo example to a **kotoba-clj `defgraph` Clojure-WASM component**, proving the migration path off `py/kotoba_langgraph` (root-repo counterpart: etzhayyim/root#1706, per ADR-2606120500 in root).

- `examples/kotoba-langgraph-echo-clj/agent.clj` — `defgraph echo-graph` mirroring the Python echo agent: CBOR `InvokeContext` decode (incl. the `thread_id` → `session_cid` and `input` → `args` fallback chains), `{"ok": <json>}` output, and `KotobaCheckpointer.save` semantics via `kqe-assert!` (`lgraph/ckpt` quad layout, ciborium `{"Text": …}` object encoding — byte-identical to the Python actor)
- `crates/kotoba-clj/tests/langgraph_echo.rs` — 6 tests compiling the example through `compile_kais_component_str` and executing it on the real kotoba-runtime `WasmExecutor` (echo round-trip, promptless input, args-as-input fallback, checkpoint quad + gas, thread-id default, size guard)
- README documenting the mapping + remaining subset gaps (JSON string escaping; checkpointer `load` — persist CBOR instead; no err-map path; no MAX_STEPS/interrupts)

## Numbers

| | componentize-py | kotoba-clj |
|---|---|---|
| component size | 18,481,059 bytes (~18 MB, bundled CPython) | **4,811 bytes** (~3,840× smaller) |

`cargo test -p kotoba-clj`: 6 new + 95 pre-existing tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)