### PR TITLE
[codex] support if-not and optional if else

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -139,9 +139,10 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
   `(extend-protocol …)`, `(defmulti …)`, `(defmethod …)`, `(defmacro …)`,
   `(defstruct …)`, `(create-struct …)`, `(comment …)`, and `(declare …)`
   (ignored where noted)
-- control: `if`, `when`, `if-let`, `when-let`, `cond`, `case`, `let` (sequential),
-  `do`, `loop`/`recur` (bounded), threading macros `->`, `->>`, `cond->`,
-  `cond->>`, `some->`, `some->>`, and `as->`
+- control: `if` (2- or 3-form), `if-not`, `when`, `when-not`, `if-let`,
+  `when-let`, `cond`, `case`, `let` (sequential), `do`, `loop`/`recur`
+  (bounded), threading macros `->`, `->>`, `cond->`, `cond->>`, `some->`,
+  `some->>`, and `as->`
 - binding forms: symbols plus vector and map destructuring in `defn`, `let`,
   `loop`, `if-let`, and `when-let`; vectors support nested destructuring, `_`
   placeholders, `& rest`, and `:as whole`; maps support `{local :key}`,

--- a/crates/kotoba-clj/src/ast.rs
+++ b/crates/kotoba-clj/src/ast.rs
@@ -9,7 +9,8 @@
 //!               top-level `(do …)` wrapping definitions
 //!               `(ns …)` namespace management decls, `(require …)` `(use …)` `(refer-clojure …)` `(import …)` `(gen-class …)` `(set! …)` record/type/protocol/multimethod decls, `(defmacro …)`, `(comment …)`, `(declare …)` ignored
 //!   expressions integer literal, `true`/`false`, symbol
-//!               `(if c t e)`  `(when c body…)` `(if-let [b v] t e)`
+//!               `(if c t e?)`  `(if-not c t e?)` `(when c body…)`
+//!               `(when-not c body…)` `(if-let [b v] t e)`
 //!               `(when-let [b v] body…)` `(case e test result … default?)`
 //!               `(let [b v …] body…)`  `(do e…)`, vector/map literals
 //!               `(-> x step…)` `(->> x step…)` `(cond-> x test step …)`
@@ -606,7 +607,9 @@ fn lower_call(items: &[EdnValue]) -> Result<Expr, CljError> {
         .unwrap_or(head.name.as_str());
     match special {
         "if" => lower_if(args),
+        "if-not" => lower_if_not(args),
         "when" => lower_when(args),
+        "when-not" => lower_when_not(args),
         "if-let" => lower_if_let(args),
         "when-let" => lower_when_let(args),
         "let" => lower_let(args),
@@ -804,13 +807,32 @@ fn lower_as_thread(args: &[EdnValue]) -> Result<Expr, CljError> {
 }
 
 fn lower_if(args: &[EdnValue]) -> Result<Expr, CljError> {
-    if args.len() != 3 {
-        return Err(CljError::Lower("if takes: (if cond then else)".into()));
+    if args.len() < 2 || args.len() > 3 {
+        return Err(CljError::Lower("if takes: (if cond then else?)".into()));
     }
     Ok(Expr::If {
         cond: Box::new(lower_expr(&args[0])?),
         then: Box::new(lower_expr(&args[1])?),
-        els: Box::new(lower_expr(&args[2])?),
+        els: Box::new(match args.get(2) {
+            Some(els) => lower_expr(els)?,
+            None => Expr::Int(0),
+        }),
+    })
+}
+
+fn lower_if_not(args: &[EdnValue]) -> Result<Expr, CljError> {
+    if args.len() < 2 || args.len() > 3 {
+        return Err(CljError::Lower(
+            "if-not takes: (if-not cond then else?)".into(),
+        ));
+    }
+    Ok(Expr::If {
+        cond: Box::new(lower_expr(&args[0])?),
+        then: Box::new(match args.get(2) {
+            Some(els) => lower_expr(els)?,
+            None => Expr::Int(0),
+        }),
+        els: Box::new(lower_expr(&args[1])?),
     })
 }
 
@@ -828,6 +850,25 @@ fn lower_when(args: &[EdnValue]) -> Result<Expr, CljError> {
         cond: Box::new(cond),
         then: Box::new(Expr::Do(body)),
         els: Box::new(Expr::Int(0)),
+    })
+}
+
+fn lower_when_not(args: &[EdnValue]) -> Result<Expr, CljError> {
+    // (when-not c body…) == (if c 0 (do body…))
+    if args.is_empty() {
+        return Err(CljError::Lower(
+            "when-not takes: (when-not cond body…)".into(),
+        ));
+    }
+    let cond = lower_expr(&args[0])?;
+    let body = args[1..]
+        .iter()
+        .map(lower_expr)
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Expr::If {
+        cond: Box::new(cond),
+        then: Box::new(Expr::Int(0)),
+        els: Box::new(Expr::Do(body)),
     })
 }
 

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -33,12 +33,14 @@
 //!   `(defmulti …)`, `(defmethod …)`, `(defmacro …)`, `(defstruct …)`,
 //!   `(create-struct …)`, `(comment …)`, and `(declare …)` (ignored where noted;
 //!   macros are accepted but not expanded)
