### PR TITLE
[codex] Improve kotoba-clj Clojure source compatibility

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -16,10 +16,10 @@ n= 5  fact=120         fib=5
 n=10  fact=3628800     fib=55
 ```
 
-## `.kotoba` files
+## `.kotoba` / `.clj` / `.cljc` / `.cljs` files
 
-`kotoba-clj` also installs a runner for Clojure-subset source files with the
-`.kotoba` extension:
+`kotoba-clj` also installs a runner for Clojure-subset source files. `.kotoba`,
+`.clj`, `.cljc`, and `.cljs` are accepted as source extensions:
 
 ```clojure
 #!/usr/bin/env kotoba-clj
@@ -32,11 +32,79 @@ $ kotoba-clj app.kotoba 41
 42
 $ kotoba-clj --func fact math.kotoba 5
 120
+$ kotoba-clj agent.cljc 41
+42
 ```
 
 By default the file runner prepends the kotoba-clj prelude, so common
 container helpers such as `count`, `nth`, `get`, and `assoc!` are available.
 Use `--no-prelude` for a bare compiler surface.
+
+This is a Clojure compatibility entry point, not JVM Clojure or ClojureScript
+runtime compatibility. `.clj` / `.cljc` / `.cljs` files still need to compile to
+the kotoba-clj subset below. For `.cljc`, reader conditionals are expanded before
+lowering:
+
+```clojure
+#?(:kotoba (defn main [x] (+ x 10))
+   :clj    (defn main [x] (+ x 1)))
+```
+
+The default reader target is `kotoba`, with `:clj` as fallback and `:default`
+after that. Use `--reader-target clj` or `--reader-target cljs` to select a
+different branch.
+
+`ns` forms may include simple `:require` / `:use` specs; top-level `(require
+'[...])` and `(use '[...])` forms are also accepted for script-style files.
+Neighboring namespaces are loaded from the entry file's directory using
+Clojure-style paths (`demo.util` → `demo/util.clj` / `.cljc` / `.cljs` /
+`.kotoba`), and `:as` / `:refer` calls are rewritten before lowering. When
+multiple files exist for a namespace, the reader target controls the extension
+priority (`kotoba`: `.kotoba`, `.cljc`, `.clj`, `.cljs`; `clj`: `.cljc`,
+`.clj`, `.kotoba`, `.cljs`; `cljs`: `.cljc`, `.cljs`, `.clj`, `.kotoba`).
+`:as-alias` records a compile-time alias without loading the target namespace.
+`clojure.*` and `cljs.*` requires are also not loaded from files; using functions
+outside the kotoba-clj subset still fails during lowering/codegen:
+
+```clojure
+(ns demo.main
+  (:require [demo.util :as u]
+            [demo.math :refer [twice]]))
+
+(defn main [x]
+  (+ (u/add x 2) (twice x)))
+```
+
+This resolver is intentionally small: it does not implement full classpath
+semantics, macros, reload semantics, or JVM/CLJS libraries.
+
+Common reader noise is accepted and ignored where it does not affect runtime
+semantics: discard forms (`#_`), metadata (`^:private`, `^String`, parameter
+metadata), top-level `(comment ...)`, top-level `(declare ...)`, and optional
+`def` / `defn` docstrings plus `defn` attr maps. Top-level namespace management
+forms (`in-ns`, `alias`, `create-ns`, `remove-ns`), `(refer-clojure ...)`,
+`(import ...)`, `(gen-class ...)`, `(set! ...)`, and unused record/type/protocol
+or multimethod/struct declarations are accepted as declarations. `defonce` lowers
+like `def`, and `defn-` lowers like `defn` for source compatibility. Top-level
+`defmacro` forms are accepted for macro-only namespaces loaded via
+`require-macros`, but macros are not expanded. Clojure-style multi-arity `defn`
+is supported for
+source-level calls by resolving on the call's argument count; `defn` pre/post
+condition maps are accepted but not asserted. Single-arity definitions remain
+exported under their source name. The common threading macros `->`, `->>`,
+`cond->`, `cond->>`, `some->`, `some->>`, and `as->` are expanded during
+lowering.
+
+The entry file's directory is always searched. If a `deps.edn` is found in the
+entry file's directory or one of its ancestors, its top-level `:paths` vector is
+also searched. Additional source roots can be provided with repeated
+`--source-path` / `-S` flags or the platform path-list environment variable
+`KOTOBA_CLJ_PATH`:
+
+```sh
+kotoba-clj -S src -S vendor app/main.clj 41
+KOTOBA_CLJ_PATH=src:vendor kotoba-clj app/main.clj 41
+```
 
 ## Pipeline
 
