### PR TITLE
[codex] add clj literal and destructuring support

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -142,13 +142,17 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
 - control: `if`, `when`, `if-let`, `when-let`, `cond`, `case`, `let` (sequential),
   `do`, `loop`/`recur` (bounded), threading macros `->`, `->>`, `cond->`,
   `cond->>`, `some->`, `some->>`, and `as->`
+- binding forms: symbols and simple/nested vector destructuring in `defn`,
+  `let`, `if-let`, and `when-let`
 - arithmetic: `+ - * / quot mod rem inc dec abs` · comparison:
   `= not= < > <= >=` (n-ary where Clojure is n-ary) · predicates:
   `zero? pos? neg?` · logic: `and or not`
 - strings: `"…"` literals, `(str-len s)`, `(byte-at s i)`
 - Clojure literals: `nil` lowers to `0`; keyword literals and quoted forms
   (`'foo`, `'(a b)`, `(quote {:k 1})`) lower to canonical EDN string handles;
-  var quote (`#'foo`, `(var foo)`) lowers to the referenced symbol name handle
+  var quote (`#'foo`, `(var foo)`) lowers to the referenced symbol name handle;
+  vector literals (`[1 2]`) and map literals (`{:k v}`) lower to the prelude's
+  mutable vector/map handles when the prelude is enabled
 - Clojure reader metadata (`^:private`, `^String`, `^long`) is stripped before
   lowering.
 - Clojure discard forms (`#_ form`) are stripped before lowering.

--- a/crates/kotoba-clj/src/ast.rs
+++ b/crates/kotoba-clj/src/ast.rs
@@ -406,11 +406,8 @@ fn lower_defn(items: &[EdnValue]) -> Result<Vec<Function>, CljError> {
             })
             .collect();
     }
