### PR TITLE
[codex] extend clj destructuring and stabilize tx scopes

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -142,8 +142,9 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
 - control: `if`, `when`, `if-let`, `when-let`, `cond`, `case`, `let` (sequential),
   `do`, `loop`/`recur` (bounded), threading macros `->`, `->>`, `cond->`,
   `cond->>`, `some->`, `some->>`, and `as->`
-- binding forms: symbols and simple/nested vector destructuring in `defn`,
-  `let`, `if-let`, and `when-let`
+- binding forms: symbols and vector destructuring in `defn`, `let`, `if-let`,
+  and `when-let`, including nested vectors, `_` placeholders, `& rest`, and
+  `:as whole`
 - arithmetic: `+ - * / quot mod rem inc dec abs` · comparison:
   `= not= < > <= >=` (n-ary where Clojure is n-ary) · predicates:
   `zero? pos? neg?` · logic: `and or not`
@@ -160,7 +161,8 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
   `(bytes-finish buf)` — mutable buffer in linear memory; `bytes-finish` → string handle
 - raw memory: `(alloc n)`, `(load64 a)`, `(store64! a v)`, `(load32 a)`, `(store32! a v)`
 - prelude aliases for common Clojure-style container calls: `count`, `empty?`,
-  `nth`, `first`, `last`, `conj!`, `get`, `assoc!`, `contains-key?`
+  `nth`, `first`, `last`, `subvec`, `rest`, `conj!`, `get`, `assoc!`,
+  `contains-key?`
 - `clojure.core/`-qualified builtin calls are accepted for the supported core
   numeric/comparison/logical operations.
 - host calls: `(has-capability? resource ability)` → `auth.has-capability`;

--- a/crates/kotoba-clj/src/ast.rs
+++ b/crates/kotoba-clj/src/ast.rs
@@ -11,10 +11,11 @@
 //!   expressions integer literal, `true`/`false`, symbol
 //!               `(if c t e)`  `(when c body…)` `(if-let [b v] t e)`
 //!               `(when-let [b v] body…)` `(case e test result … default?)`
-//!               `(let [b v …] body…)`  `(do e…)`
+//!               `(let [b v …] body…)`  `(do e…)`, vector/map literals
 //!               `(-> x step…)` `(->> x step…)` `(cond-> x test step …)`
 //!               `(cond->> x test step …)` `(some-> x step…)`
 //!               `(some->> x step…)` `(as-> x name form …)`
+//!               vector destructuring in `defn`, `let`, `if-let`, `when-let`
 //!               builtins: + - * / mod  = < > <= >=  and or not
 //!               `(f args…)`  call a user `defn`
 
@@ -973,15 +974,68 @@ fn collect_vector_destructuring(
             "{ctx} must be a vector destructuring form"
         )));
     };
-    for (idx, item) in items.iter().enumerate() {
+
+    let mut item_idx = 0;
+    let mut value_idx = 0;
+    let mut rest_seen = false;
+    while item_idx < items.len() {
+        let item = &items[item_idx];
+        if is_destructure_as(item) {
+            let Some(name) = items.get(item_idx + 1) else {
+                return Err(CljError::Lower(format!(
+                    "{ctx} vector destructuring `:as` requires a following symbol"
+                )));
+            };
+            if item_idx + 2 != items.len() {
+                return Err(CljError::Lower(format!(
+                    "{ctx} vector destructuring `:as` must be the final option"
+                )));
+            }
+            let name = sym_name(name, ctx)?;
+            if name != "_" {
+                out.push((name, source.clone()));
+            }
+            item_idx += 2;
+            continue;
+        }
+
+        if is_destructure_rest(item) {
+            let Some(rest) = items.get(item_idx + 1) else {
+                return Err(CljError::Lower(format!(
+                    "{ctx} vector destructuring `&` requires a following symbol"
+                )));
+            };
+            let name = sym_name(rest, ctx)?;
+            if name != "_" {
+                out.push((
+                    name,
+                    Expr::Call {
+                        name: "subvec".to_string(),
+                        args: vec![source.clone(), Expr::Int(value_idx as i64)],
+                    },
+                ));
+            }
+            rest_seen = true;
+            item_idx += 2;
+            continue;
+        }
+
+        if rest_seen {
+            return Err(CljError::Lower(format!(
+                "{ctx} vector destructuring only allows `:as` after `& rest`"
+            )));
+        }
+
         let value = Expr::Call {
             name: "nth".to_string(),
-            args: vec![source.clone(), Expr::Int(idx as i64)],
+            args: vec![source.clone(), Expr::Int(value_idx as i64)],
         };
         match item {
             EdnValue::Symbol(_) => {
                 let name = sym_name(item, ctx)?;
-                out.push((name, value));
+                if name != "_" {
+                    out.push((name, value));
+                }
             }
             EdnValue::Vector(_) => {
                 let temp = format!("\0kotoba_nested_destructure_{}", out.len());
@@ -994,8 +1048,18 @@ fn collect_vector_destructuring(
                 )))
             }
         }