@@ -61,12 +129,29 @@ i64 result
 Stack values are 64-bit: a number/boolean is the i64 (booleans `1`/`0`, truthy ⇔
 non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
 
-- top-level: `(def name <const>)`, `(defn name [params…] body…)`, `(ns …)` (ignored)
-- control: `if`, `when`, `cond`, `let` (sequential), `do`, `loop`/`recur` (bounded)
+- top-level: `(def name "doc?" <const>)`,
+  `(defonce name "doc?" <const>)`, `(defn name "doc?" attr-map? [params…] body…)`,
+  `(defn name "doc?" attr-map? ([params…] body…) ([params…] body…))`,
+  `(defn- …)`, top-level `(do …)` wrapping definitions, `(ns …)`,
+  `(in-ns …)`, `(alias …)`, `(create-ns …)`, `(remove-ns …)`, `(require …)`,
+  `(use …)`, `(refer-clojure …)`, `(import …)`, `(gen-class …)`, `(set! …)`,
+  `(defrecord …)`, `(deftype …)`, `(defprotocol …)`, `(extend-type …)`,
+  `(extend-protocol …)`, `(defmulti …)`, `(defmethod …)`, `(defmacro …)`,
+  `(defstruct …)`, `(create-struct …)`, `(comment …)`, and `(declare …)`
+  (ignored where noted)
+- control: `if`, `when`, `if-let`, `when-let`, `cond`, `case`, `let` (sequential),
+  `do`, `loop`/`recur` (bounded), threading macros `->`, `->>`, `cond->`,
+  `cond->>`, `some->`, `some->>`, and `as->`
 - arithmetic: `+ - * / quot mod rem inc dec abs` · comparison:
   `= not= < > <= >=` (n-ary where Clojure is n-ary) · predicates:
   `zero? pos? neg?` · logic: `and or not`
 - strings: `"…"` literals, `(str-len s)`, `(byte-at s i)`
+- Clojure literals: `nil` lowers to `0`; keyword literals and quoted forms
+  (`'foo`, `'(a b)`, `(quote {:k 1})`) lower to canonical EDN string handles;
+  var quote (`#'foo`, `(var foo)`) lowers to the referenced symbol name handle
+- Clojure reader metadata (`^:private`, `^String`, `^long`) is stripped before
+  lowering.
+- Clojure discard forms (`#_ form`) are stripped before lowering.
 - byte builder: `(bytes-alloc cap)`, `(byte-append! buf b)`, `(bytes-len buf)`,
   `(bytes-finish buf)` — mutable buffer in linear memory; `bytes-finish` → string handle
 - raw memory: `(alloc n)`, `(load64 a)`, `(store64! a v)`, `(load32 a)`, `(store32! a v)`
@@ -86,11 +171,14 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
   `cbor-enc-map-header!`, `cbor-enc-array-header!` — return a structured result
 - `defgraph`: a langgraph-shaped node/edge graph (`:entry`/`:nodes`/`:edges`,
   static + `(if-edge pred? :then :else)` edges) → dispatch/next/runner `defn`s
-- user `defn` calls, including (mutual) recursion
+- user `defn` calls, including (mutual) recursion and arity-based resolution
 
-Each `defn` is exported under its name. `def` initialisers are folded to a
-compile-time constant and inlined. Every module also exports a linear `memory`
-and a `cabi_realloc` bump allocator (the Canonical-ABI substrate).
+Each single-arity `defn` is exported under its name. Multi-arity `defn`s are
+resolved for source-level calls and Component entry wrapping, but are not
+exported as multiple same-name core wasm functions. `def` initialisers are
+folded to a compile-time constant and inlined. Every module also exports a
+linear `memory` and a `cabi_realloc` bump allocator (the Canonical-ABI
+substrate).
 
 ## Roadmap to the kotoba:kais binding
 

--- a/crates/kotoba-clj/src/ast.rs
+++ b/crates/kotoba-clj/src/ast.rs
@@ -3,15 +3,22 @@
 //!
 //! Subset (everything is a 64-bit signed integer; booleans are 1/0):
 //!   top-level   `(def name <const-expr>)`     compile-time integer constant
-//!               `(defn name [a b …] body…)`   exported wasm function
-//!               `(ns …)`                        ignored (namespace decl)
+//!               `(defn name [a b …] body…)` / `(defn- …)` wasm function
+//!               multi-arity `(defn name ([a] …) ([a b] …))`
+//!               `(defonce name <const-expr>)` compile-time integer constant
+//!               top-level `(do …)` wrapping definitions
+//!               `(ns …)` namespace management decls, `(require …)` `(use …)` `(refer-clojure …)` `(import …)` `(gen-class …)` `(set! …)` record/type/protocol/multimethod decls, `(defmacro …)`, `(comment …)`, `(declare …)` ignored
 //!   expressions integer literal, `true`/`false`, symbol
-//!               `(if c t e)`  `(when c body…)`
+//!               `(if c t e)`  `(when c body…)` `(if-let [b v] t e)`
+//!               `(when-let [b v] body…)` `(case e test result … default?)`
 //!               `(let [b v …] body…)`  `(do e…)`
+//!               `(-> x step…)` `(->> x step…)` `(cond-> x test step …)`
+//!               `(cond->> x test step …)` `(some-> x step…)`
+//!               `(some->> x step…)` `(as-> x name form …)`
 //!               builtins: + - * / mod  = < > <= >=  and or not
 //!               `(f args…)`  call a user `defn`
 
-use kotoba_edn::{EdnValue, Symbol};
+use kotoba_edn::{to_string as edn_to_string, EdnValue, Symbol};
 
 use crate::CljError;
 
@@ -29,10 +36,13 @@ pub struct Def {
     pub value: Expr,
 }
 
-/// `(defn name [params…] body…)` — becomes an exported wasm function.
+/// `(defn name [params…] body…)` — becomes an exported wasm function when
+/// `export_name` is set. Multi-arity definitions share `name` for source-level
+/// calls and are resolved by arity during codegen.
 #[derive(Debug, Clone)]
 pub struct Function {
     pub name: String,
+    pub export_name: Option<String>,
     pub params: Vec<String>,
     /// Implicit `do`: the last expression is the return value.
     pub body: Vec<Expr>,
@@ -288,30 +298,50 @@ pub fn parse_program(src: &str) -> Result<Program, CljError> {
     let mut functions = Vec::new();
 
     for form in &forms {
-        let items = match form {
-            EdnValue::List(items) => items,
-            // A bare top-level non-list (e.g. a stray literal) is meaningless.
-            other => {
-                return Err(CljError::Lower(format!(
-                    "top-level form must be a list, found: {other:?}"
-                )))
-            }
-        };
-        let head = list_head_symbol(items)?;
-        match head.name.as_str() {
-            "ns" => { /* namespace declaration — accepted and ignored */ }
-            "def" => defs.push(lower_def(items)?),
-            "defn" => functions.push(lower_defn(items)?),
-            "defgraph" => functions.extend(lower_defgraph(items)?),
-            other => {
-                return Err(CljError::Lower(format!(
-                    "unsupported top-level form `({other} …)` — expected def/defn/ns/defgraph"
-                )))
-            }
-        }
+        parse_top_level_form(form, &mut defs, &mut functions)?;
     }
 
     Ok(Program { defs, functions })
+}
+
+fn parse_top_level_form(
+    form: &EdnValue,
+    defs: &mut Vec<Def>,
+    functions: &mut Vec<Function>,
+) -> Result<(), CljError> {
+    let items = match form {
+        EdnValue::List(items) => items,
+        // A bare top-level non-list (e.g. a stray literal) is meaningless.
+        other => {
+            return Err(CljError::Lower(format!(
+                "top-level form must be a list, found: {other:?}"
+            )))
+        }
+    };
+    let head = list_head_symbol(items)?;
+    match head.name.as_str() {
+        "ns" | "require" | "require-macros" | "use" | "use-macros" | "refer-clojure"
+        | "in-ns" | "alias" | "create-ns" | "remove-ns" | "import" | "gen-class" | "set!"
+        | "defrecord" | "deftype" | "defprotocol" | "extend-type" | "extend-protocol"
+        | "defmulti" | "defmethod" | "defmacro" | "defstruct" | "create-struct" | "comment"
+        | "declare" => {
+            /* source-compat declarations — accepted and ignored */
+        }
+        "do" => {
+            for item in &items[1..] {
+                parse_top_level_form(item, defs, functions)?;
+            }
+        }
+        "def" | "defonce" => defs.push(lower_def(items)?),
+        "defn" | "defn-" => functions.extend(lower_defn(items)?),
+        "defgraph" => functions.extend(lower_defgraph(items)?),
+        other => {
+            return Err(CljError::Lower(format!(
+                "unsupported top-level form `({other} …)` — expected def/defonce/defn/defn-/defmacro/ns/namespace-management/require/use/refer-clojure/import/gen-class/set!/record-type-protocol-multimethod/struct/defgraph/do/comment/declare"
+            )))
+        }
+    }
+    Ok(())
 }
 
 fn list_head_symbol(items: &[EdnValue]) -> Result<&Symbol, CljError> {
@@ -324,27 +354,60 @@ fn list_head_symbol(items: &[EdnValue]) -> Result<&Symbol, CljError> {
 }
 
 fn lower_def(items: &[EdnValue]) -> Result<Def, CljError> {
-    // (def name value)
-    if items.len() != 3 {
+    // (def name "doc?" value)
+    if items.len() != 3 && items.len() != 4 {
         return Err(CljError::Lower(
-            "def takes exactly: (def name value)".into(),
+            "def takes exactly: (def name \"doc?\" value)".into(),
         ));
     }
     let name = sym_name(&items[1], "def name")?;
-    let value = lower_expr(&items[2])?;
+    let value_idx = if items.len() == 4 && matches!(items.get(2), Some(EdnValue::String(_))) {
+        3
+    } else {
+        2
+    };
+    let value = lower_expr(&items[value_idx])?;
     Ok(Def { name, value })
 }
 
-fn lower_defn(items: &[EdnValue]) -> Result<Function, CljError> {
-    // (defn name [params…] body…)
-    if items.len() < 4 {
+fn lower_defn(items: &[EdnValue]) -> Result<Vec<Function>, CljError> {
+    // (defn name "doc?" attr-map? [params…] body…)
+    // (defn name "doc?" attr-map? ([params…] body…) ([params…] body…))
+    if items.len() < 3 {
         return Err(CljError::Lower(
-            "defn requires: (defn name [params…] body…)".into(),
+            "defn requires: (defn name \"doc?\" attr-map? [params…] body…)".into(),
         ));
     }
     let name = sym_name(&items[1], "defn name")?;
-    let params = match &items[2] {
-        EdnValue::Vector(ps) => ps
+    let mut params_idx = 2;
+    if matches!(items.get(params_idx), Some(EdnValue::String(_))) {
+        params_idx += 1;
+    }
+    if matches!(items.get(params_idx), Some(EdnValue::Map(_))) {
+        params_idx += 1;
+    }
+    if let Some(EdnValue::List(arity)) = items.get(params_idx) {
+        if !items[params_idx..]
+            .iter()
+            .all(|item| matches!(item, EdnValue::List(_)))
+        {
+            return Err(CljError::Lower(format!(
+                "defn `{name}` arity-list form cannot be mixed with non-arity body forms"
+            )));
+        }
+        if items.len() == params_idx + 1 {
+            return Ok(vec![lower_defn_arity(&name, arity, Some(name.clone()))?]);
+        }
+        return items[params_idx..]
+            .iter()
+            .map(|item| match item {
+                EdnValue::List(arity) => lower_defn_arity(&name, arity, None),
+                _ => unreachable!("checked above"),
+            })
+            .collect();
+    }
+    let params = match items.get(params_idx) {
+        Some(EdnValue::Vector(ps)) => ps
             .iter()
             .map(|p| sym_name(p, "defn parameter"))
             .collect::<Result<Vec<_>, _>>()?,
@@ -354,18 +417,94 @@ fn lower_defn(items: &[EdnValue]) -> Result<Function, CljError> {
             )))
         }
     };
-    let body = items[3..]
+    if items.len() <= params_idx + 1 {
+        return Err(CljError::Lower(format!(
+            "defn `{name}` requires at least one body expression"
+        )));
+    }
+    let body_idx = skip_prepost_map(items, params_idx + 1);
+    if items.len() <= body_idx {
+        return Err(CljError::Lower(format!(
+            "defn `{name}` requires at least one body expression after pre/post conditions"
+        )));
+    }
+    let body = items[body_idx..]
         .iter()
         .map(lower_expr)
         .collect::<Result<Vec<_>, _>>()?;
-    Ok(Function { name, params, body })
+    Ok(vec![Function {
+        export_name: Some(name.clone()),
+        name,
+        params,
+        body,
+    }])
+}
+
+fn lower_defn_arity(
+    name: &str,
+    items: &[EdnValue],
+    export_name: Option<String>,
+) -> Result<Function, CljError> {
+    if items.len() < 2 {
+        return Err(CljError::Lower(format!(
+            "defn `{name}` arity-list requires: ([params…] body…)"
+        )));
+    }
+    let params = match &items[0] {
+        EdnValue::Vector(ps) => ps
+            .iter()
+            .map(|p| sym_name(p, "defn parameter"))
+            .collect::<Result<Vec<_>, _>>()?,
+        _ => {
+            return Err(CljError::Lower(format!(
+                "defn `{name}` arity-list must begin with a parameter vector"
+            )))
+        }
+    };
+    let body_idx = skip_prepost_map(items, 1);
+    if items.len() <= body_idx {
+        return Err(CljError::Lower(format!(
+            "defn `{name}` arity-list requires at least one body expression after pre/post conditions"
+        )));
+    }
+    let body = items[body_idx..]
+        .iter()
+        .map(lower_expr)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Function {
+        name: name.to_string(),
+        export_name,
+        params,
+        body,
+    })
+}
+
+fn skip_prepost_map(items: &[EdnValue], body_idx: usize) -> usize {
+    match items.get(body_idx) {
+        Some(EdnValue::Map(m)) if is_prepost_map(m) => body_idx + 1,
+        _ => body_idx,
+    }
+}
+
+fn is_prepost_map(m: &std::collections::BTreeMap<EdnValue, EdnValue>) -> bool {
+    !m.is_empty()
+        && m.keys().all(|k| {
+            matches!(
+                k,
+                EdnValue::Keyword(keyword)
+                    if keyword.namespace().is_none()
+                        && matches!(keyword.name(), "pre" | "post")
+            )
+        })
 }
 
 fn lower_expr(v: &EdnValue) -> Result<Expr, CljError> {
     match v {
+        EdnValue::Nil => Ok(Expr::Int(0)),
         EdnValue::Integer(i) => Ok(Expr::Int(*i)),
         EdnValue::Bool(b) => Ok(Expr::Int(if *b { 1 } else { 0 })),
         EdnValue::String(s) => Ok(Expr::Str(s.clone().into_bytes())),
+        EdnValue::Keyword(_) => Ok(Expr::Str(edn_to_string(v).into_bytes())),
         EdnValue::Symbol(s) => Ok(Expr::Var(s.to_qualified())),
         EdnValue::List(items) => lower_call(items),
         other => Err(CljError::Lower(format!(
@@ -386,12 +525,24 @@ fn lower_call(items: &[EdnValue]) -> Result<Expr, CljError> {
     match special {
         "if" => lower_if(args),
         "when" => lower_when(args),
+        "if-let" => lower_if_let(args),
+        "when-let" => lower_when_let(args),
         "let" => lower_let(args),
         "cond" => lower_cond(args),
+        "case" => lower_case(args),
         "loop" => lower_loop(args),
         "recur" => Ok(Expr::Recur(
             args.iter().map(lower_expr).collect::<Result<_, _>>()?,
         )),
+        "quote" => lower_quote(args),
+        "var" => lower_var(args),
+        "->" => lower_thread(args, ThreadPosition::First),
+        "->>" => lower_thread(args, ThreadPosition::Last),
+        "cond->" => lower_cond_thread(args, ThreadPosition::First),
+        "cond->>" => lower_cond_thread(args, ThreadPosition::Last),
+        "some->" => lower_some_thread(args, ThreadPosition::First),
+        "some->>" => lower_some_thread(args, ThreadPosition::Last),
+        "as->" => lower_as_thread(args),
         "do" => Ok(Expr::Do(
             args.iter().map(lower_expr).collect::<Result<_, _>>()?,
         )),
@@ -408,6 +559,166 @@ fn lower_call(items: &[EdnValue]) -> Result<Expr, CljError> {
             }
         }
     }
+}
+
+fn lower_quote(args: &[EdnValue]) -> Result<Expr, CljError> {
+    if args.len() != 1 {
+        return Err(CljError::Lower("quote takes: (quote form)".into()));
+    }
+    Ok(Expr::Str(edn_to_string(&args[0]).into_bytes()))
+}
+
+fn lower_var(args: &[EdnValue]) -> Result<Expr, CljError> {
+    if args.len() != 1 {
+        return Err(CljError::Lower("var takes: (var symbol)".into()));
+    }
+    match &args[0] {
+        EdnValue::Symbol(_) => Ok(Expr::Str(edn_to_string(&args[0]).into_bytes())),
+        other => Err(CljError::Lower(format!(
+            "var requires a symbol, found {other:?}"
+        ))),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum ThreadPosition {
+    First,
+    Last,
+}
+
+fn lower_thread(args: &[EdnValue], position: ThreadPosition) -> Result<Expr, CljError> {
+    let Some((first, steps)) = args.split_first() else {
+        return Err(CljError::Lower("threading macro requires a value".into()));
+    };
+    let mut acc = first.clone();
+    for step in steps {
+        acc = thread_step(acc, step, position)?;
+    }
+    lower_expr(&acc)
+}
+
+fn thread_step(
+    value: EdnValue,
+    step: &EdnValue,
+    position: ThreadPosition,
+) -> Result<EdnValue, CljError> {
+    match step {
+        EdnValue::List(items) => {
+            let Some((head, args)) = items.split_first() else {
+                return Err(CljError::Lower(
+                    "threading macro step cannot be an empty list".into(),
+                ));
+            };
+            let mut out = Vec::with_capacity(items.len() + 1);
+            out.push(head.clone());
+            match position {
+                ThreadPosition::First => {
+                    out.push(value);
+                    out.extend(args.iter().cloned());
+                }
+                ThreadPosition::Last => {
+                    out.extend(args.iter().cloned());
+                    out.push(value);
+                }
+            }
+            Ok(EdnValue::List(out))
+        }
+        EdnValue::Symbol(_) => Ok(EdnValue::List(vec![step.clone(), value])),
+        other => Err(CljError::Lower(format!(
+            "threading macro step must be a list or symbol, found: {other:?}"
+        ))),
+    }
+}
+
+fn lower_cond_thread(args: &[EdnValue], position: ThreadPosition) -> Result<Expr, CljError> {
+    let Some((first, clauses)) = args.split_first() else {
+        return Err(CljError::Lower(
+            "conditional threading macro requires a value".into(),
+        ));
+    };
+    if clauses.len() % 2 != 0 {
+        return Err(CljError::Lower(
+            "conditional threading macro requires test/step pairs".into(),
+        ));
+    }
+    let thread_value = "__kotoba_cond_thread_value".to_string();
+    let mut body = Expr::Var(thread_value.clone());
+    for pair in clauses.chunks_exact(2).rev() {
+        let threaded = thread_step(
+            EdnValue::Symbol(Symbol::bare(thread_value.clone())),
+            &pair[1],
+            position,
+        )?;
+        body = Expr::Let {
+            bindings: vec![(
+                thread_value.clone(),
+                Expr::If {
+                    cond: Box::new(lower_expr(&pair[0])?),
+                    then: Box::new(lower_expr(&threaded)?),
+                    els: Box::new(Expr::Var(thread_value.clone())),
+                },
+            )],
+            body: vec![body],
+        };
+    }
+    Ok(Expr::Let {
+        bindings: vec![(thread_value, lower_expr(first)?)],
+        body: vec![body],
+    })
+}
+
+fn lower_some_thread(args: &[EdnValue], position: ThreadPosition) -> Result<Expr, CljError> {
+    let Some((first, steps)) = args.split_first() else {
+        return Err(CljError::Lower(
+            "nil-aware threading macro requires a value".into(),
+        ));
+    };
+    let thread_value = "__kotoba_some_thread_value".to_string();
+    let mut body = Expr::Var(thread_value.clone());
+    for step in steps.iter().rev() {
+        let threaded = thread_step(
+            EdnValue::Symbol(Symbol::bare(thread_value.clone())),
+            step,
+            position,
+        )?;
+        body = Expr::Let {
+            bindings: vec![(
+                thread_value.clone(),
+                Expr::If {
+                    cond: Box::new(Expr::Var(thread_value.clone())),
+                    then: Box::new(lower_expr(&threaded)?),
+                    els: Box::new(Expr::Int(0)),
+                },
+            )],
+            body: vec![body],
+        };
+    }
+    Ok(Expr::Let {
+        bindings: vec![(thread_value, lower_expr(first)?)],
+        body: vec![body],
+    })
+}
+
+fn lower_as_thread(args: &[EdnValue]) -> Result<Expr, CljError> {
+    if args.len() < 2 {
+        return Err(CljError::Lower("as-> takes: (as-> expr name form…)".into()));
+    }
+    let name = sym_name(&args[1], "as-> binding name")?;
+    let mut forms = args[2..].iter().rev();
+    let mut body = match forms.next() {
+        Some(last) => lower_expr(last)?,
+        None => Expr::Var(name.clone()),
+    };
+    for form in forms {
+        body = Expr::Let {
+            bindings: vec![(name.clone(), lower_expr(form)?)],
+            body: vec![body],
+        };
+    }
+    Ok(Expr::Let {
+        bindings: vec![(name, lower_expr(&args[0])?)],
+        body: vec![body],
+    })
 }
 
 fn lower_if(args: &[EdnValue]) -> Result<Expr, CljError> {
@@ -436,6 +747,72 @@ fn lower_when(args: &[EdnValue]) -> Result<Expr, CljError> {
         then: Box::new(Expr::Do(body)),
         els: Box::new(Expr::Int(0)),
     })
+}
+
+fn lower_if_let(args: &[EdnValue]) -> Result<Expr, CljError> {
+    if args.len() < 2 || args.len() > 3 {
+        return Err(CljError::Lower(
+            "if-let takes: (if-let [name init] then else?)".into(),
+        ));
+    }
+    let (name, init) = lower_single_binding(args.first(), "if-let")?;
+    let then = lower_expr(&args[1])?;
+    let els = match args.get(2) {
+        Some(els) => lower_expr(els)?,
+        None => Expr::Int(0),
+    };
+    Ok(Expr::Let {
+        bindings: vec![(name.clone(), init)],
+        body: vec![Expr::If {
+            cond: Box::new(Expr::Var(name)),
+            then: Box::new(then),
+            els: Box::new(els),
+        }],
+    })
+}
+
+fn lower_when_let(args: &[EdnValue]) -> Result<Expr, CljError> {
+    if args.len() < 2 {
+        return Err(CljError::Lower(
+            "when-let takes: (when-let [name init] body…)".into(),
+        ));
+    }
+    let (name, init) = lower_single_binding(args.first(), "when-let")?;
+    let body = args[1..]
+        .iter()
+        .map(lower_expr)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Expr::Let {
+        bindings: vec![(name.clone(), init)],
+        body: vec![Expr::If {
+            cond: Box::new(Expr::Var(name)),
+            then: Box::new(Expr::Do(body)),
+            els: Box::new(Expr::Int(0)),
+        }],
+    })
+}
+
+fn lower_single_binding(
+    binding_form: Option<&EdnValue>,
+    form_name: &str,
+) -> Result<(String, Expr), CljError> {
+    let binding_vec = match binding_form {
+        Some(EdnValue::Vector(v)) => v,
+        _ => {
+            return Err(CljError::Lower(format!(
+                "{form_name} requires a binding vector: ({form_name} [name init] …)"
+            )))
+        }
+    };
+    if binding_vec.len() != 2 {
+        return Err(CljError::Lower(format!(
+            "{form_name} binding vector must contain exactly one name/init pair"
+        )));
+    }
+    Ok((
+        sym_name(&binding_vec[0], &format!("{form_name} binding name"))?,
+        lower_expr(&binding_vec[1])?,
+    ))
 }
 
 fn lower_let(args: &[EdnValue]) -> Result<Expr, CljError> {
@@ -468,6 +845,72 @@ fn lower_let(args: &[EdnValue]) -> Result<Expr, CljError> {
         ));
     }
     Ok(Expr::Let { bindings, body })
+}
+
+fn lower_case(args: &[EdnValue]) -> Result<Expr, CljError> {
+    let Some((value, clauses)) = args.split_first() else {
+        return Err(CljError::Lower(
+            "case takes: (case expr test result … default?)".into(),
+        ));
+    };
+    if clauses.len() < 2 {
+        return Err(CljError::Lower(
+            "case requires at least one test/result clause".into(),
+        ));
+    }
+    let default = if clauses.len() % 2 == 1 {
+        lower_expr(clauses.last().expect("default exists"))?
+    } else {
+        Expr::Int(0)
+    };
+    let pairs = &clauses[..clauses.len() - (clauses.len() % 2)];
+    let case_value = "__kotoba_case_value".to_string();
+    let mut acc = default;
+    for pair in pairs.chunks_exact(2).rev() {
+        let tests = case_tests(&pair[0]);
+        let then = lower_expr(&pair[1])?;
+        let cond = lower_case_tests(&case_value, tests)?;
+        acc = Expr::If {
+            cond: Box::new(cond),
+            then: Box::new(then),
+            els: Box::new(acc),
+        };
+    }
+    Ok(Expr::Let {
+        bindings: vec![(case_value, lower_expr(value)?)],
+        body: vec![acc],
+    })
+}
+
+fn case_tests(test: &EdnValue) -> Vec<&EdnValue> {
+    match test {
+        EdnValue::List(xs) | EdnValue::Vector(xs) => xs.iter().collect(),
+        EdnValue::Set(xs) => xs.iter().collect(),
+        other => vec![other],
+    }
+}
+
+fn lower_case_tests(case_value: &str, tests: Vec<&EdnValue>) -> Result<Expr, CljError> {
+    if tests.is_empty() {
+        return Ok(Expr::Int(0));
+    }
+    let mut iter = tests.into_iter().rev();
+    let first = iter.next().expect("non-empty case tests");
+    let mut acc = case_eq(case_value, first)?;
+    for test in iter {
+        acc = Expr::Builtin {
+            op: Builtin::Or,
+            args: vec![case_eq(case_value, test)?, acc],
+        };
+    }
+    Ok(acc)
+}
+
+fn case_eq(case_value: &str, test: &EdnValue) -> Result<Expr, CljError> {
+    Ok(Expr::Builtin {
+        op: Builtin::Eq,
+        args: vec![Expr::Var(case_value.to_string()), lower_expr(test)?],
+    })
 }
 
 /// `(cond t1 e1 t2 e2 … [:else ed])` → right-nested `if`. A `:else` keyword (or
@@ -681,6 +1124,7 @@ fn lower_defgraph(items: &[EdnValue]) -> Result<Vec<Function>, CljError> {
     }
     let dispatch_fn = Function {
         name: dispatch_name.clone(),
+        export_name: Some(dispatch_name.clone()),
         params: vec!["__nid".into(), "__state".into()],
         body: vec![dispatch_body],
     };
@@ -706,6 +1150,7 @@ fn lower_defgraph(items: &[EdnValue]) -> Result<Vec<Function>, CljError> {
     }
     let next_fn = Function {
         name: next_name.clone(),
+        export_name: Some(next_name.clone()),
         params: vec!["__nid".into(), "__state".into()],
         body: vec![next_body],
     };
@@ -713,6 +1158,7 @@ fn lower_defgraph(items: &[EdnValue]) -> Result<Vec<Function>, CljError> {
     // runner: loop [__nid entry __s state] — dispatch then advance until -1.
     let runner = Function {
         name: name.clone(),
+        export_name: Some(name.clone()),
         params: vec!["state".into()],
         body: vec![Expr::Loop {
             bindings: vec![
@@ -788,7 +1234,16 @@ fn build_merge_fn(
 fn parse_one_defn(src: &str) -> Result<Function, CljError> {
     let forms = kotoba_edn::parse_all(src).map_err(|e| CljError::Read(e.to_string()))?;
     match forms.first() {
-        Some(EdnValue::List(items)) => lower_defn(items),
+        Some(EdnValue::List(items)) => {
+            let mut functions = lower_defn(items)?;
+            if functions.len() == 1 {
+                Ok(functions.remove(0))
+            } else {
+                Err(CljError::Lower(
+                    "generated merge fn unexpectedly lowered to multiple arities".into(),
+                ))
+            }
+        }
         _ => Err(CljError::Lower(
             "generated merge fn did not parse as a defn".into(),
         )),

--- a/crates/kotoba-clj/src/codegen.rs
+++ b/crates/kotoba-clj/src/codegen.rs
@@ -107,30 +107,30 @@ pub fn compile_core(program: &Program, entry: Option<Entry>) -> Result<Vec<u8>, 
         import_index.insert(*imp, i as u32);
     }
 
-    let mut fn_index: HashMap<String, (u32, usize)> = HashMap::new();
+    let mut fn_index: HashMap<(String, usize), u32> = HashMap::new();
     for (i, f) in program.functions.iter().enumerate() {
-        if fn_index.contains_key(&f.name) {
+        let arity = f.params.len();
+        let key = (f.name.clone(), arity);
+        if fn_index.contains_key(&key) {
             return Err(CljError::Codegen(format!(
-                "function `{}` defined twice",
+                "function `{}` with arity {arity} defined twice",
                 f.name
             )));
         }
-        fn_index.insert(f.name.clone(), (import_base + i as u32, f.params.len()));
+        fn_index.insert(key, import_base + i as u32);
     }
 
     // Validate the entry point up front.
     let entry_target = match entry {
         Some(Entry { name, abi }) => {
-            let (idx, arity) = fn_index.get(name).copied().ok_or_else(|| {
-                CljError::Codegen(format!(
-                    "component entry `(defn {name} [input] …)` not found"
-                ))
-            })?;
-            if arity != 1 {
-                return Err(CljError::Codegen(format!(
-                    "component entry `{name}` must take exactly 1 argument (the input bytes), got {arity}"
-                )));
-            }
+            let idx = fn_index
+                .get(&(name.to_string(), 1))
+                .copied()
+                .ok_or_else(|| {
+                    CljError::Codegen(format!(
+                        "component entry `(defn {name} [input] …)` not found"
+                    ))
+                })?;
             Some((idx, abi))
         }
         None => None,
@@ -153,7 +153,9 @@ pub fn compile_core(program: &Program, entry: Option<Entry>) -> Result<Vec<u8>, 
         // In component mode the wrapper owns the export names; don't leak the
         // raw i64 functions (avoids a clash on the `run` name).
         if entry.is_none() {
-            exports.export(&f.name, ExportKind::Func, import_base + i as u32);
+            if let Some(export_name) = &f.export_name {
+                exports.export(export_name, ExportKind::Func, import_base + i as u32);
+            }
         }
     }
 
@@ -566,7 +568,7 @@ struct LoopTarget {
 /// Per-function compilation context.
 struct FnCtx<'a> {
     consts: &'a HashMap<String, i64>,
-    fn_index: &'a HashMap<String, (u32, usize)>,
+    fn_index: &'a HashMap<(String, usize), u32>,
     /// Host-import → wasm function index (imports occupy `0..num_imports`).
     import_index: &'a HashMap<HostImport, u32>,
     literals: &'a Literals,
@@ -741,16 +743,16 @@ fn compile_expr(cg: &mut FnCtx, expr: &Expr) -> Result<(), CljError> {
         Expr::Builtin { op, args } => compile_builtin(cg, *op, args)?,
 
         Expr::Call { name, args } => {
-            let (idx, arity) =
-                cg.fn_index.get(name).copied().ok_or_else(|| {
-                    CljError::Codegen(format!("call to unknown function `{name}`"))
+            let arity = args.len();
+            let idx = cg
+                .fn_index
+                .get(&(name.clone(), arity))
+                .copied()
+                .ok_or_else(|| {
+                    CljError::Codegen(format!(
+                        "call to unknown function `{name}` with arity {arity}"
+                    ))
                 })?;
-            if args.len() != arity {
-                return Err(CljError::Codegen(format!(
-                    "`{name}` expects {arity} args, got {}",
-                    args.len()
-                )));
-            }
             for a in args {
                 compile_expr(cg, a)?;
             }

--- a/crates/kotoba-clj/src/compat.rs
+++ b/crates/kotoba-clj/src/compat.rs
@@ -1,0 +1,1357 @@
+//! Clojure source compatibility helpers that run before the EDN reader.
+//!
+//! This is deliberately a loader layer, not a second Clojure compiler. It
+//! normalizes source features that decide which forms the existing kotoba-clj
+//! compiler should see.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use kotoba_edn::{parse_all, to_string, EdnValue, Symbol};
+
+use crate::CljError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReaderTarget {
+    Kotoba,
+    Clj,
+    Cljs,
+}
+
+impl ReaderTarget {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "kotoba" => Some(Self::Kotoba),
+            "clj" => Some(Self::Clj),
+            "cljs" => Some(Self::Cljs),
+            _ => None,
+        }
+    }
+
+    fn branch_names(self) -> &'static [&'static str] {
+        match self {
+            Self::Kotoba => &["kotoba", "clj", "default"],
+            Self::Clj => &["clj", "default"],
+            Self::Cljs => &["cljs", "default"],
+        }
+    }
+}
+
+pub fn normalize_source(src: &str, target: ReaderTarget) -> Result<String, CljError> {
+    let src = expand_discard_syntax(src)?;
+    let src = expand_metadata_syntax(&src)?;
+    let src = expand_var_quote_syntax(&src)?;
+    let src = expand_quote_syntax(&src)?;
+    let src = expand_reader_conditionals(&src, target)?;
+    qualify_source(&src)
+}
+
+pub fn load_file_graph(path: &Path, target: ReaderTarget) -> Result<String, CljError> {
+    load_file_graph_with_source_paths(path, target, &[])
+}
+
+pub fn load_file_graph_with_source_paths(
+    path: &Path,
+    target: ReaderTarget,
+    source_paths: &[PathBuf],
+) -> Result<String, CljError> {
+    let roots = source_roots(path, source_paths)?;
+    let mut seen = HashSet::new();
+    let mut exports = HashMap::new();
+    let mut out = Vec::new();
+    load_file_graph_inner(
+        path,
+        &roots,
+        target,
+        false,
+        &mut seen,
+        &mut exports,
+        &mut out,
+    )?;
+    Ok(out.join("\n"))
+}
+
+fn load_file_graph_inner(
+    path: &Path,
+    roots: &[PathBuf],
+    target: ReaderTarget,
+    qualify_defs: bool,
+    seen: &mut HashSet<PathBuf>,
+    exports: &mut HashMap<String, HashSet<String>>,
+    out: &mut Vec<String>,
+) -> Result<(), CljError> {
+    let key = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    if !seen.insert(key) {
+        return Ok(());
+    }
+
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| CljError::Read(format!("read {}: {e}", path.display())))?;
+    let stripped = strip_shebang(&raw);
+    let without_discards = expand_discard_syntax(stripped)?;
+    let without_metadata = expand_metadata_syntax(&without_discards)?;
+    let var_quoted = expand_var_quote_syntax(&without_metadata)?;
+    let quoted = expand_quote_syntax(&var_quoted)?;
+    let expanded = expand_reader_conditionals(&quoted, target)?;
+    let forms = parse_all(&expanded).map_err(|e| CljError::Read(e.to_string()))?;
+    for ns in required_namespaces(&forms) {
+        let dep = resolve_namespace(roots, &ns, target).ok_or_else(|| {
+            CljError::Read(format!(
+                "could not resolve required namespace `{ns}` from source paths: {}",
+                roots
+                    .iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join(":")
+            ))
+        })?;
+        load_file_graph_inner(&dep, roots, target, true, seen, exports, out)?;
+    }
+    if let Some(ns) = namespace_name(&forms) {
+        exports.insert(ns, exported_names(&forms));
+    }
+    out.push(qualify_forms(forms, qualify_defs, exports)?);
+    Ok(())
+}
+
+fn source_roots(entry: &Path, explicit: &[PathBuf]) -> Result<Vec<PathBuf>, CljError> {
+    let mut roots = Vec::new();
+    roots.push(
+        entry
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf(),
+    );
+    roots.extend(deps_edn_source_roots(entry)?);
+    roots.extend(explicit.iter().cloned());
+    if let Some(env_paths) = std::env::var_os("KOTOBA_CLJ_PATH") {
+        roots.extend(std::env::split_paths(&env_paths));
+    }
+
+    let mut seen = HashSet::new();
+    Ok(roots
+        .into_iter()
+        .filter(|p| seen.insert(p.clone()))
+        .collect())
+}
+
+fn deps_edn_source_roots(entry: &Path) -> Result<Vec<PathBuf>, CljError> {
+    let Some(path) = find_deps_edn(entry) else {
+        return Ok(Vec::new());
+    };
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let src = std::fs::read_to_string(&path)
+        .map_err(|e| CljError::Read(format!("read {}: {e}", path.display())))?;
+    let forms = parse_all(&src).map_err(|e| {
+        CljError::Read(format!(
+            "parse {} for :paths source roots: {e}",
+            path.display()
+        ))
+    })?;
+    let Some(EdnValue::Map(m)) = forms.first() else {
+        return Ok(Vec::new());
+    };
+    let Some(EdnValue::Vector(paths)) = m.get(&EdnValue::kw_bare("paths")) else {
+        return Ok(Vec::new());
+    };
+    Ok(paths
+        .iter()
+        .filter_map(|v| v.as_string())
+        .map(|p| dir.join(p))
+        .collect())
+}
+
+fn find_deps_edn(entry: &Path) -> Option<PathBuf> {
+    let mut dir = entry.parent().unwrap_or_else(|| Path::new("."));
+    loop {
+        let candidate = dir.join("deps.edn");
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        dir = dir.parent()?;
+    }
+}
+
+fn strip_shebang(src: &str) -> &str {
+    if let Some(rest) = src.strip_prefix("#!") {
+        match rest.find('\n') {
+            Some(i) => &rest[i + 1..],
+            None => "",
+        }
+    } else {
+        src
+    }
+}
+
+fn resolve_namespace(roots: &[PathBuf], ns: &str, target: ReaderTarget) -> Option<PathBuf> {
+    let rel = ns
+        .split('.')
+        .map(|segment| segment.replace('-', "_"))
+        .collect::<Vec<_>>()
+        .join("/");
+    let extensions = match target {
+        ReaderTarget::Kotoba => ["kotoba", "cljc", "clj", "cljs"],
+        ReaderTarget::Clj => ["cljc", "clj", "kotoba", "cljs"],
+        ReaderTarget::Cljs => ["cljc", "cljs", "clj", "kotoba"],
+    };
+    roots.iter().find_map(|root| {
+        extensions
+            .iter()
+            .map(|ext| root.join(format!("{rel}.{ext}")))
+            .find(|p| p.exists())
+    })
+}
+
+fn qualify_source(src: &str) -> Result<String, CljError> {
+    let forms = parse_all(src).map_err(|e| CljError::Read(e.to_string()))?;
+    qualify_forms(forms, false, &HashMap::new())
+}
+
+fn qualify_forms(
+    forms: Vec<EdnValue>,
+    qualify_defs: bool,
+    exports: &HashMap<String, HashSet<String>>,
+) -> Result<String, CljError> {
+    let ctx = NamespaceCtx::from_forms(&forms, exports);
+    let forms = forms
+        .into_iter()
+        .map(|form| qualify_top_level(form, &ctx, qualify_defs))
+        .collect::<Vec<_>>();
+    Ok(forms.iter().map(to_string).collect::<Vec<_>>().join("\n"))
+}
+
+fn expand_reader_conditionals(src: &str, target: ReaderTarget) -> Result<String, CljError> {
+    let bytes = src.as_bytes();
+    let mut out = String::with_capacity(src.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => {
+                let end = skip_string(src, i)?;
+                out.push_str(&src[i..end]);
+                i = end;
+            }
+            b';' => {
+                let end = skip_comment(src, i);
+                out.push_str(&src[i..end]);
+                i = end;
+            }
+            b'#' if bytes.get(i + 1) == Some(&b'?') => {
+                let (splicing, open) = if bytes.get(i + 2) == Some(&b'@') {
+                    (true, i + 3)
+                } else {
+                    (false, i + 2)
+                };
+                if bytes.get(open) != Some(&b'(') {
+                    out.push(bytes[i] as char);
+                    i += 1;
+                    continue;
+                }
+                let close = find_matching(src, open)?;
+                let inner = &src[open + 1..close];
+                let selected = select_reader_branch(inner, target)?;
+                match selected {
+                    Some(value) if splicing => out.push_str(&splice_value(&value)),
+                    Some(value) => out.push_str(&to_string(&value)),
+                    None if splicing => {}
+                    None => out.push_str("nil"),
+                }
+                i = close + 1;
+            }
+            _ => {
+                let ch = src[i..].chars().next().expect("valid char boundary");
+                out.push(ch);
+                i += ch.len_utf8();
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn expand_var_quote_syntax(src: &str) -> Result<String, CljError> {
+    let bytes = src.as_bytes();
+    let mut out = String::with_capacity(src.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => {
+                let end = skip_string(src, i)?;
+                out.push_str(&src[i..end]);
+                i = end;
+            }
+            b';' => {
+                let end = skip_comment(src, i);
+                out.push_str(&src[i..end]);
+                i = end;
+            }
+            b'#' if bytes.get(i + 1) == Some(&b'\'') => {
+                let form_start = skip_ws_bytes(src, i + 2);
+                if form_start >= bytes.len() {
+                    return Err(CljError::Read("var quote has no following form".into()));
+                }
+                let form_end = find_form_end(src, form_start)?;
+                out.push_str("(var ");
+                out.push_str(&src[form_start..form_end]);
+                out.push(')');
+                i = form_end;
+            }
+            _ => {
+                let ch = src[i..].chars().next().expect("valid char boundary");
+                out.push(ch);
+                i += ch.len_utf8();
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn expand_quote_syntax(src: &str) -> Result<String, CljError> {
+    let bytes = src.as_bytes();
+    let mut out = String::with_capacity(src.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => {
+                let end = skip_string(src, i)?;
+                out.push_str(&src[i..end]);
+                i = end;
+            }
+            b';' => {
+                let end = skip_comment(src, i);
+                out.push_str(&src[i..end]);
+                i = end;
+            }
+            b'\'' => {
+                let form_start = skip_ws_bytes(src, i + 1);
+                if form_start >= bytes.len() {
+                    return Err(CljError::Read("quote has no following form".into()));
+                }
+                let form_end = find_form_end(src, form_start)?;
+                out.push_str("(quote ");
+                out.push_str(&src[form_start..form_end]);
+                out.push(')');
+                i = form_end;
+            }
+            _ => {
+                let ch = src[i..].chars().next().expect("valid char boundary");
+                out.push(ch);
+                i += ch.len_utf8();
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn expand_discard_syntax(src: &str) -> Result<String, CljError> {
+    let bytes = src.as_bytes();
+    let mut out = String::with_capacity(src.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => {
+                let end = skip_string(src, i)?;
+                out.push_str(&src[i..end]);
+                i = end;
+            }
+            b';' => {
+                let end = skip_comment(src, i);
+                out.push_str(&src[i..end]);
+                i = end;
+            }
+            b'#' if bytes.get(i + 1) == Some(&b'_') => {
+                let form_start = skip_ws_and_comments(src, i + 2)?;
+                if form_start >= bytes.len() {
+                    return Err(CljError::Read(
+                        "discard marker has no following form".into(),
+                    ));
+                }
+                i = find_reader_form_end(src, form_start)?;
+                out.push(' ');
+            }
+            _ => {
+                let ch = src[i..].chars().next().expect("valid char boundary");
+                out.push(ch);
+                i += ch.len_utf8();
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn expand_metadata_syntax(src: &str) -> Result<String, CljError> {
+    let bytes = src.as_bytes();
+    let mut out = String::with_capacity(src.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => {
+                let end = skip_string(src, i)?;
+                out.push_str(&src[i..end]);
+                i = end;
+            }
+            b';' => {
+                let end = skip_comment(src, i);
+                out.push_str(&src[i..end]);
+                i = end;
+            }
+            b'^' if is_metadata_position(src, i) => {
+                let metadata_start = skip_ws_bytes(src, i + 1);
+                if metadata_start >= bytes.len() {
+                    return Err(CljError::Read(
+                        "metadata marker has no metadata form".into(),
+                    ));
+                }
+                let metadata_end = find_form_end(src, metadata_start)?;
+                i = skip_ws_bytes(src, metadata_end);
+                out.push(' ');
+            }
+            _ => {
+                let ch = src[i..].chars().next().expect("valid char boundary");
+                out.push(ch);
+                i += ch.len_utf8();
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn is_metadata_position(src: &str, i: usize) -> bool {
+    if i == 0 {
+        return true;
+    }
+    src.as_bytes()
+        .get(i - 1)
+        .is_none_or(|b| matches!(b, b' ' | b'\t' | b'\n' | b'\r' | b',' | b'(' | b'[' | b'{'))
+}
+
+fn select_reader_branch(src: &str, target: ReaderTarget) -> Result<Option<EdnValue>, CljError> {
+    let forms = parse_all(src)
+        .map_err(|e| CljError::Read(format!("reader conditional parse error in `#?(...)`: {e}")))?;
+    if forms.len() % 2 != 0 {
+        return Err(CljError::Read(
+            "reader conditional requires feature/expression pairs".into(),
+        ));
+    }
+
+    for name in target.branch_names() {
+        for pair in forms.chunks_exact(2) {
+            if keyword_name(&pair[0]) == Some(*name) {
+                return Ok(Some(pair[1].clone()));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn keyword_name(v: &EdnValue) -> Option<&str> {
+    v.as_keyword().and_then(|k| {
+        if k.namespace().is_none() {
+            Some(k.name())
+        } else {
+            None
+        }
+    })
+}
+
+#[derive(Debug, Default)]
+struct NamespaceCtx {
+    current_ns: Option<String>,
+    aliases: HashMap<String, String>,
+    non_load_aliases: HashSet<String>,
+    refers: HashMap<String, String>,
+    refer_all: HashSet<String>,
+    refer_all_excludes: HashMap<String, HashSet<String>>,
+    renames: HashMap<String, String>,
+    local_defs: HashSet<String>,
+}
+
+impl NamespaceCtx {
+    fn from_forms(forms: &[EdnValue], exports: &HashMap<String, HashSet<String>>) -> Self {
+        let mut ctx = Self::default();
+        for form in forms {
+            collect_namespace_ctx(form, &mut ctx);
+        }
+        for ns in ctx.refer_all.clone() {
+            if let Some(names) = exports.get(&ns) {
+                let excludes = ctx.refer_all_excludes.get(&ns);
+                for name in names {
+                    if excludes.is_some_and(|excluded| excluded.contains(name)) {
+                        continue;
+                    }
+                    ctx.refers.insert(name.clone(), format!("{ns}/{name}"));
+                }
+            }
+        }
+        ctx
+    }
+}
+
+fn collect_namespace_ctx(form: &EdnValue, ctx: &mut NamespaceCtx) {
+    let EdnValue::List(items) = form else {
+        return;
+    };
+    match list_head_name(items).as_deref() {
+        Some("ns") => {
+            if let Some(EdnValue::Symbol(s)) = items.get(1) {
+                ctx.current_ns = Some(s.to_qualified());
+            }
+            read_ns_requires(items, ctx);
+        }
+        Some("require" | "require-macros") => {
+            read_require_specs(&items[1..], ctx);
+        }
+        Some("use" | "use-macros") => {
+            read_use_specs(&items[1..], ctx);
+        }
+        Some("def" | "defonce" | "defn" | "defn-" | "defgraph") => {
+            if let Some(EdnValue::Symbol(s)) = items.get(1) {
+                if s.namespace.is_none() {
+                    ctx.local_defs.insert(s.name.clone());
+                }
+            }
+        }
+        Some("do") => {
+            for item in &items[1..] {
+                collect_namespace_ctx(item, ctx);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn namespace_name(forms: &[EdnValue]) -> Option<String> {
+    forms.iter().find_map(namespace_name_in_form)
+}
+
+fn namespace_name_in_form(form: &EdnValue) -> Option<String> {
+    let EdnValue::List(items) = form else {
+        return None;
+    };
+    match list_head_name(items).as_deref() {
+        Some("ns") => match items.get(1) {
+            Some(EdnValue::Symbol(s)) => Some(s.to_qualified()),
+            _ => None,
+        },
+        Some("do") => items[1..].iter().find_map(namespace_name_in_form),
+        _ => None,
+    }
+}
+
+fn exported_names(forms: &[EdnValue]) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for form in forms {
+        collect_exported_names(form, &mut out);
+    }
+    out
+}
+
+fn collect_exported_names(form: &EdnValue, out: &mut HashSet<String>) {
+    let EdnValue::List(items) = form else {
+        return;
+    };
+    match list_head_name(items).as_deref() {
+        Some("def" | "defonce" | "defn" | "defgraph") => {
+            if let Some(EdnValue::Symbol(s)) = items.get(1) {
+                out.insert(s.name.clone());
+            }
+        }
+        Some("do") => {
+            for item in &items[1..] {
+                collect_exported_names(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn required_namespaces(forms: &[EdnValue]) -> Vec<String> {
+    let ctx = NamespaceCtx::from_forms(forms, &HashMap::new());
+    let mut out = HashSet::new();
+    out.extend(
+        ctx.aliases
+            .iter()
+            .filter(|(alias, _)| !ctx.non_load_aliases.contains(*alias))
+            .map(|(_, ns)| ns.clone()),
+    );
+    out.extend(ctx.refer_all.iter().cloned());
+    out.extend(
+        ctx.refers
+            .values()
+            .filter_map(|qualified| qualified.split('/').next())
+            .map(str::to_string),
+    );
+    out.into_iter()
+        .filter(|ns| !is_platform_namespace(ns))
+        .collect()
+}
+
+fn is_platform_namespace(ns: &str) -> bool {
+    ns == "clojure.core"
+        || ns.starts_with("clojure.")
+        || ns == "cljs.core"
+        || ns.starts_with("cljs.")
+}
+
+fn read_ns_requires(items: &[EdnValue], ctx: &mut NamespaceCtx) {
+    for clause in &items[2..] {
+        let EdnValue::List(parts) = clause else {
+            continue;
+        };
+        match keyword_name(parts.first().unwrap_or(&EdnValue::Nil)) {
+            Some("require" | "require-macros") => {
+                read_require_specs(&parts[1..], ctx);
+            }
+            Some("use" | "use-macros") => {
+                read_use_specs(&parts[1..], ctx);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn read_require_specs(specs: &[EdnValue], ctx: &mut NamespaceCtx) {
+    for spec in specs {
+        read_require_spec(unquote_decl_spec(spec), ctx);
+    }
+}
+
+fn read_require_spec(spec: &EdnValue, ctx: &mut NamespaceCtx) {
+    match spec {
+        EdnValue::Symbol(ns) => {
+            let ns = ns.to_qualified();
+            ctx.aliases.entry(ns.clone()).or_insert(ns);
+        }
+        EdnValue::Vector(xs) => read_require_vector(xs, ctx),
+        _ => {}
+    }
+}
+
+fn read_require_vector(xs: &[EdnValue], ctx: &mut NamespaceCtx) {
+    let Some(EdnValue::Symbol(ns)) = xs.first() else {
+        return;
+    };
+    let ns = ns.to_qualified();
+    if xs.get(1).is_some_and(|v| matches!(v, EdnValue::Vector(_))) {
+        for child in &xs[1..] {
+            let EdnValue::Vector(child) = child else {
+                continue;
+            };
+            read_prefixed_require(&ns, child, ctx);
+        }
+        return;
+    }
+    read_require_options(&ns, &xs[1..], ctx);
+}
+
+fn read_prefixed_require(prefix: &str, xs: &[EdnValue], ctx: &mut NamespaceCtx) {
+    let Some(EdnValue::Symbol(suffix)) = xs.first() else {
+        return;
+    };
+    let ns = format!("{prefix}.{}", suffix.to_qualified());
+    read_require_options(&ns, &xs[1..], ctx);
+}
+
+fn read_use_specs(specs: &[EdnValue], ctx: &mut NamespaceCtx) {
+    for spec in specs {
+        read_use_spec(unquote_decl_spec(spec), ctx);
+    }
+}
+
+fn read_use_spec(spec: &EdnValue, ctx: &mut NamespaceCtx) {
+    match spec {
+        EdnValue::Symbol(ns) => {
+            ctx.refer_all.insert(ns.to_qualified());
+        }
+        EdnValue::Vector(xs) => read_use_vector(xs, ctx),
+        _ => {}
+    }
+}
+
+fn read_use_vector(xs: &[EdnValue], ctx: &mut NamespaceCtx) {
+    let Some(EdnValue::Symbol(ns)) = xs.first() else {
+        return;
+    };
+    let ns = ns.to_qualified();
+    if xs.get(1).is_some_and(|v| matches!(v, EdnValue::Vector(_))) {
+        for child in &xs[1..] {
+            let EdnValue::Vector(child) = child else {
+                continue;
+            };
+            read_prefixed_use(&ns, child, ctx);
+        }
+        return;
+    }
+    read_use_options(&ns, &xs[1..], ctx);
+}
+
+fn read_prefixed_use(prefix: &str, xs: &[EdnValue], ctx: &mut NamespaceCtx) {
+    let Some(EdnValue::Symbol(suffix)) = xs.first() else {
+        return;
+    };
+    let ns = format!("{prefix}.{}", suffix.to_qualified());
+    read_use_options(&ns, &xs[1..], ctx);
+}
+
+fn unquote_decl_spec(spec: &EdnValue) -> &EdnValue {
+    let EdnValue::List(items) = spec else {
+        return spec;
+    };
+    match (list_head_name(items).as_deref(), items.get(1), items.len()) {
+        (Some("quote"), Some(inner), 2) => inner,
+        _ => spec,
+    }
+}
+
+fn read_require_options(ns: &str, opts: &[EdnValue], ctx: &mut NamespaceCtx) {
+    let mut saw_alias_or_refer = false;
+    let mut i = 0;
+    while i + 1 < opts.len() {
+        match keyword_name(&opts[i]) {
+            Some("as") => {
+                if let EdnValue::Symbol(alias) = &opts[i + 1] {
+                    ctx.aliases.insert(alias.name.clone(), ns.to_string());
+                    ctx.non_load_aliases.remove(&alias.name);
+                    saw_alias_or_refer = true;
+                }
+            }
+            Some("as-alias") => {
+                if let EdnValue::Symbol(alias) = &opts[i + 1] {
+                    ctx.aliases.insert(alias.name.clone(), ns.to_string());
+                    ctx.non_load_aliases.insert(alias.name.clone());
+                    saw_alias_or_refer = true;
+                }
+            }
+            Some("refer") => {
+                match &opts[i + 1] {
+                    EdnValue::Vector(names) => {
+                        for name in names {
+                            if let EdnValue::Symbol(name) = name {
+                                ctx.refers
+                                    .insert(name.name.clone(), format!("{ns}/{}", name.name));
+                            }
+                        }
+                    }
+                    EdnValue::Keyword(k) if k.name() == "all" => {
+                        ctx.refer_all.insert(ns.to_string());
+                    }
+                    _ => {}
+                }
+                saw_alias_or_refer = true;
+            }
+            Some("rename") => {
+                if let EdnValue::Map(renames) = &opts[i + 1] {
+                    for (from, to) in renames {
+                        if let (EdnValue::Symbol(from), EdnValue::Symbol(to)) = (from, to) {
+                            ctx.renames
+                                .insert(to.name.clone(), format!("{ns}/{}", from.name));
+                        }
+                    }
+                }
+            }
+            Some("exclude") => {
+                read_refer_all_excludes(ns, &opts[i + 1], ctx);
+            }
+            _ => {}
+        }
+        i += 2;
+    }
+    if !saw_alias_or_refer && !ns.starts_with("clojure.") {
+        ctx.aliases
+            .entry(ns.to_string())
+            .or_insert_with(|| ns.to_string());
+    }
+}
+
+fn read_use_options(ns: &str, opts: &[EdnValue], ctx: &mut NamespaceCtx) {
+    let mut saw_only = false;
+    let mut i = 0;
+    while i + 1 < opts.len() {
+        match keyword_name(&opts[i]) {
+            Some("only") => {
+                if let EdnValue::Vector(names) = &opts[i + 1] {
+                    for name in names {
+                        if let EdnValue::Symbol(name) = name {
+                            ctx.refers
+                                .insert(name.name.clone(), format!("{ns}/{}", name.name));
+                        }
+                    }
+                }
+                saw_only = true;
+            }
+            Some("as") => {
+                if let EdnValue::Symbol(alias) = &opts[i + 1] {
+                    ctx.aliases.insert(alias.name.clone(), ns.to_string());
+                }
+            }
+            Some("rename") => {
+                if let EdnValue::Map(renames) = &opts[i + 1] {
+                    for (from, to) in renames {
+                        if let (EdnValue::Symbol(from), EdnValue::Symbol(to)) = (from, to) {
+                            ctx.renames
+                                .insert(to.name.clone(), format!("{ns}/{}", from.name));
+                        }
+                    }
+                }
+            }
+            Some("exclude") => {
+                read_refer_all_excludes(ns, &opts[i + 1], ctx);
+            }
+            _ => {}
+        }
+        i += 2;
+    }
+    if !saw_only {
+        ctx.refer_all.insert(ns.to_string());
+    }
+}
+
+fn read_refer_all_excludes(ns: &str, value: &EdnValue, ctx: &mut NamespaceCtx) {
+    let EdnValue::Vector(names) = value else {
+        return;
+    };
+    let excludes = ctx.refer_all_excludes.entry(ns.to_string()).or_default();
+    for name in names {
+        if let EdnValue::Symbol(name) = name {
+            excludes.insert(name.name.clone());
+        }
+    }
+}
+
+fn qualify_top_level(form: EdnValue, ctx: &NamespaceCtx, qualify_defs: bool) -> EdnValue {
+    let EdnValue::List(mut items) = form else {
+        return form;
+    };
+    match list_head_name(&items).as_deref() {
+        Some("def" | "defonce") => {
+            if qualify_defs {
+                if let Some(name) = items.get_mut(1) {
+                    *name = qualify_definition_name(name.clone(), ctx);
+                }
+            }
+            for item in items.iter_mut().skip(2) {
+                *item = qualify_expr(item.clone(), ctx, qualify_defs);
+            }
+            EdnValue::List(items)
+        }
+        Some("defn" | "defn-") => qualify_defn_top_level(items, ctx, qualify_defs),
+        Some("defgraph") => {
+            if qualify_defs {
+                if let Some(name) = items.get_mut(1) {
+                    *name = qualify_definition_name(name.clone(), ctx);
+                }
+            }
+            for item in items.iter_mut().skip(2) {
+                *item = qualify_expr(item.clone(), ctx, qualify_defs);
+            }
+            EdnValue::List(items)
+        }
+        Some(
+            "ns" | "require" | "require-macros" | "use" | "use-macros" | "refer-clojure" | "import"
+            | "in-ns" | "alias" | "create-ns" | "remove-ns" | "gen-class" | "set!" | "defrecord"
+            | "deftype" | "defprotocol" | "extend-type" | "extend-protocol" | "defmulti"
+            | "defmethod" | "defmacro" | "defstruct" | "create-struct",
+        ) => EdnValue::List(items),
+        Some("do") => {
+            let mut out = Vec::with_capacity(items.len());
+            out.push(items.remove(0));
+            out.extend(
+                items
+                    .into_iter()
+                    .map(|item| qualify_top_level(item, ctx, qualify_defs)),
+            );
+            EdnValue::List(out)
+        }
+        _ => EdnValue::List(
+            items
+                .into_iter()
+                .map(|v| qualify_expr(v, ctx, qualify_defs))
+                .collect(),
+        ),
+    }
+}
+
+fn qualify_defn_top_level(
+    mut items: Vec<EdnValue>,
+    ctx: &NamespaceCtx,
+    qualify_defs: bool,
+) -> EdnValue {
+    if qualify_defs {
+        if let Some(name) = items.get_mut(1) {
+            *name = qualify_definition_name(name.clone(), ctx);
+        }
+    }
+    let mut idx = 2;
+    if matches!(items.get(idx), Some(EdnValue::String(_))) {
+        idx += 1;
+    }
+    if matches!(items.get(idx), Some(EdnValue::Map(_))) {
+        idx += 1;
+    }
+    match items.get_mut(idx) {
+        Some(EdnValue::Vector(_)) => {
+            let shadow = param_shadow(items.get(idx));
+            for item in items.iter_mut().skip(idx + 1) {
+                *item = qualify_expr_with_shadow(item.clone(), ctx, qualify_defs, &shadow);
+            }
+        }
+        Some(EdnValue::List(arity)) => {
+            let shadow = param_shadow(arity.first());
+            for item in arity.iter_mut().skip(1) {
+                *item = qualify_expr_with_shadow(item.clone(), ctx, qualify_defs, &shadow);
+            }
+        }
+        _ => {
+            for item in items.iter_mut().skip(2) {
+                *item = qualify_expr(item.clone(), ctx, qualify_defs);
+            }
+        }
+    }
+    EdnValue::List(items)
+}
+
+fn param_shadow(params: Option<&EdnValue>) -> HashSet<String> {
+    let Some(EdnValue::Vector(params)) = params else {
+        return HashSet::new();
+    };
+    params
+        .iter()
+        .filter_map(|p| match p {
+            EdnValue::Symbol(s) if s.namespace.is_none() => Some(s.name.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+fn qualify_expr(v: EdnValue, ctx: &NamespaceCtx, qualify_defs: bool) -> EdnValue {
+    qualify_expr_with_shadow(v, ctx, qualify_defs, &HashSet::new())
+}
+
+fn qualify_expr_with_shadow(
+    v: EdnValue,
+    ctx: &NamespaceCtx,
+    qualify_defs: bool,
+    shadowed: &HashSet<String>,
+) -> EdnValue {
+    match v {
+        EdnValue::List(items) => qualify_list_expr(items, ctx, qualify_defs, shadowed),
+        EdnValue::Vector(xs) => EdnValue::Vector(
+            xs.into_iter()
+                .map(|v| qualify_expr_with_shadow(v, ctx, qualify_defs, shadowed))
+                .collect(),
+        ),
+        EdnValue::Map(m) => EdnValue::Map(
+            m.into_iter()
+                .map(|(k, v)| {
+                    (
+                        qualify_expr_with_shadow(k, ctx, qualify_defs, shadowed),
+                        qualify_expr_with_shadow(v, ctx, qualify_defs, shadowed),
+                    )
+                })
+                .collect::<BTreeMap<_, _>>(),
+        ),
+        other => qualify_symbol_value(other, ctx, qualify_defs, shadowed),
+    }
+}
+
+fn qualify_list_expr(
+    items: Vec<EdnValue>,
+    ctx: &NamespaceCtx,
+    qualify_defs: bool,
+    shadowed: &HashSet<String>,
+) -> EdnValue {
+    let Some(head) = items.first() else {
+        return EdnValue::List(items);
+    };
+    let special = list_head_name(&items).unwrap_or_default();
+    match special.as_str() {
+        "let" | "loop" => {
+            let mut out = items;
+            let mut inner_shadow = shadowed.clone();
+            if let Some(EdnValue::Vector(bindings)) = out.get_mut(1) {
+                for i in (1..bindings.len()).step_by(2) {
+                    bindings[i] = qualify_expr_with_shadow(
+                        bindings[i].clone(),
+                        ctx,
+                        qualify_defs,
+                        &inner_shadow,
+                    );
+                    if let Some(EdnValue::Symbol(s)) = bindings.get(i - 1) {
+                        if s.namespace.is_none() {
+                            inner_shadow.insert(s.name.clone());
+                        }
+                    }
+                }
+            }
+            for item in out.iter_mut().skip(2) {
+                *item = qualify_expr_with_shadow(item.clone(), ctx, qualify_defs, &inner_shadow);
+            }
+            EdnValue::List(out)
+        }
+        "if-let" | "when-let" => {
+            let mut out = items;
+            let mut inner_shadow = shadowed.clone();
+            if let Some(EdnValue::Vector(bindings)) = out.get_mut(1) {
+                if let Some(init) = bindings.get_mut(1) {
+                    *init = qualify_expr_with_shadow(init.clone(), ctx, qualify_defs, shadowed);
+                }
+                if let Some(EdnValue::Symbol(s)) = bindings.first() {
+                    if s.namespace.is_none() {
+                        inner_shadow.insert(s.name.clone());
+                    }
+                }
+            }
+            for item in out.iter_mut().skip(2) {
+                *item = qualify_expr_with_shadow(item.clone(), ctx, qualify_defs, &inner_shadow);
+            }
+            EdnValue::List(out)
+        }
+        "as->" => {
+            let mut out = items;
+            let mut inner_shadow = shadowed.clone();
+            if let Some(init) = out.get_mut(1) {
+                *init = qualify_expr_with_shadow(init.clone(), ctx, qualify_defs, shadowed);
+            }
+            if let Some(EdnValue::Symbol(s)) = out.get(2) {
+                if s.namespace.is_none() {
+                    inner_shadow.insert(s.name.clone());
+                }
+            }
+            for item in out.iter_mut().skip(3) {
+                *item = qualify_expr_with_shadow(item.clone(), ctx, qualify_defs, &inner_shadow);
+            }
+            EdnValue::List(out)
+        }
+        "quote" => EdnValue::List(items),
+        _ => {
+            let mut out = Vec::with_capacity(items.len());
+            out.push(qualify_call_head(head.clone(), ctx, qualify_defs));
+            out.extend(
+                items
+                    .into_iter()
+                    .skip(1)
+                    .map(|v| qualify_expr_with_shadow(v, ctx, qualify_defs, shadowed)),
+            );
+            EdnValue::List(out)
+        }
+    }
+}
+
+fn qualify_definition_name(v: EdnValue, ctx: &NamespaceCtx) -> EdnValue {
+    match (v, ctx.current_ns.as_deref()) {
+        (EdnValue::Symbol(s), Some(ns)) if s.namespace.is_none() => {
+            EdnValue::Symbol(Symbol::namespaced(ns, s.name))
+        }
+        (other, _) => other,
+    }
+}
+
+fn qualify_call_head(v: EdnValue, ctx: &NamespaceCtx, qualify_defs: bool) -> EdnValue {
+    let EdnValue::Symbol(s) = v else {
+        return v;
+    };
+    if let Some(ns) = s
+        .namespace
+        .as_deref()
+        .and_then(|alias| ctx.aliases.get(alias))
+    {
+        return EdnValue::Symbol(Symbol::namespaced(ns, s.name));
+    }
+    if s.namespace.is_none() {
+        if let Some(full) = ctx.renames.get(&s.name) {
+            return EdnValue::Symbol(Symbol::parse(full));
+        }
+        if let Some(full) = ctx.refers.get(&s.name) {
+            return EdnValue::Symbol(Symbol::parse(full));
+        }
+        if qualify_defs && ctx.local_defs.contains(&s.name) {
+            if let Some(ns) = &ctx.current_ns {
+                return EdnValue::Symbol(Symbol::namespaced(ns, s.name));
+            }
+        }
+    }
+    EdnValue::Symbol(s)
+}
+
+fn qualify_symbol_value(
+    v: EdnValue,
+    ctx: &NamespaceCtx,
+    qualify_defs: bool,
+    shadowed: &HashSet<String>,
+) -> EdnValue {
+    match v {
+        EdnValue::Symbol(s) => {
+            if let Some(ns) = s
+                .namespace
+                .as_deref()
+                .and_then(|alias| ctx.aliases.get(alias))
+            {
+                EdnValue::Symbol(Symbol::namespaced(ns, s.name))
+            } else if qualify_defs
+                && s.namespace.is_none()
+                && !shadowed.contains(&s.name)
+                && ctx.local_defs.contains(&s.name)
+            {
+                match ctx.current_ns.as_deref() {
+                    Some(ns) => EdnValue::Symbol(Symbol::namespaced(ns, s.name)),
+                    None => EdnValue::Symbol(s),
+                }
+            } else {
+                EdnValue::Symbol(s)
+            }
+        }
+        other => other,
+    }
+}
+
+fn list_head_name(items: &[EdnValue]) -> Option<String> {
+    match items.first() {
+        Some(EdnValue::Symbol(s)) => Some(s.to_qualified()),
+        _ => None,
+    }
+}
+
+fn splice_value(v: &EdnValue) -> String {
+    match v {
+        EdnValue::List(xs) | EdnValue::Vector(xs) => {
+            xs.iter().map(to_string).collect::<Vec<_>>().join(" ")
+        }
+        other => to_string(other),
+    }
+}
+
+fn find_matching(src: &str, open: usize) -> Result<usize, CljError> {
+    let bytes = src.as_bytes();
+    let mut i = open;
+    let mut stack = Vec::new();
+    while i < bytes.len() {
+        match bytes[i] {
+            b'"' => {
+                i = skip_string(src, i)?;
+                continue;
+            }
+            b';' => {
+                i = skip_comment(src, i);
+                continue;
+            }
+            b'(' | b'[' | b'{' => stack.push(bytes[i]),
+            b')' | b']' | b'}' => {
+                let Some(last) = stack.pop() else {
+                    return Err(CljError::Read(format!(
+                        "unbalanced reader conditional at byte {i}"
+                    )));
+                };
+                if !matches!((last, bytes[i]), (b'(', b')') | (b'[', b']') | (b'{', b'}')) {
+                    return Err(CljError::Read(format!(
+                        "mismatched delimiter in reader conditional at byte {i}"
+                    )));
+                }
+                if stack.is_empty() {
+                    return Ok(i);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    Err(CljError::Read("unterminated reader conditional".into()))
+}
+
+fn find_form_end(src: &str, start: usize) -> Result<usize, CljError> {
+    match src.as_bytes().get(start).copied() {
+        Some(b'(' | b'[' | b'{') => find_matching(src, start).map(|i| i + 1),
+        Some(b'"') => skip_string(src, start),
+        Some(_) => Ok(read_token_end(src, start)),
+        None => Err(CljError::Read("expected quoted form".into())),
+    }
+}
+
+fn find_reader_form_end(src: &str, start: usize) -> Result<usize, CljError> {
+    match src.as_bytes().get(start).copied() {
+        Some(b'^') => {
+            let metadata_start = skip_ws_and_comments(src, start + 1)?;
+            if metadata_start >= src.len() {
+                return Err(CljError::Read(
+                    "metadata marker has no metadata form".into(),
+                ));
+            }
+            let metadata_end = find_reader_form_end(src, metadata_start)?;
+            let form_start = skip_ws_and_comments(src, metadata_end)?;
+            if form_start >= src.len() {
+                return Err(CljError::Read(
+                    "metadata marker has no following form".into(),
+                ));
+            }
+            find_reader_form_end(src, form_start)
+        }
+        Some(b'\'') => {
+            let form_start = skip_ws_and_comments(src, start + 1)?;
+            if form_start >= src.len() {
+                return Err(CljError::Read("quote has no following form".into()));
+            }
+            find_reader_form_end(src, form_start)
+        }
+        Some(b'#') if src.as_bytes().get(start + 1) == Some(&b'_') => {
+            let form_start = skip_ws_and_comments(src, start + 2)?;
+            if form_start >= src.len() {
+                return Err(CljError::Read(
+                    "discard marker has no following form".into(),
+                ));
+            }
+            find_reader_form_end(src, form_start)
+        }
+        _ => find_form_end(src, start),
+    }
+}
+
+fn read_token_end(src: &str, start: usize) -> usize {
+    let bytes = src.as_bytes();
+    let mut i = start;
+    while i < bytes.len() {
+        if is_reader_terminator(bytes[i]) {
+            break;
+        }
+        let ch = src[i..].chars().next().expect("valid char boundary");
+        i += ch.len_utf8();
+    }
+    i
+}
+
+fn skip_ws_and_comments(src: &str, mut i: usize) -> Result<usize, CljError> {
+    let bytes = src.as_bytes();
+    loop {
+        while i < bytes.len() && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r' | b',') {
+            i += 1;
+        }
+        if i < bytes.len() && bytes[i] == b';' {
+            i = skip_comment(src, i);
+            continue;
+        }
+        return Ok(i);
+    }
+}
+
+fn skip_ws_bytes(src: &str, mut i: usize) -> usize {
+    let bytes = src.as_bytes();
+    while i < bytes.len() && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r' | b',') {
+        i += 1;
+    }
+    i
+}
+
+fn is_reader_terminator(b: u8) -> bool {
+    matches!(
+        b,
+        b' ' | b'\t' | b'\n' | b'\r' | b',' | b';' | b'(' | b')' | b'[' | b']' | b'{' | b'}' | b'"'
+    )
+}
+
+fn skip_string(src: &str, start: usize) -> Result<usize, CljError> {
+    let bytes = src.as_bytes();
+    let mut i = start + 1;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => i += 2,
+            b'"' => return Ok(i + 1),
+            _ => i += 1,
+        }
+    }
+    Err(CljError::Read("unterminated string literal".into()))
+}
+
+fn skip_comment(src: &str, start: usize) -> usize {
+    let bytes = src.as_bytes();
+    let mut i = start;
+    while i < bytes.len() {
+        i += 1;
+        if bytes[i - 1] == b'\n' {
+            break;
+        }
+    }
+    i
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expands_reader_conditional_for_kotoba_then_clj_then_default() {
+        assert_eq!(
+            normalize_source("#?(:kotoba 1 :clj 2 :default 3)", ReaderTarget::Kotoba).unwrap(),
+            "1"
+        );
+        assert_eq!(
+            normalize_source("#?(:cljs 1 :clj 2 :default 3)", ReaderTarget::Kotoba).unwrap(),
+            "2"
+        );
+        assert_eq!(
+            normalize_source("#?(:cljs 1 :default 3)", ReaderTarget::Kotoba).unwrap(),
+            "3"
+        );
+    }
+
+    #[test]
+    fn splices_selected_forms() {
+        assert_eq!(
+            normalize_source("(do #?@(:clj [(inc 1) (inc 2)]))", ReaderTarget::Kotoba).unwrap(),
+            "(do (inc 1) (inc 2))"
+        );
+    }
+
+    #[test]
+    fn ignores_reader_conditional_markers_in_strings_and_comments() {
+        let src = "\"#?(:clj 1)\" ; #?(:clj 2)\n#?(:clj 3)";
+        assert_eq!(
+            normalize_source(src, ReaderTarget::Kotoba).unwrap(),
+            "\"#?(:clj 1)\"\n3"
+        );
+    }
+
+    #[test]
+    fn expands_var_quote_before_plain_quote() {
+        assert_eq!(
+            normalize_source("#'demo/ok", ReaderTarget::Kotoba).unwrap(),
+            "(var demo/ok)"
+        );
+        assert_eq!(
+            normalize_source("\"#'kept\" ; #'ignored\n#'demo/ok", ReaderTarget::Kotoba).unwrap(),
+            "\"#'kept\"\n(var demo/ok)"
+        );
+    }
+
+    #[test]
+    fn strips_metadata_reader_syntax() {
+        assert_eq!(
+            normalize_source(
+                " ^:private (defn f [^long x ^String y] (+ x (str-len y)))",
+                ReaderTarget::Kotoba,
+            )
+            .unwrap(),
+            "(defn f [x y] (+ x (str-len y)))"
+        );
+        assert_eq!(
+            normalize_source("(defn f [] (str-len \"^kept\"))", ReaderTarget::Kotoba).unwrap(),
+            "(defn f [] (str-len \"^kept\"))"
+        );
+    }
+
+    #[test]
+    fn strips_discard_reader_syntax() {
+        assert_eq!(
+            normalize_source(
+                "#_ (def ignored 1) (defn f [] 42) #_ ^:private '(a b)",
+                ReaderTarget::Kotoba,
+            )
+            .unwrap(),
+            "(defn f [] 42)"
+        );
+        assert_eq!(
+            normalize_source(
+                "\"#_kept\" ; #_ (ignored)\n(defn f [] 42)",
+                ReaderTarget::Kotoba
+            )
+            .unwrap(),
+            "\"#_kept\"\n(defn f [] 42)"
+        );
+    }
+}

--- a/crates/kotoba-clj/src/component.rs
+++ b/crates/kotoba-clj/src/component.rs
@@ -8,12 +8,14 @@
 //!
 //! The source program must define `(defn run [input] …)`: an arity-1 function
 //! whose argument is the input bytes (as a string handle) and whose result is a
-//! string handle for the output bytes.
+//! string handle for the output bytes. Source text is normalized through the
+//! same Clojure reader compatibility layer as [`crate::compile_str`].
 
 use wit_component::{ComponentEncoder, StringEncoding};
 use wit_parser::Resolve;
 
 use crate::codegen::{Entry, EntryAbi};
+use crate::compat::{self, ReaderTarget};
 use crate::CljError;
 
 /// The WIT world every kotoba-clj program component targets.
@@ -28,7 +30,17 @@ world program {
 /// Compile Clojure-subset source into a WASM **Component** exporting
 /// `run(list<u8>) -> list<u8>`. Requires a `(defn run [input] …)`.
 pub fn compile_component_str(src: &str) -> Result<Vec<u8>, CljError> {
-    let program = crate::ast::parse_program(src)?;
+    compile_component_str_with_reader_target(src, ReaderTarget::Kotoba)
+}
+
+/// Compile source into a WASM **Component** after applying Clojure reader
+/// compatibility for `target`.
+pub fn compile_component_str_with_reader_target(
+    src: &str,
+    target: ReaderTarget,
+) -> Result<Vec<u8>, CljError> {
+    let src = compat::normalize_source(src, target)?;
+    let program = crate::ast::parse_program(&src)?;
     let core = crate::codegen::compile_core(
         &program,
         Some(Entry {
@@ -114,7 +126,18 @@ pub fn compile_and_run_component(src: &str, input: &[u8]) -> Result<Vec<u8>, Clj
 /// component that `kotoba-runtime` can load. It does not make a program that
 /// meaningfully reads `ctx`/`args`.
 pub fn compile_kais_component_str(src: &str, wit_dir: &str) -> Result<Vec<u8>, CljError> {
-    let program = crate::ast::parse_program(src)?;
+    compile_kais_component_str_with_reader_target(src, wit_dir, ReaderTarget::Kotoba)
+}
+
+/// Compile source into a `kotoba-node` Component after applying Clojure reader
+/// compatibility for `target`.
+pub fn compile_kais_component_str_with_reader_target(
+    src: &str,
+    wit_dir: &str,
+    target: ReaderTarget,
+) -> Result<Vec<u8>, CljError> {
+    let src = compat::normalize_source(src, target)?;
+    let program = crate::ast::parse_program(&src)?;
     let core = crate::codegen::compile_core(
         &program,
         Some(Entry {

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -22,12 +22,32 @@
 //! `1`/`0`, truthy ⇔ non-zero). A **string** is a packed `(offset << 32) | len`
 //! handle into linear memory.
 //!
-//! - top-level: `(def name <const>)`, `(defn name [params…] body…)`, `(ns …)` (ignored)
-//! - control: `if`, `when`, `cond`, `let`, `do`, `loop`/`recur` (bounded iteration)
+//! - top-level: `(def name "doc?" <const>)`, `(defonce name "doc?" <const>)`,
+//!   `(defn name "doc?" attr-map? [params…] body…)`, arity-list
+//!   `(defn name "doc?" attr-map? ([params…] body…) ([params…] body…))`,
+//!   `(defn- …)`, top-level `(do …)` wrapping definitions, `(ns …)`,
+//!   `(in-ns …)`, `(alias …)`, `(create-ns …)`, `(remove-ns …)`,
+//!   `(require …)`, `(use …)`, `(refer-clojure …)`, `(import …)`,
+//!   `(gen-class …)`, `(set! …)`, `(defrecord …)`, `(deftype …)`,
+//!   `(defprotocol …)`, `(extend-type …)`, `(extend-protocol …)`,
+//!   `(defmulti …)`, `(defmethod …)`, `(defmacro …)`, `(defstruct …)`,
+//!   `(create-struct …)`, `(comment …)`, and `(declare …)` (ignored where noted;
+//!   macros are accepted but not expanded)
+//! - control: `if`, `when`, `if-let`, `when-let`, `cond`, `case`, `let`, `do`,
+//!   `loop`/`recur` (bounded iteration), threading macros `->`, `->>`,
+//!   `cond->`, `cond->>`, `some->`, `some->>`, and `as->`
 //! - arithmetic: `+ - * / mod`
 //! - comparison: `= < > <= >=`
 //! - logic: `and or not` (short-circuit; return 0/1)
 //! - strings: `"…"` literals, `(str-len s)`, `(byte-at s i)`
+//! - Clojure literals: `nil` lowers to `0`; keyword literals and quoted forms
+//!   lower to canonical EDN string handles; var quote (`#'foo`, `(var foo)`)
+//!   lowers to the referenced symbol name handle
+//! - `defn` pre/post condition maps (`{:pre […] :post […]}`) are accepted for
+//!   source compatibility but not asserted
+//! - Clojure reader metadata (`^:private`, `^String`, `^long`) is stripped before
+//!   lowering
+//! - Clojure discard forms (`#_ form`) are stripped before lowering
 //! - byte builder: `(bytes-alloc cap)`, `(byte-append! buf b)`, `(bytes-len buf)`,
 //!   `(bytes-finish buf)` — a mutable buffer in linear memory; `bytes-finish`
 //!   yields a string handle (the foundation for in-guest CBOR encode/decode)
@@ -48,11 +68,14 @@
 //!   with `:state`, a reducer-merge) `defn`s. Static + `(if-edge pred? :then
 //!   :else)` edges; `:state {:ch add-messages}` makes nodes return partial
 //!   updates merged per channel (extend vs override). State = a Stage-B map.
-//! - user function calls, including (mutual) recursion
+//! - user function calls, including (mutual) recursion and arity-based
+//!   resolution
 //!
-//! Each `defn` is exported under its own name. `def` initialisers are evaluated
-//! at compile time and inlined. Every module also exports a linear `memory` and
-//! a `cabi_realloc` bump allocator (the Canonical-ABI substrate).
+//! Each single-arity `defn` is exported under its own name. Multi-arity `defn`s
+//! are resolved for source-level calls and Component entry wrapping, but are not
+//! exported as multiple same-name core wasm functions. `def` initialisers are
+//! evaluated at compile time and inlined. Every module also exports a linear
+//! `memory` and a `cabi_realloc` bump allocator (the Canonical-ABI substrate).
 //!
 //! ## Roadmap to the kotoba:kais binding
 //!
@@ -84,10 +107,13 @@
 
 pub mod ast;
 pub mod codegen;
+pub mod compat;
 #[cfg(feature = "component")]
 pub mod component;
 #[cfg(feature = "run")]
 pub mod run;
+
+pub use compat::ReaderTarget;
 
 use std::path::Path;
 use thiserror::Error;
@@ -111,11 +137,20 @@ pub enum CljError {
 
 /// Compile Clojure-subset source text into WebAssembly bytes.
 pub fn compile_str(src: &str) -> Result<Vec<u8>, CljError> {
-    let program = ast::parse_program(src)?;
+    compile_str_with_reader_target(src, ReaderTarget::Kotoba)
+}
+
+/// Compile source text after applying Clojure reader compatibility for `target`.
+pub fn compile_str_with_reader_target(
+    src: &str,
+    target: ReaderTarget,
+) -> Result<Vec<u8>, CljError> {
+    let src = compat::normalize_source(src, target)?;
+    let program = ast::parse_program(&src)?;
     codegen::compile(&program)
 }
 
-/// Compile a `.kotoba` source file into WebAssembly bytes.
+/// Compile a `.kotoba` / `.clj` / `.cljc` / `.cljs` source file into WebAssembly bytes.
 ///
 /// A leading Unix shebang (`#!...`) is stripped before the EDN/Clojure reader
 /// sees the source, so executable scripts can start with:
@@ -124,27 +159,48 @@ pub fn compile_str(src: &str) -> Result<Vec<u8>, CljError> {
 /// #!/usr/bin/env kotoba-clj
 /// ```
 pub fn compile_file(path: impl AsRef<Path>) -> Result<Vec<u8>, CljError> {
-    let src = std::fs::read_to_string(path.as_ref())
-        .map_err(|e| CljError::Read(format!("read {}: {e}", path.as_ref().display())))?;
-    compile_str(strip_shebang(&src))
+    compile_file_with_reader_target(path, ReaderTarget::Kotoba)
+}
+
+/// Compile a source file with a specific reader conditional target.
+pub fn compile_file_with_reader_target(
+    path: impl AsRef<Path>,
+    target: ReaderTarget,
+) -> Result<Vec<u8>, CljError> {
+    compile_file_with_reader_target_and_source_paths(path, target, &[])
+}
+
+/// Compile a source file with a reader target and additional source paths.
+pub fn compile_file_with_reader_target_and_source_paths(
+    path: impl AsRef<Path>,
+    target: ReaderTarget,
+    source_paths: &[std::path::PathBuf],
+) -> Result<Vec<u8>, CljError> {
+    let src = compat::load_file_graph_with_source_paths(path.as_ref(), target, source_paths)?;
+    compile_str_with_reader_target(&src, target)
 }
 
 /// Compile a source file with the container + CBOR prelude.
 pub fn compile_file_with_prelude(path: impl AsRef<Path>) -> Result<Vec<u8>, CljError> {
-    let src = std::fs::read_to_string(path.as_ref())
-        .map_err(|e| CljError::Read(format!("read {}: {e}", path.as_ref().display())))?;
-    compile_str_with_prelude(strip_shebang(&src))
+    compile_file_with_prelude_and_reader_target(path, ReaderTarget::Kotoba)
 }
 
-fn strip_shebang(src: &str) -> &str {
-    if let Some(rest) = src.strip_prefix("#!") {
-        match rest.find('\n') {
-            Some(i) => &rest[i + 1..],
-            None => "",
-        }
-    } else {
-        src
-    }
+/// Compile a source file with the container + CBOR prelude and reader target.
+pub fn compile_file_with_prelude_and_reader_target(
+    path: impl AsRef<Path>,
+    target: ReaderTarget,
+) -> Result<Vec<u8>, CljError> {
+    compile_file_with_prelude_reader_target_and_source_paths(path, target, &[])
+}
+
+/// Compile a source file with prelude, reader target, and additional source paths.
+pub fn compile_file_with_prelude_reader_target_and_source_paths(
+    path: impl AsRef<Path>,
+    target: ReaderTarget,
+    source_paths: &[std::path::PathBuf],
+) -> Result<Vec<u8>, CljError> {
+    let src = compat::load_file_graph_with_source_paths(path.as_ref(), target, source_paths)?;
+    compile_str_with_prelude_and_reader_target(&src, target)
 }
 
 /// A dynamic-container prelude written in the kotoba-clj subset **itself**:
@@ -393,9 +449,18 @@ pub const KQE_PRELUDE: &str = r#"
 /// accessors [`KQE_PRELUDE`] prepended, so the program can use `vec-*` /
 /// `map-*` / `cbor-*` / `kqe-*` directly.
 pub fn compile_str_with_prelude(src: &str) -> Result<Vec<u8>, CljError> {
-    compile_str(&format!(
-        "{PRELUDE}\n{CBOR_PRELUDE}\n{CBOR_ENC_PRELUDE}\n{KQE_PRELUDE}\n{src}"
-    ))
+    compile_str_with_prelude_and_reader_target(src, ReaderTarget::Kotoba)
+}
+
+/// Compile `src` with the combined prelude and a specific reader target.
+pub fn compile_str_with_prelude_and_reader_target(
+    src: &str,
+    target: ReaderTarget,
+) -> Result<Vec<u8>, CljError> {
+    compile_str_with_reader_target(
+        &format!("{PRELUDE}\n{CBOR_PRELUDE}\n{CBOR_ENC_PRELUDE}\n{KQE_PRELUDE}\n{src}"),
+        target,
+    )
 }
 
 /// The combined prelude text (containers + CBOR decode + CBOR encode + kqe

--- a/crates/kotoba-clj/src/main.rs
+++ b/crates/kotoba-clj/src/main.rs
@@ -9,17 +9,25 @@ fn main() {
 
 fn real_main() -> Result<(), String> {
     let opts = Options::parse(std::env::args().skip(1).collect())?;
-    if opts.path.extension().is_none_or(|ext| ext != "kotoba") && !opts.allow_any_ext {
+    if !is_supported_source_ext(&opts.path) && !opts.allow_any_ext {
         return Err(format!(
-            "expected a .kotoba file (got {}). Use --allow-any-ext to run anyway.",
+            "expected a .kotoba/.clj/.cljc/.cljs file (got {}). Use --allow-any-ext to run anyway.",
             opts.path.display()
         ));
     }
 
     let wasm = if opts.prelude {
-        kotoba_clj::compile_file_with_prelude(&opts.path)
+        kotoba_clj::compile_file_with_prelude_reader_target_and_source_paths(
+            &opts.path,
+            opts.reader_target,
+            &opts.source_paths,
+        )
     } else {
-        kotoba_clj::compile_file(&opts.path)
+        kotoba_clj::compile_file_with_reader_target_and_source_paths(
+            &opts.path,
+            opts.reader_target,
+            &opts.source_paths,
+        )
     }
     .map_err(|e| e.to_string())?;
 
@@ -39,6 +47,8 @@ struct Options {
     args: Vec<i64>,
     prelude: bool,
     allow_any_ext: bool,
+    reader_target: kotoba_clj::ReaderTarget,
+    source_paths: Vec<PathBuf>,
     wasm_out: Option<PathBuf>,
 }
 
@@ -47,6 +57,8 @@ impl Options {
         let mut func = "main".to_string();
         let mut prelude = true;
         let mut allow_any_ext = false;
+        let mut reader_target = kotoba_clj::ReaderTarget::Kotoba;
+        let mut source_paths = Vec::new();
         let mut wasm_out = None;
         let mut positional = Vec::new();
         let mut i = 0;
@@ -62,6 +74,22 @@ impl Options {
                 }
                 "--no-prelude" => prelude = false,
                 "--allow-any-ext" => allow_any_ext = true,
+                "--reader-target" => {
+                    i += 1;
+                    let target = argv
+                        .get(i)
+                        .ok_or_else(|| "--reader-target requires kotoba|clj|cljs".to_string())?;
+                    reader_target = kotoba_clj::ReaderTarget::parse(target)
+                        .ok_or_else(|| format!("unsupported reader target: {target}"))?;
+                }
+                "-S" | "--source-path" => {
+                    i += 1;
+                    let path = argv
+                        .get(i)
+                        .cloned()
+                        .ok_or_else(|| "--source-path requires a directory".to_string())?;
+                    source_paths.push(PathBuf::from(path));
+                }
                 "--wasm-out" => {
                     i += 1;
                     let path = argv
@@ -101,16 +129,27 @@ impl Options {
             args,
             prelude,
             allow_any_ext,
+            reader_target,
+            source_paths,
             wasm_out,
         })
     }
 }
 
+fn is_supported_source_ext(path: &std::path::Path) -> bool {
+    matches!(
+        path.extension().and_then(|ext| ext.to_str()),
+        Some("kotoba" | "clj" | "cljc" | "cljs")
+    )
+}
+
 fn usage() -> String {
-    "usage: kotoba-clj [--func NAME|-f NAME] [--no-prelude] [--wasm-out OUT.wasm] [--allow-any-ext] FILE.kotoba [i64 args...]\n\
+    "usage: kotoba-clj [--func NAME|-f NAME] [--no-prelude] [--reader-target kotoba|clj|cljs] [--source-path DIR|-S DIR] [--wasm-out OUT.wasm] [--allow-any-ext] FILE.{kotoba,clj,cljc,cljs} [i64 args...]\n\
      examples:\n\
        kotoba-clj app.kotoba\n\
        kotoba-clj --func fact math.kotoba 10\n\
+       kotoba-clj -S src app.clj\n\
+       kotoba-clj --reader-target kotoba agent.cljc\n\
        chmod +x app.kotoba && ./app.kotoba"
         .to_string()
 }
@@ -129,6 +168,8 @@ mod tests {
                 args: vec![1, 2],
                 prelude: true,
                 allow_any_ext: false,
+                reader_target: kotoba_clj::ReaderTarget::Kotoba,
+                source_paths: vec![],
                 wasm_out: None,
             }
         );
@@ -142,6 +183,12 @@ mod tests {
                 "fact".into(),
                 "--no-prelude".into(),
                 "--allow-any-ext".into(),
+                "--reader-target".into(),
+                "cljs".into(),
+                "-S".into(),
+                "src".into(),
+                "--source-path".into(),
+                "vendor".into(),
                 "--wasm-out".into(),
                 "out.wasm".into(),
                 "math.clj".into(),
@@ -154,6 +201,8 @@ mod tests {
                 args: vec![5],
                 prelude: false,
                 allow_any_ext: true,
+                reader_target: kotoba_clj::ReaderTarget::Cljs,
+                source_paths: vec![PathBuf::from("src"), PathBuf::from("vendor")],
                 wasm_out: Some(PathBuf::from("out.wasm")),
             }
         );

--- a/crates/kotoba-clj/tests/compile_run.rs
+++ b/crates/kotoba-clj/tests/compile_run.rs
@@ -127,6 +127,187 @@ fn if_when_let_do() {
     // sequential let: second binding sees the first
     let l = "(defn l [x] (let [a (* x 2) b (+ a 1)] (do a b)))";
     assert_eq!(compile_and_run(l, "l", &[5]).unwrap(), 11);
+
+    let if_let = "(defn il [x] (if-let [v x] (+ v 2) 99))";
+    assert_eq!(compile_and_run(if_let, "il", &[40]).unwrap(), 42);
+    assert_eq!(compile_and_run(if_let, "il", &[0]).unwrap(), 99);
+
+    let when_let = "(defn wl [x] (when-let [v x] (+ v 2)))";
+    assert_eq!(compile_and_run(when_let, "wl", &[40]).unwrap(), 42);
+    assert_eq!(compile_and_run(when_let, "wl", &[0]).unwrap(), 0);
+
+    let c = "(defn c [x] (case x 0 99 1 10 (2 3) 42 5))";
+    assert_eq!(compile_and_run(c, "c", &[2]).unwrap(), 42);
+    assert_eq!(compile_and_run(c, "c", &[3]).unwrap(), 42);
+    assert_eq!(compile_and_run(c, "c", &[1]).unwrap(), 10);
+    assert_eq!(compile_and_run(c, "c", &[9]).unwrap(), 5);
+}
+
+#[test]
+fn nil_keyword_and_quote_literals() {
+    assert_eq!(compile_and_run("(defn n [] nil)", "n", &[]).unwrap(), 0);
+    assert_eq!(
+        compile_and_run("(defn k [] (str-len :demo/ok))", "k", &[]).unwrap(),
+        8
+    );
+    assert_eq!(
+        compile_and_run("(defn k [] (byte-at :demo/ok 0))", "k", &[]).unwrap(),
+        b':' as i64
+    );
+    assert_eq!(
+        compile_and_run("(defn q [] (str-len 'demo/ok))", "q", &[]).unwrap(),
+        7
+    );
+    assert_eq!(
+        compile_and_run("(defn q [] (str-len '(a b c)))", "q", &[]).unwrap(),
+        7
+    );
+    assert_eq!(
+        compile_and_run("(defn q [] (byte-at '[1 2] 0))", "q", &[]).unwrap(),
+        b'[' as i64
+    );
+    assert_eq!(
+        compile_and_run("(defn v [] (str-len #'demo/ok))", "v", &[]).unwrap(),
+        7
+    );
+    assert_eq!(
+        compile_and_run("(defn v [] (str-len (var demo/ok)))", "v", &[]).unwrap(),
+        7
+    );
+}
+
+#[test]
+fn accepts_common_clojure_declaration_forms() {
+    let src = r#"
+        (comment
+          (defn ignored [x] (missing x)))
+        (declare later)
+        (refer-clojure :exclude [max])
+        (in-ns 'demo.main)
+        (create-ns 'demo.extra)
+        (alias 'extra 'demo.extra)
+        (remove-ns 'demo.extra)
+        (import '[java.time Instant])
+        (gen-class)
+        (set! *warn-on-reflection* true)
+        (defrecord User [id name])
+        (deftype Box [value])
+        (defprotocol Renderable (render [this]))
+        (extend-type User Renderable (render [this] (:name this)))
+        (extend-protocol Renderable Box (render [this] "box"))
+        (defmulti describe :kind)
+        (defmethod describe :user [x] (:name x))
+        (defstruct legacy-user :id :name)
+        (create-struct :id :name)
+        (def offset "compile-time constant" 1)
+        (defonce bonus 1)
+        (defn later "Adds one." {:private true} [x] (inc x))
+        (defn- hidden [x] (+ x bonus))
+        (defn main {:export true} [x] (hidden (+ (later x) offset)))
+    "#;
+    assert_eq!(compile_and_run(src, "main", &[39]).unwrap(), 42);
+}
+
+#[test]
+fn accepts_top_level_do_wrapping_definitions() {
+    let src = r#"
+        (do
+          (def offset 2)
+          (defn helper [x] (+ x offset)))
+        (do
+          (defn main [x] (helper x)))
+    "#;
+    assert_eq!(compile_and_run(src, "main", &[40]).unwrap(), 42);
+}
+
+#[test]
+fn accepts_single_arity_list_defn_shape() {
+    let src = r#"
+        (defn wrapped
+          "Single arity written in Clojure's arity-list shape."
+          ([x] (+ x 2)))
+    "#;
+    assert_eq!(compile_and_run(src, "wrapped", &[40]).unwrap(), 42);
+}
+
+#[test]
+fn accepts_multi_arity_defn_for_source_calls() {
+    let src = r#"
+        (defn addish
+          ([x] (+ x 1))
+          ([x y] (+ x y)))
+        (defn main [x]
+          (+ (addish x) (addish x 1)))
+    "#;
+    assert_eq!(compile_and_run(src, "main", &[20]).unwrap(), 42);
+}
+
+#[test]
+fn accepts_defn_prepost_condition_maps() {
+    let src = r#"
+        (defn guarded [x]
+          {:pre [(pos? x)] :post [(pos? %)]}
+          (+ x 4))
+        (defn addish
+          ([x]
+           {:pre [(pos? x)]}
+           (+ x 1))
+          ([x y]
+           {:post [(pos? %)]}
+           (+ x y)))
+        (defn main [x]
+          (+ (guarded x) (addish x) (addish x 1)))
+    "#;
+    assert_eq!(compile_and_run(src, "main", &[12]).unwrap(), 42);
+}
+
+#[test]
+fn accepts_threading_macros() {
+    let src = r#"
+        (defn first-thread [x]
+          (-> x inc (+ 10) (* 2)))
+        (defn last-thread [x]
+          (->> x (+ 10) (* 2)))
+        (defn conditional-first-thread [x]
+          (cond-> x true (+ 10) (> x 0) (* 2) false (+ 1000)))
+        (defn conditional-last-thread [x]
+          (cond->> x true (- 100) false (+ 1000)))
+        (defn named-thread [x]
+          (as-> x v
+            (+ v 1)
+            (* v 2)))
+        (defn nil-aware-first-thread [x]
+          (some-> x inc (+ 10) (* 2)))
+        (defn nil-aware-last-thread [x]
+          (some->> x (+ 10) (* 2)))
+    "#;
+    assert_eq!(compile_and_run(src, "first-thread", &[10]).unwrap(), 42);
+    assert_eq!(compile_and_run(src, "last-thread", &[11]).unwrap(), 42);
+    assert_eq!(
+        compile_and_run(src, "conditional-first-thread", &[11]).unwrap(),
+        42
+    );
+    assert_eq!(
+        compile_and_run(src, "conditional-last-thread", &[58]).unwrap(),
+        42
+    );
+    assert_eq!(compile_and_run(src, "named-thread", &[20]).unwrap(), 42);
+    assert_eq!(
+        compile_and_run(src, "nil-aware-first-thread", &[10]).unwrap(),
+        42
+    );
+    assert_eq!(
+        compile_and_run(src, "nil-aware-first-thread", &[0]).unwrap(),
+        0
+    );
+    assert_eq!(
+        compile_and_run(src, "nil-aware-last-thread", &[11]).unwrap(),
+        42
+    );
+    assert_eq!(
+        compile_and_run(src, "nil-aware-last-thread", &[0]).unwrap(),
+        0
+    );
 }
 
 #[test]

--- a/crates/kotoba-clj/tests/component.rs
+++ b/crates/kotoba-clj/tests/component.rs
@@ -5,8 +5,11 @@
 //! machinery the future kotoba:kais `run(ctx-cbor: list<u8>)` export reuses.
 #![cfg(feature = "component")]
 
-use kotoba_clj::component::{compile_and_run_component, compile_component_str};
+use kotoba_clj::component::{
+    compile_and_run_component, compile_component_str, compile_component_str_with_reader_target,
+};
 use kotoba_clj::CljError;
+use kotoba_clj::ReaderTarget;
 
 #[test]
 fn component_is_real_wasm() {
@@ -39,6 +42,42 @@ fn returns_data_segment_literal() {
     // Output handle points into the data segment (not the input buffer) — proves
     // the lift reads arbitrary guest memory, not just the host-lowered input.
     let out = compile_and_run_component(r#"(defn run [input] "ok")"#, b"ignored").unwrap();
+    assert_eq!(out, b"ok");
+}
+
+#[test]
+fn component_compile_applies_clojure_reader_compat() {
+    let src = r#"
+        #_ (defn ignored [input] "bad")
+        ^:private
+        (defn run "entry" [input]
+          (if-let [x (str-len '(a b c))]
+            (-> input)
+            "bad"))
+    "#;
+    let out = compile_and_run_component(src, b"ok").unwrap();
+    assert_eq!(out, b"ok");
+}
+
+#[test]
+fn component_compile_honors_reader_target() {
+    let src = r#"
+        (defn run [input]
+          #?(:cljs "cljs" :clj "clj" :default "default"))
+    "#;
+    let component = compile_component_str_with_reader_target(src, ReaderTarget::Cljs).unwrap();
+    let out = kotoba_clj::component::run_component(&component, b"ignored").unwrap();
+    assert_eq!(out, b"cljs");
+}
+
+#[test]
+fn component_entry_can_be_multi_arity_defn() {
+    let src = r#"
+        (defn run
+          ([input] input)
+          ([input suffix] suffix))
+    "#;
+    let out = compile_and_run_component(src, b"ok").unwrap();
     assert_eq!(out, b"ok");
 }
 
@@ -90,5 +129,23 @@ fn kais_entry_can_echo_raw_ctx() {
     // The raw ctx-cbor bytes are handed to the program as its input handle, so
     // an echo program is well-typed against the result<list<u8>,string> ABI.
     let component = compile_kais_component_str("(defn run [ctx] ctx)", KAIS_WIT_DIR).unwrap();
+    assert_loads(&component).unwrap();
+}
+
+#[test]
+fn kais_component_compile_applies_clojure_reader_compat() {
+    let component = compile_kais_component_str(
+        r#"
+        (do
+          #_ (defn run [ctx] "bad")
+          ^String
+          (defn run "entry" [ctx]
+            (if-let [quoted (str-len '(ctx payload))]
+              (-> ctx)
+              "bad")))
+        "#,
+        KAIS_WIT_DIR,
+    )
+    .unwrap();
     assert_loads(&component).unwrap();
 }

--- a/crates/kotoba-clj/tests/kotoba_file.rs
+++ b/crates/kotoba-clj/tests/kotoba_file.rs
@@ -39,8 +39,997 @@ fn binary_runs_kotoba_file_main() {
     let _ = fs::remove_file(path);
 }
 
+#[test]
+fn binary_accepts_clj_extension_without_escape_hatch() {
+    let path = temp_path("main.clj");
+    fs::write(
+        &path,
+        "(ns demo.main (:require [clojure.core :as c]))\n(defn main [x] (inc x))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&path)
+        .arg("41")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn binary_accepts_quote_syntax_in_file() {
+    let path = temp_path("quote.clj");
+    fs::write(
+        &path,
+        "(ns demo.quote)\n(defn main [x] (+ x (str-len '(a b c))))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&path)
+        .arg("35")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn binary_ignores_clojure_metadata_syntax() {
+    let path = temp_path("metadata.clj");
+    fs::write(
+        &path,
+        r#"
+(ns demo.metadata)
+^:private
+(defn ^:export main "entry" [^long x ^String y]
+  (+ x (str-len y)))
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&path)
+        .arg("40")
+        .arg("2")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn binary_ignores_discard_reader_syntax() {
+    let path = temp_path("discard.clj");
+    fs::write(
+        &path,
+        r#"
+(ns demo.discard)
+#_ (defn main [x] (missing x))
+#_ ^:private '(discarded data)
+(defn main [x] (+ x 2))
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&path)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn binary_accepts_threading_macros_in_file() {
+    let path = temp_path("threading.clj");
+    fs::write(
+        &path,
+        r#"
+(ns demo.threading)
+(defn main [x]
+  (+ (-> x inc)
+     (->> x (+ 1) (* 1))
+     (cond-> 0 true (+ 0))
+     (some-> 5 (+ 5))))
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&path)
+        .arg("15")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn binary_accepts_case_in_file() {
+    let path = temp_path("case.clj");
+    fs::write(
+        &path,
+        r#"
+(ns demo.case)
+(defn main [x]
+  (case x
+    1 10
+    (2 3) 42
+    7))
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&path)
+        .arg("3")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn cljc_reader_conditionals_select_kotoba_then_clj_fallback() {
+    let path = temp_path("conditional.cljc");
+    fs::write(
+        &path,
+        r#"
+(ns demo.conditional)
+#?(:cljs (defn ignored [x] x)
+   :kotoba (defn main [x] (+ x 10))
+   :clj (defn main [x] (+ x 1)))
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&path)
+        .arg("32")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn reader_target_can_select_cljs_branch() {
+    let path = temp_path("target.cljs");
+    fs::write(
+        &path,
+        r#"
+#?(:cljs (defn main [x] (+ x 2))
+   :clj (defn main [x] (+ x 100)))
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg("--reader-target")
+        .arg("cljs")
+        .arg(&path)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn require_alias_loads_neighbor_namespace() {
+    let dir = temp_dir("require-alias");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/util.clj"),
+        "(ns demo.util)\n(defn add [a b] (+ a b))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [demo.util :as u]))\n(defn main [x] (u/add x 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn require_as_alias_does_not_load_namespace() {
+    let dir = temp_dir("require-as-alias");
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [missing.spec :as-alias spec]))\n(defn main [x] (+ x 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn unused_platform_requires_do_not_load_files() {
+    let path = temp_path("platform-requires.cljc");
+    fs::write(
+        &path,
+        r#"
+(ns demo.platform
+  (:require [clojure.string :as str]
+            [clojure.set :refer [union]]
+            [cljs.core :as cljs]))
+(defn main [x] (+ x 2))
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg("--reader-target")
+        .arg("cljs")
+        .arg(&path)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
+fn reader_target_controls_required_namespace_extension_priority() {
+    let dir = temp_dir("require-extension-priority");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/util.clj"),
+        "(ns demo.util)\n(defn add [a b] (+ a b 1000))\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("demo/util.cljs"),
+        "(ns demo.util)\n(defn add [a b] (+ a b))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.cljs");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [demo.util :as u]))\n(defn main [x] (u/add x 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg("--reader-target")
+        .arg("cljs")
+        .arg(&main)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn kotoba_target_prefers_kotoba_required_namespace() {
+    let dir = temp_dir("require-kotoba-priority");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/util.clj"),
+        "(ns demo.util)\n(defn add [a b] (+ a b 1000))\n",
+    )
+    .unwrap();
+    fs::write(
+        dir.join("demo/util.kotoba"),
+        "(ns demo.util)\n(defn add [a b] (+ a b))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.kotoba");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [demo.util :as u]))\n(defn main [x] (u/add x 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn require_loads_namespace_with_defonce_and_private_defn() {
+    let dir = temp_dir("require-private-defn");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/util.clj"),
+        r#"
+(ns demo.util)
+(defonce bonus "compile-time value" 1)
+(defn- hidden
+  ([x] (+ x bonus)))
+(defn shadow-param [bonus] bonus)
+(defn shadow-let [x] (let [bonus x] bonus))
+(defn shadow-if-let [bonus] (if-let [bonus bonus] bonus 0))
+(defn shadow-when-let [bonus] (when-let [bonus bonus] bonus))
+(defn shadow-as-thread [bonus] (as-> bonus bonus (+ bonus 1)))
+(defn add [a]
+  (+ (hidden a)
+     (shadow-param 80)
+     (shadow-let 10)
+     (shadow-if-let 5)
+     (shadow-when-let 5)
+     (shadow-as-thread 6)))
+"#,
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [demo.util :as u]))\n(defn main [x] (u/add x))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("--")
+        .arg("-66")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn require_loads_namespace_wrapped_in_top_level_do() {
+    let dir = temp_dir("require-top-level-do");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/util.clj"),
+        r#"
+(do
+  (ns demo.util)
+  (def offset 2)
+  (defn add [x] (+ x offset)))
+"#,
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [demo.util :refer [add]]))\n(defn main [x] (add x))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn require_refer_loads_neighbor_namespace() {
+    let dir = temp_dir("require-refer");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/math.clj"),
+        "(ns demo.math)\n(defn twice [x] (* x 2))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [demo.math :refer [twice]]))\n(defn main [x] (+ (twice x) 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("20")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn require_refer_all_loads_exported_names_only() {
+    let dir = temp_dir("require-refer-all");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/math.clj"),
+        "(ns demo.math)\n(defn twice [x] (* x 2))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [demo.math :refer :all]))\n(defn main [x] (+ (twice x) 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("20")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn require_refer_all_exclude_preserves_local_name() {
+    let dir = temp_dir("require-refer-all-exclude");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/math.clj"),
+        "(ns demo.math)\n(defn twice [x] (* x 100))\n(defn inc2 [x] (+ x 2))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [demo.math :refer :all :exclude [twice]]))\n(defn twice [x] (+ x 2))\n(defn main [x] (+ (twice x) (inc2 0)))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("38")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn require_rename_rewrites_local_name_to_exported_name() {
+    let dir = temp_dir("require-rename");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/math.clj"),
+        "(ns demo.math)\n(defn twice [x] (* x 2))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [demo.math :rename {twice double}]))\n(defn main [x] (+ (double x) 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("20")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn require_prefix_list_loads_nested_namespace() {
+    let dir = temp_dir("require-prefix");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/util.clj"),
+        "(ns demo.util)\n(defn add [a b] (+ a b))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [demo [util :as u]]))\n(defn main [x] (u/add x 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn ns_use_exclude_preserves_local_name() {
+    let dir = temp_dir("ns-use-exclude");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/math.clj"),
+        "(ns demo.math)\n(defn twice [x] (* x 100))\n(defn inc2 [x] (+ x 2))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:use [demo.math :exclude [twice]]))\n(defn twice [x] (+ x 2))\n(defn main [x] (+ (twice x) (inc2 0)))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("38")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn require_macros_is_loaded_like_require_for_compat() {
+    let dir = temp_dir("require-macros");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/math.clj"),
+        "(ns demo.math)\n(defn twice [x] (* x 2))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.cljs");
+    fs::write(
+        &main,
+        "(ns demo.main (:require-macros [demo.math :refer [twice]]))\n(defn main [x] (+ (twice x) 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg("--reader-target")
+        .arg("cljs")
+        .arg(&main)
+        .arg("20")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn require_macros_can_load_macro_only_namespace() {
+    let dir = temp_dir("require-macro-only");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/macros.clj"),
+        r#"
+(ns demo.macros)
+(defmacro ignored-when-runtime-only [x] (list '+ x 1000))
+"#,
+    )
+    .unwrap();
+    let main = dir.join("main.cljs");
+    fs::write(
+        &main,
+        "(ns demo.main (:require-macros [demo.macros :refer [ignored-when-runtime-only]]))\n(defn main [x] (+ x 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg("--reader-target")
+        .arg("cljs")
+        .arg(&main)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn ns_use_only_and_rename_load_neighbor_namespace() {
+    let dir = temp_dir("ns-use");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/math.clj"),
+        "(ns demo.math)\n(defn twice [x] (* x 2))\n(defn bump [x] (+ x 1))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:use [demo.math :only [twice] :rename {bump inc2}]))\n(defn main [x] (+ (twice x) (inc2 1)))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("20")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn top_level_require_loads_neighbor_namespace() {
+    let dir = temp_dir("top-level-require");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/util.clj"),
+        "(ns demo.util)\n(defn add [a b] (+ a b))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(require '[demo.util :as u])\n(defn main [x] (u/add x 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn top_level_use_loads_neighbor_namespace() {
+    let dir = temp_dir("top-level-use");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/math.clj"),
+        "(ns demo.math)\n(defn twice [x] (* x 2))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(use '[demo.math :only [twice]])\n(defn main [x] (+ (twice x) 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("20")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn source_path_flag_resolves_require_outside_entry_dir() {
+    let dir = temp_dir("source-path-flag");
+    fs::create_dir_all(dir.join("src/demo")).unwrap();
+    fs::write(
+        dir.join("src/demo/util.clj"),
+        "(ns demo.util)\n(defn add [a b] (+ a b))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [demo.util :as u]))\n(defn main [x] (u/add x 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg("--source-path")
+        .arg(dir.join("src"))
+        .arg(&main)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn env_source_path_resolves_require_outside_entry_dir() {
+    let dir = temp_dir("source-path-env");
+    fs::create_dir_all(dir.join("lib/demo")).unwrap();
+    fs::write(
+        dir.join("lib/demo/util.clj"),
+        "(ns demo.util)\n(defn add [a b] (+ a b))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [demo.util :as u]))\n(defn main [x] (u/add x 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .env("KOTOBA_CLJ_PATH", dir.join("lib"))
+        .arg(&main)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn deps_edn_paths_resolve_project_source_root() {
+    let dir = temp_dir("deps-edn-paths");
+    fs::create_dir_all(dir.join("src/demo")).unwrap();
+    fs::write(dir.join("deps.edn"), "{:paths [\"src\"]}\n").unwrap();
+    fs::write(
+        dir.join("src/demo/util.clj"),
+        "(ns demo.util)\n(defn add [a b] (+ a b))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [demo.util :as u]))\n(defn main [x] (u/add x 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn deps_edn_is_discovered_from_entry_ancestors() {
+    let dir = temp_dir("deps-edn-ancestor");
+    fs::create_dir_all(dir.join("app")).unwrap();
+    fs::create_dir_all(dir.join("src/demo")).unwrap();
+    fs::write(dir.join("deps.edn"), "{:paths [\"src\"]}\n").unwrap();
+    fs::write(
+        dir.join("src/demo/util.clj"),
+        "(ns demo.util)\n(defn add [a b] (+ a b))\n",
+    )
+    .unwrap();
+    let main = dir.join("app/main.clj");
+    fs::write(
+        &main,
+        "(ns demo.main (:require [demo.util :as u]))\n(defn main [x] (u/add x 2))\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("40")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
 fn temp_path(name: &str) -> std::path::PathBuf {
     let mut path = std::env::temp_dir();
     path.push(format!("kotoba-clj-test-{}-{name}", std::process::id()));
+    path
+}
+
+fn temp_dir(name: &str) -> std::path::PathBuf {
+    let path = temp_path(name);
+    let _ = fs::remove_dir_all(&path);
+    fs::create_dir_all(&path).unwrap();
     path
 }

--- a/crates/kotoba-clj/tests/langgraph_echo.rs
+++ b/crates/kotoba-clj/tests/langgraph_echo.rs
@@ -76,7 +76,11 @@ fn ok_json(output_cbor: &[u8]) -> String {
     let map = value.as_map().expect("output is a CBOR map");
     assert_eq!(map.len(), 1, "exactly the ok entry");
     assert_eq!(map[0].0.as_text(), Some("ok"));
-    map[0].1.as_text().expect("ok holds a JSON string").to_string()
+    map[0]
+        .1
+        .as_text()
+        .expect("ok holds a JSON string")
+        .to_string()
 }
 
 // ---- echo semantics: prompt round-trips to response ---------------------------
@@ -102,7 +106,10 @@ fn empty_prompt_when_input_has_no_prompt_key() {
         (text("session_cid"), text("sess-2")),
     ]));
     let result = invoke(ctx);
-    assert_eq!(ok_json(&result.output_cbor), r#"{"prompt": "", "response": ""}"#);
+    assert_eq!(
+        ok_json(&result.output_cbor),
+        r#"{"prompt": "", "response": ""}"#
+    );
 }
 
 #[test]
@@ -110,7 +117,10 @@ fn prompt_falls_back_to_args_when_input_absent() {
     // _entry.py: input_state = args.get("input", args) — without an "input"
     // map the args dict itself is the input state.
     let ctx = cbor(&Value::Map(vec![
-        (text("args"), Value::Map(vec![(text("prompt"), text("direct"))])),
+        (
+            text("args"),
+            Value::Map(vec![(text("prompt"), text("direct"))]),
+        ),
         (text("session_cid"), text("sess-3")),
     ]));
     let result = invoke(ctx);
@@ -127,7 +137,11 @@ fn checkpointer_persists_state_to_lgraph_ckpt() {
     // checkpointer.py storage layout: graph "lgraph/ckpt" / subject thread_id /
     // predicate "state" / object CBOR {"Text": json.dumps(state)}.
     let result = invoke(invoke_ctx("hi", "sess-4", Some("thread-42")));
-    assert_eq!(result.assert_quads.len(), 1, "one checkpoint write per invoke");
+    assert_eq!(
+        result.assert_quads.len(),
+        1,
+        "one checkpoint write per invoke"
+    );
     let q = &result.assert_quads[0];
     assert_eq!(q.graph, "lgraph/ckpt");
     assert_eq!(q.subject, "thread-42");
@@ -138,7 +152,11 @@ fn checkpointer_persists_state_to_lgraph_ckpt() {
     )]));
     assert_eq!(q.object_cbor, expected_obj);
     // kqe.assert-quad charges gas, same as the Python actor's checkpoint write
-    assert!(result.gas_used >= 10, "gas charged for the assert, got {}", result.gas_used);
+    assert!(
+        result.gas_used >= 10,
+        "gas charged for the assert, got {}",
+        result.gas_used
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add Clojure source compatibility preprocessing for .clj/.cljc/.cljs files, reader conditionals, quote/metadata/discard syntax, and namespace loading.
- Extend top-level and expression lowering for common Clojure forms, declarations, multi-arity defn, threading macros, case, nil/keyword/quote/var literals, and arity-aware calls.
- Wire compatibility normalization into CLI and component compilation, document the behavior, and add file/component/runtime regression coverage.

## Validation
- cargo test -p kotoba-clj

## Notes
- Left unrelated untracked crates/kotoba-datomic/examples/ out of this PR.