### PR TITLE
[codex] extend prelude vector aliases

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -163,8 +163,9 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
   `(bytes-finish buf)` — mutable buffer in linear memory; `bytes-finish` → string handle
 - raw memory: `(alloc n)`, `(load64 a)`, `(store64! a v)`, `(load32 a)`, `(store32! a v)`
 - prelude aliases for common Clojure-style container calls: `count`, `empty?`,
-  `seq`, `not-empty`, `nth`, `first`, `last`, `subvec`, `rest`, `conj!`,
-  `get` (2- or 3-arity), `assoc!`, `contains-key?`
+  `seq`, `not-empty`, `nth` (2- or 3-arity), `first`, `second`, `last`,
+  `peek`, `subvec`, `rest`, `conj!`, `get` (2- or 3-arity), `assoc!`,
+  `contains-key?`
 - `clojure.core/`-qualified builtin calls are accepted for the supported core
   numeric/comparison/logical operations.
 - host calls: `(has-capability? resource ability)` → `auth.has-capability`;

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -226,8 +226,8 @@ pub fn compile_file_with_prelude_reader_target_and_source_paths(
 /// `vec-nth` `vec-conj!` `vec-extend!` (the `add_messages` reducer), `map-make`
 /// `map-count` `map-get` `map-assoc!`, and `str-eq?`. It also exposes a small
 /// Clojure-core compatibility layer: `count`, `empty?`, `seq`, `not-empty`,
-/// `nth`, `first`, `last`, `subvec`, `rest`, `conj!`, `get`, `assoc!`, and
-/// `contains-key?`. The
+/// `nth`, `first`, `second`, `last`, `peek`, `subvec`, `rest`, `conj!`, `get`,
+/// `assoc!`, and `contains-key?`. The
 /// lowering phase also accepts vector and map destructuring in `defn`, `let`,
 /// `loop`, `if-let`, and `when-let`; map destructuring supports `{local :key}`,
 /// `{:keys [...]}`, `{:strs [...]}`, `:or`, and `:as`.
@@ -314,9 +314,13 @@ pub const PRELUDE: &str = r#"
 (defn empty? [x] (= (count x) 0))
 (defn seq [x] (if (empty? x) 0 x))
 (defn not-empty [x] (if (empty? x) 0 x))
-(defn nth [v i] (vec-nth v i))
+(defn nth
+  ([v i] (vec-nth v i))
+  ([v i default] (if (>= i (vec-count v)) default (vec-nth v i))))
 (defn first [v] (vec-nth v 0))
+(defn second [v] (nth v 1))
 (defn last [v] (vec-nth v (- (vec-count v) 1)))
+(defn peek [v] (last v))
 (defn rest [v] (subvec v 1))
 (defn conj! [v x] (vec-conj! v x))
 (defn get

--- a/crates/kotoba-clj/tests/heap_values.rs
+++ b/crates/kotoba-clj/tests/heap_values.rs
@@ -57,9 +57,15 @@ fn clojure_core_vector_aliases() {
            (conj! v 11)
            (conj! v 22)
            (conj! v 33)
-           (+ (count v) (first v) (nth v 1) (last v)))",
+           (+ (count v)
+              (first v)
+              (second v)
+              (nth v 1)
+              (nth v 99 7)
+              (last v)
+              (peek v)))",
     );
-    assert_eq!(v, 69);
+    assert_eq!(v, 131);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- extend the kotoba-clj prelude with vector aliases `second` and `peek`

- add 3-arity `nth` so vector reads can return a caller-provided default when the index is past the end
- document the expanded prelude surface and cover the aliases in heap value tests



## Validation
- cargo fmt && cargo fmt --check

- cargo test -p kotoba-clj --test heap_values clojure_core_vector_aliases

- cargo test -p kotoba-clj
- cargo clippy -p kotoba-clj --all-targets -- -D warnings