-    let params = match items.get(params_idx) {
-        Some(EdnValue::Vector(ps)) => ps
-            .iter()
-            .map(|p| sym_name(p, "defn parameter"))
-            .collect::<Result<Vec<_>, _>>()?,
+    let (params, destructured_params) = match items.get(params_idx) {
+        Some(EdnValue::Vector(ps)) => lower_param_list(ps, "defn parameter")?,
         _ => {
             return Err(CljError::Lower(format!(
                 "defn `{name}` parameter list must be a vector `[…]`"
@@ -432,6 +429,7 @@ fn lower_defn(items: &[EdnValue]) -> Result<Vec<Function>, CljError> {
         .iter()
         .map(lower_expr)
         .collect::<Result<Vec<_>, _>>()?;
+    let body = prepend_bindings(destructured_params, body);
     Ok(vec![Function {
         export_name: Some(name.clone()),
         name,
@@ -450,11 +448,8 @@ fn lower_defn_arity(
             "defn `{name}` arity-list requires: ([params…] body…)"
         )));
     }
-    let params = match &items[0] {
-        EdnValue::Vector(ps) => ps
-            .iter()
-            .map(|p| sym_name(p, "defn parameter"))
-            .collect::<Result<Vec<_>, _>>()?,
+    let (params, destructured_params) = match &items[0] {
+        EdnValue::Vector(ps) => lower_param_list(ps, "defn parameter")?,
         _ => {
             return Err(CljError::Lower(format!(
                 "defn `{name}` arity-list must begin with a parameter vector"
@@ -471,12 +466,50 @@ fn lower_defn_arity(
         .iter()
         .map(lower_expr)
         .collect::<Result<Vec<_>, _>>()?;
+    let body = prepend_bindings(destructured_params, body);
     Ok(Function {
         name: name.to_string(),
         export_name,
         params,
         body,
     })
+}
+
+type LoweredBindings = Vec<(String, Expr)>;
+type LoweredParams = (Vec<String>, LoweredBindings);
+
+fn lower_param_list(params: &[EdnValue], ctx: &str) -> Result<LoweredParams, CljError> {
+    let mut lowered = Vec::with_capacity(params.len());
+    let mut destructured = Vec::new();
+    for (idx, param) in params.iter().enumerate() {
+        match param {
+            EdnValue::Symbol(_) => lowered.push(sym_name(param, ctx)?),
+            EdnValue::Vector(_) => {
+                let temp = format!("\0kotoba_param_{idx}");
+                collect_vector_destructuring(
+                    param,
+                    Expr::Var(temp.clone()),
+                    &mut destructured,
+                    ctx,
+                )?;
+                lowered.push(temp);
+            }
+            other => {
+                return Err(CljError::Lower(format!(
+                    "{ctx} must be a symbol or vector destructuring form, found {other:?}"
+                )))
+            }
+        }
+    }
+    Ok((lowered, destructured))
+}
+
+fn prepend_bindings(bindings: LoweredBindings, body: Vec<Expr>) -> Vec<Expr> {
+    if bindings.is_empty() {
+        body
+    } else {
+        vec![Expr::Let { bindings, body }]
+    }
 }
 
 fn skip_prepost_map(items: &[EdnValue], body_idx: usize) -> usize {
@@ -507,10 +540,62 @@ fn lower_expr(v: &EdnValue) -> Result<Expr, CljError> {
         EdnValue::Keyword(_) => Ok(Expr::Str(edn_to_string(v).into_bytes())),
         EdnValue::Symbol(s) => Ok(Expr::Var(s.to_qualified())),
         EdnValue::List(items) => lower_call(items),
+        EdnValue::Vector(items) => lower_vector_literal(items),
+        EdnValue::Map(items) => lower_map_literal(items),
         other => Err(CljError::Lower(format!(
-            "unsupported expression: {other:?} (only integers, booleans, symbols and lists are supported)"
+            "unsupported expression: {other:?} (only integers, booleans, strings, keywords, symbols, lists, vectors and maps are supported)"
         ))),
     }
+}
+
+fn lower_vector_literal(items: &[EdnValue]) -> Result<Expr, CljError> {
+    let name = "\0kotoba_vec_literal".to_string();
+    let mut body = Vec::with_capacity(items.len() + 1);
+    for item in items {
+        body.push(Expr::Call {
+            name: "vec-conj!".to_string(),
+            args: vec![Expr::Var(name.clone()), lower_expr(item)?],
+        });
+    }
+    body.push(Expr::Var(name.clone()));
+    Ok(Expr::Let {
+        bindings: vec![(
+            name,
+            Expr::Call {
+                name: "vec-make".to_string(),
+                args: vec![Expr::Int(items.len() as i64)],
+            },
+        )],
+        body,
+    })
+}
+
+fn lower_map_literal(
+    items: &std::collections::BTreeMap<EdnValue, EdnValue>,
+) -> Result<Expr, CljError> {
+    let name = "\0kotoba_map_literal".to_string();
+    let mut body = Vec::with_capacity(items.len() + 1);
+    for (key, value) in items {
+        body.push(Expr::Call {
+            name: "map-assoc!".to_string(),
+            args: vec![
+                Expr::Var(name.clone()),
+                lower_expr(key)?,
+                lower_expr(value)?,
+            ],
+        });
+    }
+    body.push(Expr::Var(name.clone()));
+    Ok(Expr::Let {
+        bindings: vec![(
+            name,
+            Expr::Call {
+                name: "map-make".to_string(),
+                args: vec![Expr::Int(items.len() as i64)],
+            },
+        )],
+        body,
+    })
 }
 
 fn lower_call(items: &[EdnValue]) -> Result<Expr, CljError> {
@@ -755,16 +840,16 @@ fn lower_if_let(args: &[EdnValue]) -> Result<Expr, CljError> {
             "if-let takes: (if-let [name init] then else?)".into(),
         ));
     }
-    let (name, init) = lower_single_binding(args.first(), "if-let")?;
+    let (truthy_name, bindings) = lower_single_binding(args.first(), "if-let")?;
     let then = lower_expr(&args[1])?;
     let els = match args.get(2) {
         Some(els) => lower_expr(els)?,
         None => Expr::Int(0),
     };
     Ok(Expr::Let {
-        bindings: vec![(name.clone(), init)],
+        bindings,
         body: vec![Expr::If {
-            cond: Box::new(Expr::Var(name)),
+            cond: Box::new(Expr::Var(truthy_name)),
             then: Box::new(then),
             els: Box::new(els),
         }],
@@ -777,15 +862,15 @@ fn lower_when_let(args: &[EdnValue]) -> Result<Expr, CljError> {
             "when-let takes: (when-let [name init] body…)".into(),
         ));
     }
-    let (name, init) = lower_single_binding(args.first(), "when-let")?;
+    let (truthy_name, bindings) = lower_single_binding(args.first(), "when-let")?;
     let body = args[1..]
         .iter()
         .map(lower_expr)
         .collect::<Result<Vec<_>, _>>()?;
     Ok(Expr::Let {
-        bindings: vec![(name.clone(), init)],
+        bindings,
         body: vec![Expr::If {
-            cond: Box::new(Expr::Var(name)),
+            cond: Box::new(Expr::Var(truthy_name)),
             then: Box::new(Expr::Do(body)),
             els: Box::new(Expr::Int(0)),
         }],
@@ -795,7 +880,7 @@ fn lower_when_let(args: &[EdnValue]) -> Result<Expr, CljError> {
 fn lower_single_binding(
     binding_form: Option<&EdnValue>,
     form_name: &str,
-) -> Result<(String, Expr), CljError> {
+) -> Result<(String, LoweredBindings), CljError> {
     let binding_vec = match binding_form {
         Some(EdnValue::Vector(v)) => v,
         _ => {
@@ -809,10 +894,13 @@ fn lower_single_binding(
             "{form_name} binding vector must contain exactly one name/init pair"
         )));
     }
-    Ok((
-        sym_name(&binding_vec[0], &format!("{form_name} binding name"))?,
-        lower_expr(&binding_vec[1])?,
-    ))
+    let init = lower_expr(&binding_vec[1])?;
+    lower_binding_pattern(
+        &binding_vec[0],
+        init,
+        0,
+        &format!("{form_name} binding name"),
+    )
 }
 
 fn lower_let(args: &[EdnValue]) -> Result<Expr, CljError> {
@@ -832,8 +920,12 @@ fn lower_let(args: &[EdnValue]) -> Result<Expr, CljError> {
     }
     let mut bindings = Vec::with_capacity(binding_vec.len() / 2);
     let mut it = binding_vec.iter();
+    let mut idx = 0;
     while let (Some(name), Some(val)) = (it.next(), it.next()) {
-        bindings.push((sym_name(name, "let binding name")?, lower_expr(val)?));
+        let (_, mut lowered) =
+            lower_binding_pattern(name, lower_expr(val)?, idx, "let binding name")?;
+        bindings.append(&mut lowered);
+        idx += 1;
     }
     let body = args[1..]
         .iter()
@@ -845,6 +937,65 @@ fn lower_let(args: &[EdnValue]) -> Result<Expr, CljError> {
         ));
     }
     Ok(Expr::Let { bindings, body })
+}
+
+fn lower_binding_pattern(
+    pattern: &EdnValue,
+    init: Expr,
+    idx: usize,
+    ctx: &str,
+) -> Result<(String, LoweredBindings), CljError> {
+    match pattern {
+        EdnValue::Symbol(_) => {
+            let name = sym_name(pattern, ctx)?;
+            Ok((name.clone(), vec![(name, init)]))
+        }
+        EdnValue::Vector(_) => {
+            let temp = format!("\0kotoba_destructure_{idx}");
+            let mut bindings = vec![(temp.clone(), init)];
+            collect_vector_destructuring(pattern, Expr::Var(temp.clone()), &mut bindings, ctx)?;
+            Ok((temp, bindings))
+        }
+        other => Err(CljError::Lower(format!(
+            "{ctx} must be a symbol or vector destructuring form, found {other:?}"
+        ))),
+    }
+}
+
+fn collect_vector_destructuring(
+    pattern: &EdnValue,
+    source: Expr,
+    out: &mut LoweredBindings,
+    ctx: &str,
+) -> Result<(), CljError> {
+    let EdnValue::Vector(items) = pattern else {
+        return Err(CljError::Lower(format!(
+            "{ctx} must be a vector destructuring form"
+        )));
+    };
+    for (idx, item) in items.iter().enumerate() {
+        let value = Expr::Call {
+            name: "nth".to_string(),
+            args: vec![source.clone(), Expr::Int(idx as i64)],
+        };
+        match item {
+            EdnValue::Symbol(_) => {
+                let name = sym_name(item, ctx)?;
+                out.push((name, value));
+            }
+            EdnValue::Vector(_) => {
+                let temp = format!("\0kotoba_nested_destructure_{}", out.len());
+                out.push((temp.clone(), value));
+                collect_vector_destructuring(item, Expr::Var(temp), out, ctx)?;
+            }
+            other => {
+                return Err(CljError::Lower(format!(
+                    "{ctx} vector destructuring entries must be symbols or nested vectors, found {other:?}"
+                )))
+            }
+        }
+    }
+    Ok(())
 }
 
 fn lower_case(args: &[EdnValue]) -> Result<Expr, CljError> {

--- a/crates/kotoba-clj/src/compat.rs
+++ b/crates/kotoba-clj/src/compat.rs
@@ -913,13 +913,25 @@ fn param_shadow(params: Option<&EdnValue>) -> HashSet<String> {
     let Some(EdnValue::Vector(params)) = params else {
         return HashSet::new();
     };
-    params
-        .iter()
-        .filter_map(|p| match p {
-            EdnValue::Symbol(s) if s.namespace.is_none() => Some(s.name.clone()),
-            _ => None,
-        })
-        .collect()
+    let mut out = HashSet::new();
+    for param in params {
+        collect_pattern_shadow(param, &mut out);
+    }
+    out
+}
+
+fn collect_pattern_shadow(pattern: &EdnValue, out: &mut HashSet<String>) {
+    match pattern {
+        EdnValue::Symbol(s) if s.namespace.is_none() => {
+            out.insert(s.name.clone());
+        }
+        EdnValue::Vector(items) => {
+            for item in items {
+                collect_pattern_shadow(item, out);
+            }
+        }
+        _ => {}
+    }
 }
 
 fn qualify_expr(v: EdnValue, ctx: &NamespaceCtx, qualify_defs: bool) -> EdnValue {
@@ -975,11 +987,7 @@ fn qualify_list_expr(
                         qualify_defs,
                         &inner_shadow,
                     );
-                    if let Some(EdnValue::Symbol(s)) = bindings.get(i - 1) {
-                        if s.namespace.is_none() {
-                            inner_shadow.insert(s.name.clone());
-                        }
-                    }
+                    collect_pattern_shadow(&bindings[i - 1], &mut inner_shadow);
                 }
             }
             for item in out.iter_mut().skip(2) {
@@ -994,10 +1002,8 @@ fn qualify_list_expr(
                 if let Some(init) = bindings.get_mut(1) {
                     *init = qualify_expr_with_shadow(init.clone(), ctx, qualify_defs, shadowed);
                 }
-                if let Some(EdnValue::Symbol(s)) = bindings.first() {
-                    if s.namespace.is_none() {
-                        inner_shadow.insert(s.name.clone());
-                    }
+                if let Some(pattern) = bindings.first() {
+                    collect_pattern_shadow(pattern, &mut inner_shadow);
                 }
             }
             for item in out.iter_mut().skip(2) {

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -36,13 +36,17 @@
 //! - control: `if`, `when`, `if-let`, `when-let`, `cond`, `case`, `let`, `do`,
 //!   `loop`/`recur` (bounded iteration), threading macros `->`, `->>`,
 //!   `cond->`, `cond->>`, `some->`, `some->>`, and `as->`
+//! - binding forms: symbols and simple/nested vector destructuring in `defn`,
+//!   `let`, `if-let`, and `when-let`
 //! - arithmetic: `+ - * / mod`
 //! - comparison: `= < > <= >=`
 //! - logic: `and or not` (short-circuit; return 0/1)
 //! - strings: `"…"` literals, `(str-len s)`, `(byte-at s i)`
 //! - Clojure literals: `nil` lowers to `0`; keyword literals and quoted forms
 //!   lower to canonical EDN string handles; var quote (`#'foo`, `(var foo)`)
-//!   lowers to the referenced symbol name handle
+//!   lowers to the referenced symbol name handle; vector literals (`[1 2]`) and
+//!   map literals (`{:k v}`) lower to the [`PRELUDE`] container handles when the
+//!   prelude is enabled
 //! - `defn` pre/post condition maps (`{:pre […] :post […]}`) are accepted for
 //!   source compatibility but not asserted
 //! - Clojure reader metadata (`^:private`, `^String`, `^long`) is stripped before

--- a/crates/kotoba-clj/tests/heap_values.rs
+++ b/crates/kotoba-clj/tests/heap_values.rs
@@ -63,6 +63,46 @@ fn clojure_core_vector_aliases() {
 }
 
 #[test]
+fn vector_literals_lower_to_prelude_vectors() {
+    let v = eval("(let [v [11 22 33]] (+ (count v) (first v) (nth v 1) (last v)))");
+    assert_eq!(v, 69);
+}
+
+#[test]
+fn nested_vector_literals_are_independent_handles() {
+    let v = eval(
+        "(let [outer [[10 20] [30 40 50]]
+               left (nth outer 0)
+               right (nth outer 1)]
+           (+ (count outer) (count left) (count right) (nth right 2)))",
+    );
+    assert_eq!(v, 57);
+}
+
+#[test]
+fn vector_destructuring_in_let_and_params() {
+    let src = r#"
+        (defn sum-pair [[a b]] (+ a b))
+        (defn t [_]
+          (let [[x y] [10 20]
+                [[a b] [c d]] [[1 2] [3 4]]]
+            (+ (sum-pair [x y]) a b c d)))
+    "#;
+    let wasm = compile_str_with_prelude(src).expect("compile");
+    let v = run(&wasm, "t", &[0]).expect("run");
+    assert_eq!(v, 40);
+}
+
+#[test]
+fn vector_destructuring_in_if_and_when_let() {
+    let v = eval(
+        "(+ (if-let [[a b] [10 20]] (+ a b) 0)
+            (when-let [[x y] [5 7]] (+ x y)))",
+    );
+    assert_eq!(v, 42);
+}
+
+#[test]
 fn add_messages_extend_reducer() {
     // vec-extend! is the add_messages reducer: a=[1,2], extend by b=[3,4,5]
     // → a=[1,2,3,4,5]; assert count + a[4] = 5 + 5 = 10
@@ -123,6 +163,43 @@ fn clojure_core_map_aliases() {
               (empty? (map-make 1))))",
     );
     assert_eq!(v, 45);
+}
+
+#[test]
+fn map_literals_lower_to_prelude_maps() {
+    let v = eval(
+        "(let [m {\"k\" 41 \"other\" 1}]
+           (+ (count m)
+              (get m \"k\")
+              (contains-key? m \"other\")))",
+    );
+    assert_eq!(v, 44);
+}
+
+#[test]
+fn keyword_keys_in_map_literals_use_canonical_string_keys() {
+    let v = eval("(let [m {:k 40 :other 2}] (+ (get m :k) (get m :other)))");
+    assert_eq!(v, 42);
+}
+
+#[test]
+fn map_literals_can_hold_vector_literals() {
+    let v = eval(
+        "(let [m {:messages [10 20 30]} msgs (get m :messages)] (+ (count msgs) (last msgs)))",
+    );
+    assert_eq!(v, 33);
+}
+
+#[test]
+fn literal_lowering_does_not_shadow_source_locals() {
+    let v = eval(
+        "(let [__kotoba_vec_literal 40
+               __kotoba_map_literal 2
+               v [__kotoba_vec_literal __kotoba_map_literal]
+               m {:v v :x __kotoba_vec_literal}]
+           (+ (get m :x) (last (get m :v))))",
+    );
+    assert_eq!(v, 42);
 }
 
 // ---- the langgraph state substrate -----------------------------------------

--- a/crates/kotoba-clj/tests/kotoba_file.rs
+++ b/crates/kotoba-clj/tests/kotoba_file.rs
@@ -245,6 +245,37 @@ fn cljc_reader_conditionals_select_kotoba_then_clj_fallback() {
 }
 
 #[test]
+fn binary_accepts_vector_and_map_literals_in_file() {
+    let path = temp_path("literals.clj");
+    fs::write(
+        &path,
+        r#"
+(ns demo.literals)
+(defn main [x]
+  (let [v [10 20 30]
+        m {:offset x :values v}]
+    (+ (get m :offset) (count (get m :values)) (last v))))
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&path)
+        .arg("9")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_file(path);
+}
+
+#[test]
 fn reader_target_can_select_cljs_branch() {
     let path = temp_path("target.cljs");
     fs::write(
@@ -611,6 +642,43 @@ fn require_refer_all_exclude_preserves_local_name() {
     let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
         .arg(&main)
         .arg("38")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn destructuring_bindings_shadow_referred_names() {
+    let dir = temp_dir("destructuring-shadow");
+    fs::create_dir_all(dir.join("demo")).unwrap();
+    fs::write(
+        dir.join("demo/math.clj"),
+        "(ns demo.math)\n(defn x [n] (+ n 1000))\n(defn y [n] (+ n 1000))\n",
+    )
+    .unwrap();
+    let main = dir.join("main.clj");
+    fs::write(
+        &main,
+        r#"
+(ns demo.main (:require [demo.math :refer [x y]]))
+(defn main [n]
+  (let [[x y] [20 22]]
+    (+ n x y)))
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kotoba-clj"))
+        .arg(&main)
+        .arg("0")
         .output()
         .unwrap();
 


### PR DESCRIPTION
## Summary
- lower Clojure vector and map literals to the kotoba-clj heap prelude helpers
- support simple and nested vector destructuring in defn params, let, if-let, and when-let
- keep namespace qualification from rewriting names introduced by destructuring patterns
- document the supported literal and destructuring surface

## Validation
- cargo fmt -p kotoba-clj
- cargo clippy -p kotoba-clj --all-targets -- -D warnings
- cargo test -p kotoba-clj