-//! - control: `if`, `when`, `if-let`, `when-let`, `cond`, `case`, `let`, `do`,
-//!   `loop`/`recur` (bounded iteration), threading macros `->`, `->>`,
-//!   `cond->`, `cond->>`, `some->`, `some->>`, and `as->`
-//! - binding forms: symbols and vector destructuring in `defn`, `let`,
-//!   `if-let`, and `when-let`, including nested vectors, `_` placeholders,
-//!   `& rest`, and `:as whole`
+//! - control: `if` (2- or 3-form), `if-not`, `when`, `when-not`, `if-let`,
+//!   `when-let`, `cond`, `case`, `let`, `do`, `loop`/`recur` (bounded
+//!   iteration), threading macros `->`, `->>`, `cond->`, `cond->>`, `some->`,
+//!   `some->>`, and `as->`
+//! - binding forms: symbols plus vector and map destructuring in `defn`, `let`,
+//!   `loop`, `if-let`, and `when-let`; vectors support nested destructuring,
+//!   `_` placeholders, `& rest`, and `:as whole`; maps support `{local :key}`,
+//!   `{:keys [...]}`, `{:strs [...]}`, `:or`, and `:as`
 //! - arithmetic: `+ - * / mod`
 //! - comparison: `= < > <= >=`
 //! - logic: `and or not` (short-circuit; return 0/1)

--- a/crates/kotoba-clj/tests/compile_run.rs
+++ b/crates/kotoba-clj/tests/compile_run.rs
@@ -120,9 +120,21 @@ fn if_when_let_do() {
     assert_eq!(compile_and_run(max, "max", &[3, 9]).unwrap(), 9);
     assert_eq!(compile_and_run(max, "max", &[9, 3]).unwrap(), 9);
 
+    let if_without_else = "(defn f [x] (if (> x 0) (* x 2)))";
+    assert_eq!(compile_and_run(if_without_else, "f", &[4]).unwrap(), 8);
+    assert_eq!(compile_and_run(if_without_else, "f", &[-4]).unwrap(), 0);
+
+    let if_not = "(defn f [x] (if-not (> x 0) 9 (* x 2)))";
+    assert_eq!(compile_and_run(if_not, "f", &[4]).unwrap(), 8);
+    assert_eq!(compile_and_run(if_not, "f", &[-4]).unwrap(), 9);
+
     let w = "(defn w [x] (when (> x 0) (* x 10)))";
     assert_eq!(compile_and_run(w, "w", &[4]).unwrap(), 40);
     assert_eq!(compile_and_run(w, "w", &[-4]).unwrap(), 0);
+
+    let when_not = "(defn w [x] (when-not (> x 0) (* (- x) 10)))";
+    assert_eq!(compile_and_run(when_not, "w", &[4]).unwrap(), 0);
+    assert_eq!(compile_and_run(when_not, "w", &[-4]).unwrap(), 40);
 
     // sequential let: second binding sees the first
     let l = "(defn l [x] (let [a (* x 2) b (+ a 1)] (do a b)))";


### PR DESCRIPTION
## Summary
- accept 2-form Clojure if by lowering omitted else to nil/0
- add if-not and when-not control forms
- update kotoba-clj docs for supported control forms and current destructuring coverage

## Verification
- cargo fmt --check
- cargo test -p kotoba-clj --test compile_run if_when_let_do -- --nocapture
- cargo test -p kotoba-clj
- cargo clippy -p kotoba-clj --all-targets -- -D warnings