### PR TITLE
[codex] support destructuring in loop bindings

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -143,7 +143,7 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
   `do`, `loop`/`recur` (bounded), threading macros `->`, `->>`, `cond->`,
   `cond->>`, `some->`, `some->>`, and `as->`
 - binding forms: symbols plus vector and map destructuring in `defn`, `let`,
-  `if-let`, and `when-let`; vectors support nested destructuring, `_`
+  `loop`, `if-let`, and `when-let`; vectors support nested destructuring, `_`
   placeholders, `& rest`, and `:as whole`; maps support `{local :key}`,
   `{:keys [...]}`, `{:strs [...]}`, `:or` defaults, and `:as whole`
 - arithmetic: `+ - * / quot mod rem inc dec abs` · comparison:

--- a/crates/kotoba-clj/src/ast.rs
+++ b/crates/kotoba-clj/src/ast.rs
@@ -15,8 +15,8 @@
 //!               `(-> x step…)` `(->> x step…)` `(cond-> x test step …)`
 //!               `(cond->> x test step …)` `(some-> x step…)`
 //!               `(some->> x step…)` `(as-> x name form …)`
-//!               vector and map destructuring in `defn`, `let`, `if-let`,
-//!               `when-let`
+//!               vector and map destructuring in `defn`, `let`, `loop`,
+//!               `if-let`, `when-let`
 //!               builtins: + - * / mod  = < > <= >=  and or not
 //!               `(f args…)`  call a user `defn`
 
@@ -1356,9 +1356,20 @@ fn lower_loop(args: &[EdnValue]) -> Result<Expr, CljError> {
         ));
     }
     let mut bindings = Vec::with_capacity(binding_vec.len() / 2);
+    let mut destructured_bindings = Vec::new();
     let mut it = binding_vec.iter();
+    let mut idx = 0;
     while let (Some(name), Some(val)) = (it.next(), it.next()) {
-        bindings.push((sym_name(name, "loop binding name")?, lower_expr(val)?));
+        let (_, lowered) = lower_binding_pattern(name, lower_expr(val)?, idx, "loop binding name")?;
+        let mut lowered = lowered.into_iter();
+        let Some(loop_binding) = lowered.next() else {
+            return Err(CljError::Lower(
+                "loop binding lowering unexpectedly produced no binding".into(),
+            ));
+        };
+        bindings.push(loop_binding);
+        destructured_bindings.extend(lowered);
+        idx += 1;
     }
     let body = args[1..]
         .iter()
@@ -1369,6 +1380,7 @@ fn lower_loop(args: &[EdnValue]) -> Result<Expr, CljError> {
             "loop requires at least one body expression".into(),
         ));
     }
+    let body = prepend_bindings(destructured_bindings, body);
     Ok(Expr::Loop { bindings, body })
 }
 

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -225,7 +225,7 @@ pub fn compile_file_with_prelude_reader_target_and_source_paths(
 /// Clojure-core compatibility layer: `count`, `empty?`, `nth`, `first`, `last`,
 /// `subvec`, `rest`, `conj!`, `get`, `assoc!`, and `contains-key?`. The
 /// lowering phase also accepts vector and map destructuring in `defn`, `let`,
-/// `if-let`, and `when-let`; map destructuring supports `{local :key}`,
+/// `loop`, `if-let`, and `when-let`; map destructuring supports `{local :key}`,
 /// `{:keys [...]}`, `{:strs [...]}`, `:or`, and `:as`.
 pub const PRELUDE: &str = r#"
 ;; ---- vector: [len, cap, e0, e1, …] ----------------------------------------

--- a/crates/kotoba-clj/tests/heap_values.rs
+++ b/crates/kotoba-clj/tests/heap_values.rs
@@ -270,6 +270,21 @@ fn map_destructuring_allows_nested_vector_values() {
     assert_eq!(v, 44);
 }
 
+#[test]
+fn loop_destructuring_rebinds_each_recur_iteration() {
+    let v = eval(
+        "(loop [[a & xs] [1 2]
+                {:keys [n] :as m} {:n 10}
+                i 0]
+           (if (>= i 3)
+             (+ a (last xs) n (count m))
+             (recur [(+ a 1) (+ (last xs) 1)]
+                    {:n (+ n 10)}
+                    (+ i 1))))",
+    );
+    assert_eq!(v, 50);
+}
+
 // ---- the langgraph state substrate -----------------------------------------
 
 #[test]


### PR DESCRIPTION
## Summary
- allow vector and map destructuring in kotoba-clj loop binding forms
- keep recur arity aligned with original loop binding slots by destructuring from loop temporaries in each iteration body
- document loop as a supported destructuring binding context

## Verification
- cargo fmt --check
- cargo test -p kotoba-clj --test heap_values loop_destructuring -- --nocapture
- cargo test -p kotoba-clj
- cargo clippy -p kotoba-clj --all-targets -- -D warnings