+        item_idx += 1;
+        value_idx += 1;
     }
     Ok(())
+}
+
+fn is_destructure_rest(v: &EdnValue) -> bool {
+    matches!(v, EdnValue::Symbol(s) if s.namespace.is_none() && s.name == "&")
+}
+
+fn is_destructure_as(v: &EdnValue) -> bool {
+    matches!(v, EdnValue::Keyword(k) if k.namespace().is_none() && k.name() == "as")
 }
 
 fn lower_case(args: &[EdnValue]) -> Result<Expr, CljError> {

--- a/crates/kotoba-clj/src/compat.rs
+++ b/crates/kotoba-clj/src/compat.rs
@@ -922,16 +922,33 @@ fn param_shadow(params: Option<&EdnValue>) -> HashSet<String> {
 
 fn collect_pattern_shadow(pattern: &EdnValue, out: &mut HashSet<String>) {
     match pattern {
-        EdnValue::Symbol(s) if s.namespace.is_none() => {
+        EdnValue::Symbol(s) if s.namespace.is_none() && s.name != "_" => {
             out.insert(s.name.clone());
         }
         EdnValue::Vector(items) => {
-            for item in items {
-                collect_pattern_shadow(item, out);
+            let mut i = 0;
+            while i < items.len() {
+                if is_destructure_rest(&items[i]) || is_destructure_as(&items[i]) {
+                    if let Some(name) = items.get(i + 1) {
+                        collect_pattern_shadow(name, out);
+                    }
+                    i += 2;
+                } else {
+                    collect_pattern_shadow(&items[i], out);
+                    i += 1;
+                }
             }
         }
         _ => {}
     }
+}
+
+fn is_destructure_rest(v: &EdnValue) -> bool {
+    matches!(v, EdnValue::Symbol(s) if s.namespace.is_none() && s.name == "&")
+}
+
+fn is_destructure_as(v: &EdnValue) -> bool {
+    matches!(v, EdnValue::Keyword(k) if k.namespace().is_none() && k.name() == "as")
 }
 
 fn qualify_expr(v: EdnValue, ctx: &NamespaceCtx, qualify_defs: bool) -> EdnValue {

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -36,8 +36,9 @@
 //! - control: `if`, `when`, `if-let`, `when-let`, `cond`, `case`, `let`, `do`,
 //!   `loop`/`recur` (bounded iteration), threading macros `->`, `->>`,
 //!   `cond->`, `cond->>`, `some->`, `some->>`, and `as->`
-//! - binding forms: symbols and simple/nested vector destructuring in `defn`,
-//!   `let`, `if-let`, and `when-let`
+//! - binding forms: symbols and vector destructuring in `defn`, `let`,
+//!   `if-let`, and `when-let`, including nested vectors, `_` placeholders,
+//!   `& rest`, and `:as whole`
 //! - arithmetic: `+ - * / mod`
 //! - comparison: `= < > <= >=`
 //! - logic: `and or not` (short-circuit; return 0/1)
@@ -222,7 +223,7 @@ pub fn compile_file_with_prelude_reader_target_and_source_paths(
 /// `vec-nth` `vec-conj!` `vec-extend!` (the `add_messages` reducer), `map-make`
 /// `map-count` `map-get` `map-assoc!`, and `str-eq?`. It also exposes a small
 /// Clojure-core compatibility layer: `count`, `empty?`, `nth`, `first`, `last`,
-/// `conj!`, `get`, `assoc!`, and `contains-key?`.
+/// `subvec`, `rest`, `conj!`, `get`, `assoc!`, and `contains-key?`.
 pub const PRELUDE: &str = r#"
 ;; ---- vector: [len, cap, e0, e1, …] ----------------------------------------
 (defn vec-make [cap]
@@ -244,6 +245,14 @@ pub const PRELUDE: &str = r#"
       dst
       (do (vec-conj! dst (vec-nth src i))
           (recur (+ i 1))))))
+(defn subvec [v start]
+  (let [n (vec-count v)
+        out (vec-make (- n start))]
+    (loop [i start]
+      (if (>= i n)
+        out
+        (do (vec-conj! out (vec-nth v i))
+            (recur (+ i 1)))))))
 
 ;; ---- string equality by content -------------------------------------------
 (defn str-eq? [a b]
@@ -299,6 +308,7 @@ pub const PRELUDE: &str = r#"
 (defn nth [v i] (vec-nth v i))
 (defn first [v] (vec-nth v 0))
 (defn last [v] (vec-nth v (- (vec-count v) 1)))
+(defn rest [v] (subvec v 1))
 (defn conj! [v x] (vec-conj! v x))
 (defn get [m k] (map-get m k))
 (defn assoc! [m k v] (map-assoc! m k v))

--- a/crates/kotoba-clj/tests/heap_values.rs
+++ b/crates/kotoba-clj/tests/heap_values.rs
@@ -103,6 +103,41 @@ fn vector_destructuring_in_if_and_when_let() {
 }
 
 #[test]
+fn vector_destructuring_supports_rest_as_and_placeholders() {
+    let src = r#"
+        (defn consume [[a _ & more :as whole]]
+          (+ a (count more) (first more) (last more) (count whole)))
+        (defn t [_]
+          (let [[x _ & xs :as all] [5 99 6 7]]
+            (+ (consume [10 999 20 30]) x (count xs) (last xs) (count all))))
+    "#;
+    let wasm = compile_str_with_prelude(src).expect("compile");
+    let v = run(&wasm, "t", &[0]).expect("run");
+    assert_eq!(v, 84);
+}
+
+#[test]
+fn vector_destructuring_rest_works_in_if_and_when_let() {
+    let v = eval(
+        "(+ (if-let [[a & xs] [10 20 30]] (+ a (count xs) (last xs)) 0)
+            (when-let [[_ & ys :as all] [1 2 3 4]] (+ (count ys) (count all) (first ys))))",
+    );
+    assert_eq!(v, 51);
+}
+
+#[test]
+fn subvec_and_rest_return_independent_vector_handles() {
+    let v = eval(
+        "(let [v [10 20 30 40]
+               tail (rest v)
+               suffix (subvec v 2)]
+           (conj! tail 50)
+           (+ (count v) (count tail) (count suffix) (last tail) (first suffix)))",
+    );
+    assert_eq!(v, 90);
+}
+
+#[test]
 fn add_messages_extend_reducer() {
     // vec-extend! is the add_messages reducer: a=[1,2], extend by b=[3,4,5]
     // → a=[1,2,3,4,5]; assert count + a[4] = 5 + 5 = 10

--- a/crates/kotoba-clj/tests/kotoba_file.rs
+++ b/crates/kotoba-clj/tests/kotoba_file.rs
@@ -661,17 +661,17 @@ fn destructuring_bindings_shadow_referred_names() {
     fs::create_dir_all(dir.join("demo")).unwrap();
     fs::write(
         dir.join("demo/math.clj"),
-        "(ns demo.math)\n(defn x [n] (+ n 1000))\n(defn y [n] (+ n 1000))\n",
+        "(ns demo.math)\n(defn x [n] (+ n 1000))\n(defn rest [n] (+ n 1000))\n(defn whole [n] (+ n 1000))\n",
     )
     .unwrap();
     let main = dir.join("main.clj");
     fs::write(
         &main,
         r#"
-(ns demo.main (:require [demo.math :refer [x y]]))
+(ns demo.main (:require [demo.math :refer [x rest whole]]))
 (defn main [n]
-  (let [[x y] [20 22]]
-    (+ n x y)))
+  (let [[x & rest :as whole] [27 4 10]]
+    (+ n x (count rest) (last rest) (count whole))))
 "#,
     )
     .unwrap();

--- a/crates/kotoba-datomic/src/distributed.rs
+++ b/crates/kotoba-datomic/src/distributed.rs
@@ -6300,8 +6300,8 @@ mod tests {
     /// ADR-2605302130 safety contract: the value the server caches as the resident
     /// `db_before` — `current_datoms(db_after)` keyed by the new head — MUST equal
     /// the cold path `db_from_head(head)`: same net-live datom set AND same
-    /// `basis_t`. Both are derived from the SAME commit so this is timestamp-
-    /// independent (the wall-clock `:db/txInstant` is baked identically into both).
+    /// `basis_t`. Both are derived from the SAME commit; wall-clock
+    /// `:db/txInstant` is metadata and is intentionally excluded from tx identity.
     /// `tx_cid` depends only on the new tx datoms + `db_before.basis_t`, and
     /// tempid/upsert/schema resolution reads `db_before.datoms`, so an equal
     /// `db_before` yields a byte-identical commit — no DAG fork. tx2 retracts a

--- a/crates/kotoba-datomic/src/lib.rs
+++ b/crates/kotoba-datomic/src/lib.rs
@@ -260,12 +260,7 @@ impl Connection {
         datoms.push(tx_instant_datom(tx_placeholder.clone(), tx_instant.clone()));
         let schema = Schema::from_datoms(&db_before.datoms);
         datoms = enforce_schema(datoms, tx_placeholder.clone(), &db_before, &schema)?;
-        let tx_cid = tx_cid_for_datoms(
-            &datoms,
-            &tx_placeholder,
-            &tx_instant,
-            db_before.basis_t.as_ref(),
-        );
+        let tx_cid = tx_cid_for_datoms(&datoms, &tx_placeholder, db_before.basis_t.as_ref());
         rewrite_tx_placeholder(&mut datoms, &tx_placeholder, &tx_cid);
         rewrite_tempid_placeholder(&mut tempids, &tx_placeholder, &tx_cid);
 
@@ -1275,12 +1270,12 @@ fn tx_placeholder_cid() -> KotobaCid {
 fn tx_cid_for_datoms(
     datoms: &[Datom],
     tx_placeholder: &KotobaCid,
-    tx_instant: &str,
     prev: Option<&KotobaCid>,
 ) -> KotobaCid {
     let mut seed = b"kotoba-tx:v2\n".to_vec();
     let mut datom_cids = datoms
         .iter()
+        .filter(|datom| datom.a != DB_TX_INSTANT)
         .map(|datom| datom_content_cid(datom, tx_placeholder).to_multibase())
         .collect::<Vec<_>>();
     datom_cids.sort();
@@ -1288,8 +1283,6 @@ fn tx_cid_for_datoms(
         seed.extend_from_slice(cid.as_bytes());
         seed.push(b'\n');
     }
-    seed.extend_from_slice(tx_instant.as_bytes());
-    seed.push(b'\n');
     if let Some(prev) = prev {
         seed.extend_from_slice(&prev.0);
     }
@@ -7347,7 +7340,7 @@ mod tests {
     }
 
     #[test]
-    fn tx_cid_is_derived_from_sorted_datom_content_and_prev_tx() {
+    fn tx_cid_is_derived_from_sorted_datom_content_and_prev_tx_not_wall_clock() {
         let placeholder = tx_placeholder_cid();
         let alice = cid(b"alice");
         let d1 = Datom::assert(
@@ -7362,16 +7355,16 @@ mod tests {
             EdnValue::String("Alice".into()),
             placeholder.clone(),
         );
-        let instant = "2026-05-29T00:00:00Z";
+        let instant1 = tx_instant_datom(placeholder.clone(), "2026-05-29T00:00:00Z".into());
+        let instant2 = tx_instant_datom(placeholder.clone(), "2026-05-30T00:00:00Z".into());
         let prev = cid(b"prev-tx");
 
         let forward = tx_cid_for_datoms(
-            &[d1.clone(), d2.clone()],
+            &[d1.clone(), d2.clone(), instant1],
             &placeholder,
-            instant,
             Some(&prev),
         );
-        let reversed = tx_cid_for_datoms(&[d2, d1], &placeholder, instant, Some(&prev));
+        let reversed = tx_cid_for_datoms(&[instant2, d2, d1], &placeholder, Some(&prev));
         let different_prev = tx_cid_for_datoms(
             &[Datom::assert(
                 placeholder.clone(),
@@ -7380,7 +7373,6 @@ mod tests {
                 placeholder.clone(),
             )],
             &placeholder,
-            instant,
             Some(&cid(b"other-prev")),
         );
 

--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -1197,28 +1197,94 @@ pub fn build_router(state: Arc<KotobaState>) -> Router {
         // ── ai.gftd.apps.kotobase.* aliases (canonical public NSIDs) ─────────
         // Same handlers; the CF Worker at kotobase.net also uses these NSIDs.
         // Registering them here means local dev and production share one namespace.
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.transact",  post(xrpc::datomic_transact))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.q",         post(xrpc::datomic_q).layer(DefaultBodyLimit::max(1024 * 1024)))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.pull",      post(xrpc::datomic_pull))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.pullMany",  post(xrpc::datomic_pull_many))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.datoms",    post(xrpc::datomic_datoms))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.seekDatoms",post(xrpc::datomic_seek_datoms))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.indexRange",post(xrpc::datomic_index_range))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.indexPull", post(xrpc::datomic_index_pull))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.entity",    post(xrpc::datomic_entity))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.ident",     post(xrpc::datomic_ident))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.entid",     post(xrpc::datomic_entid))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.asOf",      post(xrpc::datomic_as_of))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.since",     post(xrpc::datomic_since))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.sync",      post(xrpc::datomic_sync))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.history",   post(xrpc::datomic_history))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.tx",        post(xrpc::datomic_tx))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.txRange",   post(xrpc::datomic_tx_range))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.log",       post(xrpc::datomic_log))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.basisT",    post(xrpc::datomic_basis_t))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.dbStats",   post(xrpc::datomic_db_stats))
-        .route("/xrpc/ai.gftd.apps.kotobase.datomic.with",      post(xrpc::datomic_with))
-        .route("/xrpc/ai.gftd.apps.kotobase.graph.query",       post(xrpc::graph_query))
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.transact",
+            post(xrpc::datomic_transact),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.q",
+            post(xrpc::datomic_q).layer(DefaultBodyLimit::max(1024 * 1024)),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.pull",
+            post(xrpc::datomic_pull),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.pullMany",
+            post(xrpc::datomic_pull_many),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.datoms",
+            post(xrpc::datomic_datoms),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.seekDatoms",
+            post(xrpc::datomic_seek_datoms),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.indexRange",
+            post(xrpc::datomic_index_range),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.indexPull",
+            post(xrpc::datomic_index_pull),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.entity",
+            post(xrpc::datomic_entity),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.ident",
+            post(xrpc::datomic_ident),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.entid",
+            post(xrpc::datomic_entid),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.asOf",
+            post(xrpc::datomic_as_of),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.since",
+            post(xrpc::datomic_since),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.sync",
+            post(xrpc::datomic_sync),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.history",
+            post(xrpc::datomic_history),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.tx",
+            post(xrpc::datomic_tx),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.txRange",
+            post(xrpc::datomic_tx_range),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.log",
+            post(xrpc::datomic_log),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.basisT",
+            post(xrpc::datomic_basis_t),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.dbStats",
+            post(xrpc::datomic_db_stats),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.datomic.with",
+            post(xrpc::datomic_with),
+        )
+        .route(
+            "/xrpc/ai.gftd.apps.kotobase.graph.query",
+            post(xrpc::graph_query),
+        )
         .route(
             &format!("/xrpc/{}", xrpc::NSID_VC_ISSUE),
             post(xrpc::vc_issue),

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -11,29 +11,29 @@
 
 /// Public kotobase NSID aliases — same handlers as com.etzhayyim.apps.kotoba.*
 pub mod kotobase {
-    pub const DATOMIC_TRANSACT:   &str = "ai.gftd.apps.kotobase.datomic.transact";
-    pub const DATOMIC_Q:          &str = "ai.gftd.apps.kotobase.datomic.q";
-    pub const DATOMIC_PULL:       &str = "ai.gftd.apps.kotobase.datomic.pull";
-    pub const DATOMIC_PULL_MANY:  &str = "ai.gftd.apps.kotobase.datomic.pullMany";
-    pub const DATOMIC_DATOMS:     &str = "ai.gftd.apps.kotobase.datomic.datoms";
-    pub const DATOMIC_SEEK_DATOMS:&str = "ai.gftd.apps.kotobase.datomic.seekDatoms";
-    pub const DATOMIC_INDEX_RANGE:&str = "ai.gftd.apps.kotobase.datomic.indexRange";
+    pub const DATOMIC_TRANSACT: &str = "ai.gftd.apps.kotobase.datomic.transact";
+    pub const DATOMIC_Q: &str = "ai.gftd.apps.kotobase.datomic.q";
+    pub const DATOMIC_PULL: &str = "ai.gftd.apps.kotobase.datomic.pull";
+    pub const DATOMIC_PULL_MANY: &str = "ai.gftd.apps.kotobase.datomic.pullMany";
+    pub const DATOMIC_DATOMS: &str = "ai.gftd.apps.kotobase.datomic.datoms";
+    pub const DATOMIC_SEEK_DATOMS: &str = "ai.gftd.apps.kotobase.datomic.seekDatoms";
+    pub const DATOMIC_INDEX_RANGE: &str = "ai.gftd.apps.kotobase.datomic.indexRange";
     pub const DATOMIC_INDEX_PULL: &str = "ai.gftd.apps.kotobase.datomic.indexPull";
-    pub const DATOMIC_ENTITY:     &str = "ai.gftd.apps.kotobase.datomic.entity";
-    pub const DATOMIC_IDENT:      &str = "ai.gftd.apps.kotobase.datomic.ident";
-    pub const DATOMIC_ENTID:      &str = "ai.gftd.apps.kotobase.datomic.entid";
-    pub const DATOMIC_AS_OF:      &str = "ai.gftd.apps.kotobase.datomic.asOf";
-    pub const DATOMIC_SINCE:      &str = "ai.gftd.apps.kotobase.datomic.since";
-    pub const DATOMIC_SYNC:       &str = "ai.gftd.apps.kotobase.datomic.sync";
-    pub const DATOMIC_HISTORY:    &str = "ai.gftd.apps.kotobase.datomic.history";
-    pub const DATOMIC_TX:         &str = "ai.gftd.apps.kotobase.datomic.tx";
-    pub const DATOMIC_TX_RANGE:   &str = "ai.gftd.apps.kotobase.datomic.txRange";
-    pub const DATOMIC_LOG:        &str = "ai.gftd.apps.kotobase.datomic.log";
-    pub const DATOMIC_BASIS_T:    &str = "ai.gftd.apps.kotobase.datomic.basisT";
-    pub const DATOMIC_DB_STATS:   &str = "ai.gftd.apps.kotobase.datomic.dbStats";
-    pub const DATOMIC_WITH:       &str = "ai.gftd.apps.kotobase.datomic.with";
-    pub const GRAPH_QUERY:        &str = "ai.gftd.apps.kotobase.graph.query";
-    pub const GRAPH_SPARQL:       &str = "ai.gftd.apps.kotobase.graph.sparql";
+    pub const DATOMIC_ENTITY: &str = "ai.gftd.apps.kotobase.datomic.entity";
+    pub const DATOMIC_IDENT: &str = "ai.gftd.apps.kotobase.datomic.ident";
+    pub const DATOMIC_ENTID: &str = "ai.gftd.apps.kotobase.datomic.entid";
+    pub const DATOMIC_AS_OF: &str = "ai.gftd.apps.kotobase.datomic.asOf";
+    pub const DATOMIC_SINCE: &str = "ai.gftd.apps.kotobase.datomic.since";
+    pub const DATOMIC_SYNC: &str = "ai.gftd.apps.kotobase.datomic.sync";
+    pub const DATOMIC_HISTORY: &str = "ai.gftd.apps.kotobase.datomic.history";
+    pub const DATOMIC_TX: &str = "ai.gftd.apps.kotobase.datomic.tx";
+    pub const DATOMIC_TX_RANGE: &str = "ai.gftd.apps.kotobase.datomic.txRange";
+    pub const DATOMIC_LOG: &str = "ai.gftd.apps.kotobase.datomic.log";
+    pub const DATOMIC_BASIS_T: &str = "ai.gftd.apps.kotobase.datomic.basisT";
+    pub const DATOMIC_DB_STATS: &str = "ai.gftd.apps.kotobase.datomic.dbStats";
+    pub const DATOMIC_WITH: &str = "ai.gftd.apps.kotobase.datomic.with";
+    pub const GRAPH_QUERY: &str = "ai.gftd.apps.kotobase.graph.query";
+    pub const GRAPH_SPARQL: &str = "ai.gftd.apps.kotobase.graph.sparql";
 }
 
 pub const NSID_DATOM_CREATE: &str = "com.etzhayyim.apps.kotoba.datom.create";


### PR DESCRIPTION
## Summary
- support `_` placeholders, `& rest`, and `:as whole` in kotoba-clj vector destructuring
- add prelude `subvec` and `rest` helpers used by destructuring and Clojure-style container code
- teach namespace qualification that rest/as destructuring names shadow referred symbols
- make Datomic tx scope CIDs independent of wall-clock `:db/txInstant`, so CACAO/VP tx-scope validation can be precomputed deterministically
- document the expanded binding and prelude surface

## Validation
- cargo fmt
- cargo test -p kotoba-datomic
- cargo test -p kotoba-server --test e2e_test datomic_transact_accepts_matching -- --nocapture
- cargo test -p kotoba-clj
- cargo clippy -p kotoba-clj --all-targets -- -D warnings
- cargo clippy -p kotoba-datomic --all-targets -- -D warnings