### PR TITLE
[codex] support even and odd predicates

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -149,7 +149,7 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
   `{:keys [...]}`, `{:strs [...]}`, `:or` defaults, and `:as whole`
 - arithmetic: `+ - * / quot mod rem inc dec abs min max` · comparison:
   `= not= < > <= >=` (n-ary where Clojure is n-ary) · predicates:
-  `nil? some? zero? pos? neg?` · logic: `and or not`
+  `nil? some? zero? pos? neg? even? odd?` · logic: `and or not`
 - strings: `"…"` literals, `(str-len s)`, `(byte-at s i)`
 - Clojure literals: `nil` lowers to `0`; keyword literals and quoted forms
   (`'foo`, `'(a b)`, `(quote {:k 1})`) lower to canonical EDN string handles;

--- a/crates/kotoba-clj/src/ast.rs
+++ b/crates/kotoba-clj/src/ast.rs
@@ -75,6 +75,8 @@ pub enum Builtin {
     Some,
     Pos,
     Neg,
+    Even,
+    Odd,
     And,
     Or,
     Not,
@@ -232,6 +234,8 @@ impl Builtin {
             "some?" => Builtin::Some,
             "pos?" => Builtin::Pos,
             "neg?" => Builtin::Neg,
+            "even?" => Builtin::Even,
+            "odd?" => Builtin::Odd,
             "and" => Builtin::And,
             "or" => Builtin::Or,
             "not" => Builtin::Not,
@@ -1770,6 +1774,8 @@ fn check_builtin_arity(op: Builtin, n: usize) -> Result<(), CljError> {
         | Builtin::Some
         | Builtin::Pos
         | Builtin::Neg
+        | Builtin::Even
+        | Builtin::Odd
         | Builtin::StrLen => n == 1,
         Builtin::BytesAlloc | Builtin::BytesLen | Builtin::BytesFinish => n == 1,
         Builtin::Alloc | Builtin::Load64 | Builtin::Load32 => n == 1,

--- a/crates/kotoba-clj/src/codegen.rs
+++ b/crates/kotoba-clj/src/codegen.rs
@@ -859,6 +859,23 @@ fn compile_builtin(cg: &mut FnCtx, op: Builtin, args: &[Expr]) -> Result<(), Clj
             cg.emit(Instruction::I64ExtendI32U);
             Ok(())
         }
+        Builtin::Even => {
+            compile_expr(cg, &args[0])?;
+            cg.emit(Instruction::I64Const(1));
+            cg.emit(Instruction::I64And);
+            cg.emit(Instruction::I64Eqz);
+            cg.emit(Instruction::I64ExtendI32U);
+            Ok(())
+        }
+        Builtin::Odd => {
+            compile_expr(cg, &args[0])?;
+            cg.emit(Instruction::I64Const(1));
+            cg.emit(Instruction::I64And);
+            cg.emit(Instruction::I64Const(0));
+            cg.emit(Instruction::I64Ne);
+            cg.emit(Instruction::I64ExtendI32U);
+            Ok(())
+        }
 
         Builtin::Not => {
             compile_expr(cg, &args[0])?;
@@ -1573,6 +1590,8 @@ fn eval_const_builtin(op: Builtin, v: &[i64]) -> Result<i64, CljError> {
         Builtin::Some => b(v[0] != 0),
         Builtin::Pos => b(v[0] > 0),
         Builtin::Neg => b(v[0] < 0),
+        Builtin::Even => b(v[0] & 1 == 0),
+        Builtin::Odd => b(v[0] & 1 != 0),
         Builtin::Not => b(v[0] == 0),
         Builtin::And => b(v.iter().all(|x| *x != 0)),
         Builtin::Or => b(v.iter().any(|x| *x != 0)),

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -43,7 +43,7 @@
 //!   `{:keys [...]}`, `{:strs [...]}`, `:or`, and `:as`
 //! - arithmetic: `+ - * / quot mod rem inc dec abs min max`
 //! - comparison: `= < > <= >=`
-//! - predicates: `nil? some? zero? pos? neg?`
+//! - predicates: `nil? some? zero? pos? neg? even? odd?`
 //! - logic: `and or not` (short-circuit; return 0/1)
 //! - strings: `"…"` literals, `(str-len s)`, `(byte-at s i)`
 //! - Clojure literals: `nil` lowers to `0`; keyword literals and quoted forms

--- a/crates/kotoba-clj/tests/compile_run.rs
+++ b/crates/kotoba-clj/tests/compile_run.rs
@@ -95,6 +95,22 @@ fn comparisons_and_logic() {
         compile_and_run("(defn o [x y] (or x y))", "o", &[0, 7]).unwrap(),
         1
     );
+    assert_eq!(
+        compile_and_run("(defn p [x] (even? x))", "p", &[-4]).unwrap(),
+        1
+    );
+    assert_eq!(
+        compile_and_run("(defn p [x] (even? x))", "p", &[-3]).unwrap(),
+        0
+    );
+    assert_eq!(
+        compile_and_run("(defn p [x] (odd? x))", "p", &[7]).unwrap(),
+        1
+    );
+    assert_eq!(
+        compile_and_run("(defn p [x] (odd? x))", "p", &[8]).unwrap(),
+        0
+    );
 }
 
 #[test]
@@ -113,6 +129,8 @@ fn clojure_core_qualified_numeric_builtins_work() {
                (clojure.core/some? 1)
                (clojure.core/pos? 4)
                (clojure.core/neg? -1)
+               (clojure.core/even? 8)
+               (clojure.core/odd? -3)
                (clojure.core/not= 1 2 3)))
         (defn nary []
           (and (= 1 1 1) (< 1 2 3) (<= 1 1 2) (> 3 2 1) (>= 3 3 2)))


### PR DESCRIPTION
## Summary

- add `even?` and `odd?` as kotoba-clj numeric predicates, including `clojure.core/` qualified calls

- compile predicates with low-bit checks and support compile-time constant folding
- document the expanded predicate surface and cover signed cases in compile/run tests



## Validation
- cargo fmt && cargo fmt --check

- cargo test -p kotoba-clj --test compile_run comparisons_and_logic

- cargo test -p kotoba-clj --test compile_run clojure_core_qualified_numeric_builtins_work
- cargo test -p kotoba-clj

- cargo clippy -p kotoba-clj --all-targets -- -D warnings


