### PR TITLE
[codex] extend prelude core container aliases

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -163,8 +163,8 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
   `(bytes-finish buf)` — mutable buffer in linear memory; `bytes-finish` → string handle
 - raw memory: `(alloc n)`, `(load64 a)`, `(store64! a v)`, `(load32 a)`, `(store32! a v)`
 - prelude aliases for common Clojure-style container calls: `count`, `empty?`,
-  `nth`, `first`, `last`, `subvec`, `rest`, `conj!`, `get`, `assoc!`,
-  `contains-key?`
+  `seq`, `not-empty`, `nth`, `first`, `last`, `subvec`, `rest`, `conj!`,
+  `get` (2- or 3-arity), `assoc!`, `contains-key?`
 - `clojure.core/`-qualified builtin calls are accepted for the supported core
   numeric/comparison/logical operations.
 - host calls: `(has-capability? resource ability)` → `auth.has-capability`;

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -225,8 +225,9 @@ pub fn compile_file_with_prelude_reader_target_and_source_paths(
 /// Prepend it with [`compile_str_with_prelude`]. Names: `vec-make` `vec-count`
 /// `vec-nth` `vec-conj!` `vec-extend!` (the `add_messages` reducer), `map-make`
 /// `map-count` `map-get` `map-assoc!`, and `str-eq?`. It also exposes a small
-/// Clojure-core compatibility layer: `count`, `empty?`, `nth`, `first`, `last`,
-/// `subvec`, `rest`, `conj!`, `get`, `assoc!`, and `contains-key?`. The
+/// Clojure-core compatibility layer: `count`, `empty?`, `seq`, `not-empty`,
+/// `nth`, `first`, `last`, `subvec`, `rest`, `conj!`, `get`, `assoc!`, and
+/// `contains-key?`. The
 /// lowering phase also accepts vector and map destructuring in `defn`, `let`,
 /// `loop`, `if-let`, and `when-let`; map destructuring supports `{local :key}`,
 /// `{:keys [...]}`, `{:strs [...]}`, `:or`, and `:as`.
@@ -311,12 +312,16 @@ pub const PRELUDE: &str = r#"
 ;; offset 0, while nth/conj! are vector-oriented and get/assoc! are map-oriented.
 (defn count [x] (load64 x))
 (defn empty? [x] (= (count x) 0))
+(defn seq [x] (if (empty? x) 0 x))
+(defn not-empty [x] (if (empty? x) 0 x))
 (defn nth [v i] (vec-nth v i))
 (defn first [v] (vec-nth v 0))
 (defn last [v] (vec-nth v (- (vec-count v) 1)))
 (defn rest [v] (subvec v 1))
 (defn conj! [v x] (vec-conj! v x))
-(defn get [m k] (map-get m k))
+(defn get
+  ([m k] (map-get m k))
+  ([m k default] (if (contains-key? m k) (map-get m k) default)))
 (defn assoc! [m k v] (map-assoc! m k v))
 (defn contains-key? [m k] (>= (map-find m k) 0))
 "#;

--- a/crates/kotoba-clj/tests/heap_values.rs
+++ b/crates/kotoba-clj/tests/heap_values.rs
@@ -194,10 +194,16 @@ fn clojure_core_map_aliases() {
            (assoc! m \"k\" 42)
            (+ (count m)
               (get m \"k\")
+              (get m \"missing\" 7)
+              (get m \"k\" 100)
               (contains-key? m \"k\")
-              (empty? (map-make 1))))",
+              (empty? (map-make 1))
+              (if (seq m) 10 0)
+              (if (seq (map-make 1)) 1000 0)
+              (if (not-empty m) 20 0)
+              (if (not-empty (map-make 1)) 1000 0)))",
     );
-    assert_eq!(v, 45);
+    assert_eq!(v, 124);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- extend the kotoba-clj prelude with `seq` and `not-empty` container aliases

- add 3-arity `get` so missing map keys can use a caller-provided default
- document the expanded prelude surface and cover the aliases in heap value tests



## Validation
- cargo fmt && cargo fmt --check

- cargo test -p kotoba-clj --test heap_values clojure_core_map_aliases

- cargo test -p kotoba-clj
- cargo clippy -p kotoba-clj --all-targets -- -D warnings




