### PR TITLE
[codex] support clj map destructuring

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -142,9 +142,10 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
 - control: `if`, `when`, `if-let`, `when-let`, `cond`, `case`, `let` (sequential),
   `do`, `loop`/`recur` (bounded), threading macros `->`, `->>`, `cond->`,
   `cond->>`, `some->`, `some->>`, and `as->`
-- binding forms: symbols and vector destructuring in `defn`, `let`, `if-let`,
-  and `when-let`, including nested vectors, `_` placeholders, `& rest`, and
-  `:as whole`
+- binding forms: symbols plus vector and map destructuring in `defn`, `let`,
+  `if-let`, and `when-let`; vectors support nested destructuring, `_`
+  placeholders, `& rest`, and `:as whole`; maps support `{local :key}`,
+  `{:keys [...]}`, `{:strs [...]}`, `:or` defaults, and `:as whole`
 - arithmetic: `+ - * / quot mod rem inc dec abs` · comparison:
   `= not= < > <= >=` (n-ary where Clojure is n-ary) · predicates:
   `zero? pos? neg?` · logic: `and or not`

--- a/crates/kotoba-clj/src/ast.rs
+++ b/crates/kotoba-clj/src/ast.rs
@@ -15,7 +15,8 @@
 //!               `(-> x step…)` `(->> x step…)` `(cond-> x test step …)`
 //!               `(cond->> x test step …)` `(some-> x step…)`
 //!               `(some->> x step…)` `(as-> x name form …)`
-//!               vector destructuring in `defn`, `let`, `if-let`, `when-let`
+//!               vector and map destructuring in `defn`, `let`, `if-let`,
+//!               `when-let`
 //!               builtins: + - * / mod  = < > <= >=  and or not
 //!               `(f args…)`  call a user `defn`
 
