### PR TITLE
[codex] support nil? and some? predicates

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -149,7 +149,7 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
   `{:keys [...]}`, `{:strs [...]}`, `:or` defaults, and `:as whole`
 - arithmetic: `+ - * / quot mod rem inc dec abs` · comparison:
   `= not= < > <= >=` (n-ary where Clojure is n-ary) · predicates:
-  `zero? pos? neg?` · logic: `and or not`
+  `nil? some? zero? pos? neg?` · logic: `and or not`
 - strings: `"…"` literals, `(str-len s)`, `(byte-at s i)`
 - Clojure literals: `nil` lowers to `0`; keyword literals and quoted forms
   (`'foo`, `'(a b)`, `(quote {:k 1})`) lower to canonical EDN string handles;

--- a/crates/kotoba-clj/src/ast.rs
+++ b/crates/kotoba-clj/src/ast.rs
@@ -70,6 +70,7 @@ pub enum Builtin {
     Le,
     Ge,
     Zero,
+    Some,
     Pos,
     Neg,
     And,
@@ -223,7 +224,8 @@ impl Builtin {
             ">" => Builtin::Gt,
             "<=" => Builtin::Le,
             ">=" => Builtin::Ge,
-            "zero?" => Builtin::Zero,
+            "zero?" | "nil?" => Builtin::Zero,
+            "some?" => Builtin::Some,
             "pos?" => Builtin::Pos,
             "neg?" => Builtin::Neg,
             "and" => Builtin::And,
@@ -1761,6 +1763,7 @@ fn check_builtin_arity(op: Builtin, n: usize) -> Result<(), CljError> {
         | Builtin::Dec
         | Builtin::Abs
         | Builtin::Zero
+        | Builtin::Some
         | Builtin::Pos
         | Builtin::Neg
         | Builtin::StrLen => n == 1,

--- a/crates/kotoba-clj/src/codegen.rs
+++ b/crates/kotoba-clj/src/codegen.rs
@@ -836,6 +836,13 @@ fn compile_builtin(cg: &mut FnCtx, op: Builtin, args: &[Expr]) -> Result<(), Clj
             cg.emit(Instruction::I64ExtendI32U);
             Ok(())
         }
+        Builtin::Some => {
+            compile_expr(cg, &args[0])?;
+            cg.emit(Instruction::I64Const(0));
+            cg.emit(Instruction::I64Ne);
+            cg.emit(Instruction::I64ExtendI32U);
+            Ok(())
+        }
         Builtin::Pos => {
             compile_expr(cg, &args[0])?;
             cg.emit(Instruction::I64Const(0));
@@ -1528,6 +1535,7 @@ fn eval_const_builtin(op: Builtin, v: &[i64]) -> Result<i64, CljError> {
         Builtin::Le => b(v.windows(2).all(|pair| pair[0] <= pair[1])),
         Builtin::Ge => b(v.windows(2).all(|pair| pair[0] >= pair[1])),
         Builtin::Zero => b(v[0] == 0),
+        Builtin::Some => b(v[0] != 0),
         Builtin::Pos => b(v[0] > 0),
         Builtin::Neg => b(v[0] < 0),
         Builtin::Not => b(v[0] == 0),

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -43,6 +43,7 @@
 //!   `{:keys [...]}`, `{:strs [...]}`, `:or`, and `:as`
 //! - arithmetic: `+ - * / mod`
 //! - comparison: `= < > <= >=`
+//! - predicates: `nil? some? zero? pos? neg?`
 //! - logic: `and or not` (short-circuit; return 0/1)
 //! - strings: `"…"` literals, `(str-len s)`, `(byte-at s i)`
 //! - Clojure literals: `nil` lowers to `0`; keyword literals and quoted forms

--- a/crates/kotoba-clj/tests/compile_run.rs
+++ b/crates/kotoba-clj/tests/compile_run.rs
@@ -99,6 +99,8 @@ fn clojure_core_qualified_numeric_builtins_work() {
              (clojure.core/quot 9 2)))
         (defn predicates []
           (and (clojure.core/zero? 0)
+               (clojure.core/nil? nil)
+               (clojure.core/some? 1)
                (clojure.core/pos? 4)
                (clojure.core/neg? -1)
                (clojure.core/not= 1 2 3)))


### PR DESCRIPTION
## Summary
- add nil? as a clojure.core-compatible nil/0 predicate
- add some? as a non-zero predicate in codegen and constant folding
- document supported predicates and cover clojure.core-qualified calls

## Verification
- cargo fmt --check
- cargo test -p kotoba-clj --test compile_run clojure_core_qualified_numeric_builtins_work -- --nocapture
- cargo test -p kotoba-clj
- cargo clippy -p kotoba-clj --all-targets -- -D warnings