### PR TITLE
[codex] add prelude map keys and vals

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -165,7 +165,7 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
 - prelude aliases for common Clojure-style container calls: `count`, `empty?`,
   `seq`, `not-empty`, `nth` (2- or 3-arity), `first`, `second`, `last`,
   `peek`, `subvec`, `rest`, `conj!`, `get` (2- or 3-arity), `assoc!`,
-  `contains-key?`
+  `contains-key?`, `keys`, `vals`
 - `clojure.core/`-qualified builtin calls are accepted for the supported core
   numeric/comparison/logical operations.
 - host calls: `(has-capability? resource ability)` → `auth.has-capability`;

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -227,7 +227,7 @@ pub fn compile_file_with_prelude_reader_target_and_source_paths(
 /// `map-count` `map-get` `map-assoc!`, and `str-eq?`. It also exposes a small
 /// Clojure-core compatibility layer: `count`, `empty?`, `seq`, `not-empty`,
 /// `nth`, `first`, `second`, `last`, `peek`, `subvec`, `rest`, `conj!`, `get`,
-/// `assoc!`, and `contains-key?`. The
+/// `assoc!`, `contains-key?`, `keys`, and `vals`. The
 /// lowering phase also accepts vector and map destructuring in `defn`, `let`,
 /// `loop`, `if-let`, and `when-let`; map destructuring supports `{local :key}`,
 /// `{:keys [...]}`, `{:strs [...]}`, `:or`, and `:as`.
@@ -328,6 +328,22 @@ pub const PRELUDE: &str = r#"
   ([m k default] (if (contains-key? m k) (map-get m k) default)))
 (defn assoc! [m k v] (map-assoc! m k v))
 (defn contains-key? [m k] (>= (map-find m k) 0))
+(defn keys [m]
+  (let [n (map-count m)
+        out (vec-make n)]
+    (loop [i 0]
+      (if (>= i n)
+        out
+        (do (vec-conj! out (map-key-at m i))
+            (recur (+ i 1)))))))
+(defn vals [m]
+  (let [n (map-count m)
+        out (vec-make n)]
+    (loop [i 0]
+      (if (>= i n)
+        out
+        (do (vec-conj! out (map-val-at m i))
+            (recur (+ i 1)))))))
 "#;
 
 /// An **in-guest CBOR decoder** (subset) written in the kotoba-clj language,

--- a/crates/kotoba-clj/tests/heap_values.rs
+++ b/crates/kotoba-clj/tests/heap_values.rs
@@ -198,6 +198,9 @@ fn clojure_core_map_aliases() {
         "(let [m (map-make 4)]
            (assoc! m \"k\" 41)
            (assoc! m \"k\" 42)
+           (assoc! m \"z\" 5)
+           (let [ks (keys m)
+                 vs (vals m)]
            (+ (count m)
               (get m \"k\")
               (get m \"missing\" 7)
@@ -207,9 +210,13 @@ fn clojure_core_map_aliases() {
               (if (seq m) 10 0)
               (if (seq (map-make 1)) 1000 0)
               (if (not-empty m) 20 0)
-              (if (not-empty (map-make 1)) 1000 0)))",
+              (if (not-empty (map-make 1)) 1000 0)
+              (count ks)
+              (count vs)
+              (str-len (first ks))
+              (last vs))))",
     );
-    assert_eq!(v, 124);
+    assert_eq!(v, 135);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add `keys` and `vals` to the kotoba-clj prelude container compatibility layer

- return vectors populated from the prelude map positional accessors
- document the expanded prelude surface and cover key/value vectors in heap value tests



## Validation
- cargo fmt && cargo fmt --check

- cargo test -p kotoba-clj --test heap_values clojure_core_map_aliases

- cargo test -p kotoba-clj
- cargo clippy -p kotoba-clj --all-targets -- -D warnings