@@ -485,19 +486,14 @@ fn lower_param_list(params: &[EdnValue], ctx: &str) -> Result<LoweredParams, Clj
     for (idx, param) in params.iter().enumerate() {
         match param {
             EdnValue::Symbol(_) => lowered.push(sym_name(param, ctx)?),
-            EdnValue::Vector(_) => {
+            EdnValue::Vector(_) | EdnValue::Map(_) => {
                 let temp = format!("\0kotoba_param_{idx}");
-                collect_vector_destructuring(
-                    param,
-                    Expr::Var(temp.clone()),
-                    &mut destructured,
-                    ctx,
-                )?;
+                collect_destructuring(param, Expr::Var(temp.clone()), &mut destructured, ctx)?;
                 lowered.push(temp);
             }
             other => {
                 return Err(CljError::Lower(format!(
-                    "{ctx} must be a symbol or vector destructuring form, found {other:?}"
+                    "{ctx} must be a symbol or destructuring form, found {other:?}"
                 )))
             }
         }
@@ -951,14 +947,29 @@ fn lower_binding_pattern(
             let name = sym_name(pattern, ctx)?;
             Ok((name.clone(), vec![(name, init)]))
         }
-        EdnValue::Vector(_) => {
+        EdnValue::Vector(_) | EdnValue::Map(_) => {
             let temp = format!("\0kotoba_destructure_{idx}");
             let mut bindings = vec![(temp.clone(), init)];
-            collect_vector_destructuring(pattern, Expr::Var(temp.clone()), &mut bindings, ctx)?;
+            collect_destructuring(pattern, Expr::Var(temp.clone()), &mut bindings, ctx)?;
             Ok((temp, bindings))
         }
         other => Err(CljError::Lower(format!(
-            "{ctx} must be a symbol or vector destructuring form, found {other:?}"
+            "{ctx} must be a symbol or destructuring form, found {other:?}"
+        ))),
+    }
+}
+
+fn collect_destructuring(
+    pattern: &EdnValue,
+    source: Expr,
+    out: &mut LoweredBindings,
+    ctx: &str,
+) -> Result<(), CljError> {
+    match pattern {
+        EdnValue::Vector(_) => collect_vector_destructuring(pattern, source, out, ctx),
+        EdnValue::Map(_) => collect_map_destructuring(pattern, source, out, ctx),
+        other => Err(CljError::Lower(format!(
+            "{ctx} must be a destructuring form, found {other:?}"
         ))),
     }
 }
@@ -1040,11 +1051,16 @@ fn collect_vector_destructuring(
             EdnValue::Vector(_) => {
                 let temp = format!("\0kotoba_nested_destructure_{}", out.len());
                 out.push((temp.clone(), value));
-                collect_vector_destructuring(item, Expr::Var(temp), out, ctx)?;
+                collect_destructuring(item, Expr::Var(temp), out, ctx)?;
+            }
+            EdnValue::Map(_) => {
+                let temp = format!("\0kotoba_nested_destructure_{}", out.len());
+                out.push((temp.clone(), value));
+                collect_destructuring(item, Expr::Var(temp), out, ctx)?;
             }
             other => {
                 return Err(CljError::Lower(format!(
-                    "{ctx} vector destructuring entries must be symbols or nested vectors, found {other:?}"
+                    "{ctx} vector destructuring entries must be symbols or nested destructuring forms, found {other:?}"
                 )))
             }
         }
@@ -1052,6 +1068,165 @@ fn collect_vector_destructuring(
         value_idx += 1;
     }
     Ok(())
+}
+
+fn collect_map_destructuring(
+    pattern: &EdnValue,
+    source: Expr,
+    out: &mut LoweredBindings,
+    ctx: &str,
+) -> Result<(), CljError> {
+    let EdnValue::Map(items) = pattern else {
+        return Err(CljError::Lower(format!(
+            "{ctx} must be a map destructuring form"
+        )));
+    };
+
+    let defaults = map_destructure_defaults(items, ctx)?;
+
+    for (binding, key) in items {
+        if map_destructure_option(binding, "or") || map_destructure_option(binding, "keys") {
+            continue;
+        }
+        if map_destructure_option(binding, "strs") {
+            let EdnValue::Vector(names) = key else {
+                return Err(CljError::Lower(format!(
+                    "{ctx} map destructuring `:strs` requires a vector of symbols"
+                )));
+            };
+            for name in names {
+                let name = sym_name(name, ctx)?;
+                if name != "_" {
+                    let key = Expr::Str(name.as_bytes().to_vec());
+                    out.push((
+                        name.clone(),
+                        map_destructure_get(source.clone(), key, Some((&name, &defaults)))?,
+                    ));
+                }
+            }
+            continue;
+        }
+        if map_destructure_option(binding, "as") {
+            let name = sym_name(key, ctx)?;
+            if name != "_" {
+                out.push((name, source.clone()));
+            }
+            continue;
+        }
+
+        if map_destructure_option(binding, "keys") {
+            unreachable!("handled above")
+        }
+
+        lower_map_destructure_entry(binding, key, source.clone(), &defaults, out, ctx)?;
+    }
+
+    if let Some(keys) = items
+        .iter()
+        .find_map(|(k, v)| map_destructure_option(k, "keys").then_some(v))
+    {
+        let EdnValue::Vector(names) = keys else {
+            return Err(CljError::Lower(format!(
+                "{ctx} map destructuring `:keys` requires a vector of symbols"
+            )));
+        };
+        for name in names {
+            let name = sym_name(name, ctx)?;
+            if name != "_" {
+                let key = Expr::Str(format!(":{name}").into_bytes());
+                out.push((
+                    name.clone(),
+                    map_destructure_get(source.clone(), key, Some((&name, &defaults)))?,
+                ));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn lower_map_destructure_entry(
+    binding: &EdnValue,
+    key: &EdnValue,
+    source: Expr,
+    defaults: &std::collections::BTreeMap<String, Expr>,
+    out: &mut LoweredBindings,
+    ctx: &str,
+) -> Result<(), CljError> {
+    let lookup = lower_expr(key)?;
+    match binding {
+        EdnValue::Symbol(_) => {
+            let name = sym_name(binding, ctx)?;
+            if name != "_" {
+                out.push((
+                    name.clone(),
+                    map_destructure_get(source, lookup, Some((&name, defaults)))?,
+                ));
+            }
+        }
+        EdnValue::Vector(_) | EdnValue::Map(_) => {
+            let temp = format!("\0kotoba_nested_destructure_{}", out.len());
+            out.push((temp.clone(), map_destructure_get(source, lookup, None)?));
+            collect_destructuring(binding, Expr::Var(temp), out, ctx)?;
+        }
+        other => {
+            return Err(CljError::Lower(format!(
+                "{ctx} map destructuring entries must bind symbols or nested destructuring forms, found {other:?}"
+            )))
+        }
+    }
+    Ok(())
+}
+
+fn map_destructure_get(
+    source: Expr,
+    key: Expr,
+    default: Option<(&str, &std::collections::BTreeMap<String, Expr>)>,
+) -> Result<Expr, CljError> {
+    let get = Expr::Call {
+        name: "get".to_string(),
+        args: vec![source.clone(), key.clone()],
+    };
+    let Some((name, defaults)) = default else {
+        return Ok(get);
+    };
+    let Some(default_expr) = defaults.get(name) else {
+        return Ok(get);
+    };
+    Ok(Expr::If {
+        cond: Box::new(Expr::Call {
+            name: "contains-key?".to_string(),
+            args: vec![source, key],
+        }),
+        then: Box::new(get),
+        els: Box::new(default_expr.clone()),
+    })
+}
+
+fn map_destructure_defaults(
+    items: &std::collections::BTreeMap<EdnValue, EdnValue>,
+    ctx: &str,
+) -> Result<std::collections::BTreeMap<String, Expr>, CljError> {
+    let mut defaults = std::collections::BTreeMap::new();
+    let Some(default_map) = items
+        .iter()
+        .find_map(|(k, v)| map_destructure_option(k, "or").then_some(v))
+    else {
+        return Ok(defaults);
+    };
+    let EdnValue::Map(entries) = default_map else {
+        return Err(CljError::Lower(format!(
+            "{ctx} map destructuring `:or` requires a map of symbol defaults"
+        )));
+    };
+    for (name, value) in entries {
+        defaults.insert(sym_name(name, ctx)?, lower_expr(value)?);
+    }
+    Ok(defaults)
+}
+
+fn map_destructure_option(v: &EdnValue, name: &str) -> bool {
+    matches!(v, EdnValue::Keyword(k) if k.namespace().is_none() && k.name() == name)
 }
 
 fn is_destructure_rest(v: &EdnValue) -> bool {

--- a/crates/kotoba-clj/src/compat.rs
+++ b/crates/kotoba-clj/src/compat.rs
@@ -939,6 +939,24 @@ fn collect_pattern_shadow(pattern: &EdnValue, out: &mut HashSet<String>) {
                 }
             }
         }
+        EdnValue::Map(items) => {
+            for (binding, value) in items {
+                if is_destructure_keys(binding)
+                    || is_destructure_strs(binding)
+                    || is_destructure_as(binding)
+                {
+                    collect_pattern_shadow(value, out);
+                } else if is_destructure_or(binding) {
+                    if let EdnValue::Map(defaults) = value {
+                        for name in defaults.keys() {
+                            collect_pattern_shadow(name, out);
+                        }
+                    }
+                } else {
+                    collect_pattern_shadow(binding, out);
+                }
+            }
+        }
         _ => {}
     }
 }
@@ -949,6 +967,18 @@ fn is_destructure_rest(v: &EdnValue) -> bool {
 
 fn is_destructure_as(v: &EdnValue) -> bool {
     matches!(v, EdnValue::Keyword(k) if k.namespace().is_none() && k.name() == "as")
+}
+
+fn is_destructure_keys(v: &EdnValue) -> bool {
+    matches!(v, EdnValue::Keyword(k) if k.namespace().is_none() && k.name() == "keys")
+}
+
+fn is_destructure_strs(v: &EdnValue) -> bool {
+    matches!(v, EdnValue::Keyword(k) if k.namespace().is_none() && k.name() == "strs")
+}
+
+fn is_destructure_or(v: &EdnValue) -> bool {
+    matches!(v, EdnValue::Keyword(k) if k.namespace().is_none() && k.name() == "or")
 }
 
 fn qualify_expr(v: EdnValue, ctx: &NamespaceCtx, qualify_defs: bool) -> EdnValue {

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -223,7 +223,10 @@ pub fn compile_file_with_prelude_reader_target_and_source_paths(
 /// `vec-nth` `vec-conj!` `vec-extend!` (the `add_messages` reducer), `map-make`
 /// `map-count` `map-get` `map-assoc!`, and `str-eq?`. It also exposes a small
 /// Clojure-core compatibility layer: `count`, `empty?`, `nth`, `first`, `last`,
-/// `subvec`, `rest`, `conj!`, `get`, `assoc!`, and `contains-key?`.
+/// `subvec`, `rest`, `conj!`, `get`, `assoc!`, and `contains-key?`. The
+/// lowering phase also accepts vector and map destructuring in `defn`, `let`,
+/// `if-let`, and `when-let`; map destructuring supports `{local :key}`,
+/// `{:keys [...]}`, `{:strs [...]}`, `:or`, and `:as`.
 pub const PRELUDE: &str = r#"
 ;; ---- vector: [len, cap, e0, e1, …] ----------------------------------------
 (defn vec-make [cap]

--- a/crates/kotoba-clj/tests/heap_values.rs
+++ b/crates/kotoba-clj/tests/heap_values.rs
@@ -237,6 +237,39 @@ fn literal_lowering_does_not_shadow_source_locals() {
     assert_eq!(v, 42);
 }
 
+#[test]
+fn map_destructuring_supports_keys_strs_as_and_or_defaults() {
+    let src = r#"
+        (defn score [{:keys [a missing] :strs [b] :or {missing 7} :as whole}]
+          (+ a b missing (count whole)))
+        (defn t [_]
+          (let [{x :x :keys [a missing] :strs [b] :or {missing 5} :as whole}
+                {:a 10 "b" 20 :x 3}]
+            (+ x a b missing (count whole) (score {:a 1 "b" 2}))))
+    "#;
+    let wasm = compile_str_with_prelude(src).expect("compile");
+    let v = run(&wasm, "t", &[0]).expect("run");
+    assert_eq!(v, 53);
+}
+
+#[test]
+fn map_destructuring_works_in_if_and_when_let() {
+    let v = eval(
+        "(+ (if-let [{:keys [a] :strs [b]} {:a 10 \"b\" 20}] (+ a b) 0)
+            (when-let [{x :x :or {x 12}} {}] x))",
+    );
+    assert_eq!(v, 42);
+}
+
+#[test]
+fn map_destructuring_allows_nested_vector_values() {
+    let v = eval(
+        "(let [{[a _ & xs] :items :keys [n]} {:items [10 99 20 30] :n 2}]
+           (+ a (count xs) (last xs) n))",
+    );
+    assert_eq!(v, 44);
+}
+
 // ---- the langgraph state substrate -----------------------------------------
 
 #[test]

--- a/crates/kotoba-clj/tests/kotoba_file.rs
+++ b/crates/kotoba-clj/tests/kotoba_file.rs
@@ -661,17 +661,18 @@ fn destructuring_bindings_shadow_referred_names() {
     fs::create_dir_all(dir.join("demo")).unwrap();
     fs::write(
         dir.join("demo/math.clj"),
-        "(ns demo.math)\n(defn x [n] (+ n 1000))\n(defn rest [n] (+ n 1000))\n(defn whole [n] (+ n 1000))\n",
+        "(ns demo.math)\n(defn x [n] (+ n 1000))\n(defn rest [n] (+ n 1000))\n(defn whole [n] (+ n 1000))\n(defn a [n] (+ n 1000))\n(defn b [n] (+ n 1000))\n(defn missing [n] (+ n 1000))\n",
     )
     .unwrap();
     let main = dir.join("main.clj");
     fs::write(
         &main,
         r#"
-(ns demo.main (:require [demo.math :refer [x rest whole]]))
+(ns demo.main (:require [demo.math :refer [x rest whole a b missing]]))
 (defn main [n]
   (let [[x & rest :as whole] [27 4 10]]
-    (+ n x (count rest) (last rest) (count whole))))
+    (let [{:keys [a missing] :strs [b] :or {missing 5}} {:a 2 "b" 4}]
+      (+ n x (count rest) (last rest) (count whole) a b missing))))
 "#,
     )
     .unwrap();
@@ -687,7 +688,7 @@ fn destructuring_bindings_shadow_referred_names() {
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
-    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "53");
 
     let _ = fs::remove_dir_all(dir);
 }


### PR DESCRIPTION
## Summary
- add map destructuring lowering for kotoba-clj defn/let/if-let/when-let
- support explicit bindings, :keys, :strs, :or defaults, :as, and nested destructuring values
- teach namespace qualification shadowing about map destructuring locals
- document the supported map destructuring forms

## Verification
- cargo fmt --check
- cargo test -p kotoba-clj
- cargo clippy -p kotoba-clj --all-targets -- -D warnings