### PR TITLE
[codex] ignore expression comment forms

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -140,7 +140,7 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
   `(defstruct …)`, `(create-struct …)`, `(comment …)`, and `(declare …)`
   (ignored where noted)
 - control: `if` (2- or 3-form), `if-not`, `when`, `when-not`, `if-let`,
-  `when-let`, `cond`, `case`, `let` (sequential), `do`, `loop`/`recur`
+  `when-let`, `cond`, `case`, `let` (sequential), `do`, `comment`, `loop`/`recur`
   (bounded), threading macros `->`, `->>`, `cond->`, `cond->>`, `some->`,
   `some->>`, and `as->`
 - binding forms: symbols plus vector and map destructuring in `defn`, `let`,

--- a/crates/kotoba-clj/src/ast.rs
+++ b/crates/kotoba-clj/src/ast.rs
@@ -12,7 +12,8 @@
 //!               `(if c t e?)`  `(if-not c t e?)` `(when c body…)`
 //!               `(when-not c body…)` `(if-let [b v] t e)`
 //!               `(when-let [b v] body…)` `(case e test result … default?)`
-//!               `(let [b v …] body…)`  `(do e…)`, vector/map literals
+//!               `(let [b v …] body…)`  `(do e…)` `(comment …)`,
+//!               vector/map literals
 //!               `(-> x step…)` `(->> x step…)` `(cond-> x test step …)`
 //!               `(cond->> x test step …)` `(some-> x step…)`
 //!               `(some->> x step…)` `(as-> x name form …)`
@@ -631,6 +632,7 @@ fn lower_call(items: &[EdnValue]) -> Result<Expr, CljError> {
         "do" => Ok(Expr::Do(
             args.iter().map(lower_expr).collect::<Result<_, _>>()?,
         )),
+        "comment" => Ok(Expr::Int(0)),
         name => {
             let lowered: Vec<Expr> = args.iter().map(lower_expr).collect::<Result<_, _>>()?;
             if let Some(op) = Builtin::from_name(name) {

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -34,7 +34,7 @@
 //!   `(create-struct …)`, `(comment …)`, and `(declare …)` (ignored where noted;
 //!   macros are accepted but not expanded)
 //! - control: `if` (2- or 3-form), `if-not`, `when`, `when-not`, `if-let`,
-//!   `when-let`, `cond`, `case`, `let`, `do`, `loop`/`recur` (bounded
+//!   `when-let`, `cond`, `case`, `let`, `do`, `comment`, `loop`/`recur` (bounded
 //!   iteration), threading macros `->`, `->>`, `cond->`, `cond->>`, `some->`,
 //!   `some->>`, and `as->`
 //! - binding forms: symbols plus vector and map destructuring in `defn`, `let`,

--- a/crates/kotoba-clj/tests/compile_run.rs
+++ b/crates/kotoba-clj/tests/compile_run.rs
@@ -433,6 +433,10 @@ fn strings_are_interned_and_usable_in_logic() {
 
 #[test]
 fn errors_are_reported() {
+    assert!(
+        compile_str("(defn f [x] (comment (g x) y) (+ x 1))").is_ok(),
+        "expression comment bodies must not be lowered or resolved"
+    );
     assert!(matches!(
         compile_str("(defn f [x] (g x))"),
         Err(CljError::Codegen(_))


### PR DESCRIPTION
## Summary
- treat expression-position (comment ...) as nil/0 without lowering its body
- allow source files to keep development comment forms containing unresolved code
- update kotoba-clj docs for expression comment support

## Verification
- cargo fmt --check
- cargo test -p kotoba-clj --test compile_run errors_are_reported -- --nocapture
- cargo test -p kotoba-clj
- cargo clippy -p kotoba-clj --all-targets -- -D warnings