### PR TITLE
[codex] add mutable core container aliases

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -164,8 +164,8 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
 - raw memory: `(alloc n)`, `(load64 a)`, `(store64! a v)`, `(load32 a)`, `(store32! a v)`
 - prelude aliases for common Clojure-style container calls: `count`, `empty?`,
   `seq`, `not-empty`, `nth` (2- or 3-arity), `first`, `second`, `last`,
-  `peek`, `subvec`, `rest`, `conj!`, `get` (2- or 3-arity), `assoc!`,
-  `contains-key?`, `keys`, `vals`
+  `peek`, `subvec`, `rest`, `conj`, `conj!`, `get` (2- or 3-arity),
+  `assoc`, `assoc!`, `contains?`, `contains-key?`, `keys`, `vals`
 - `clojure.core/`-qualified builtin calls are accepted for the supported core
   numeric/comparison/logical operations.
 - host calls: `(has-capability? resource ability)` → `auth.has-capability`;

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -226,8 +226,9 @@ pub fn compile_file_with_prelude_reader_target_and_source_paths(
 /// `vec-nth` `vec-conj!` `vec-extend!` (the `add_messages` reducer), `map-make`
 /// `map-count` `map-get` `map-assoc!`, and `str-eq?`. It also exposes a small
 /// Clojure-core compatibility layer: `count`, `empty?`, `seq`, `not-empty`,
-/// `nth`, `first`, `second`, `last`, `peek`, `subvec`, `rest`, `conj!`, `get`,
-/// `assoc!`, `contains-key?`, `keys`, and `vals`. The
+/// `nth`, `first`, `second`, `last`, `peek`, `subvec`, `rest`, `conj`,
+/// `conj!`, `get`, `assoc`, `assoc!`, `contains?`, `contains-key?`, `keys`,
+/// and `vals`. The
 /// lowering phase also accepts vector and map destructuring in `defn`, `let`,
 /// `loop`, `if-let`, and `when-let`; map destructuring supports `{local :key}`,
 /// `{:keys [...]}`, `{:strs [...]}`, `:or`, and `:as`.
@@ -322,11 +323,14 @@ pub const PRELUDE: &str = r#"
 (defn last [v] (vec-nth v (- (vec-count v) 1)))
 (defn peek [v] (last v))
 (defn rest [v] (subvec v 1))
+(defn conj [v x] (vec-conj! v x))
 (defn conj! [v x] (vec-conj! v x))
 (defn get
   ([m k] (map-get m k))
   ([m k default] (if (contains-key? m k) (map-get m k) default)))
+(defn assoc [m k v] (map-assoc! m k v))
 (defn assoc! [m k v] (map-assoc! m k v))
+(defn contains? [m k] (>= (map-find m k) 0))
 (defn contains-key? [m k] (>= (map-find m k) 0))
 (defn keys [m]
   (let [n (map-count m)

--- a/crates/kotoba-clj/tests/heap_values.rs
+++ b/crates/kotoba-clj/tests/heap_values.rs
@@ -55,7 +55,7 @@ fn clojure_core_vector_aliases() {
     let v = eval(
         "(let [v (vec-make 8)]
            (conj! v 11)
-           (conj! v 22)
+           (conj v 22)
            (conj! v 33)
            (+ (count v)
               (first v)
@@ -197,14 +197,15 @@ fn clojure_core_map_aliases() {
     let v = eval(
         "(let [m (map-make 4)]
            (assoc! m \"k\" 41)
-           (assoc! m \"k\" 42)
-           (assoc! m \"z\" 5)
+           (assoc m \"k\" 42)
+           (assoc m \"z\" 5)
            (let [ks (keys m)
                  vs (vals m)]
            (+ (count m)
               (get m \"k\")
               (get m \"missing\" 7)
               (get m \"k\" 100)
+              (contains? m \"z\")
               (contains-key? m \"k\")
               (empty? (map-make 1))
               (if (seq m) 10 0)
@@ -216,7 +217,7 @@ fn clojure_core_map_aliases() {
               (str-len (first ks))
               (last vs))))",
     );
-    assert_eq!(v, 135);
+    assert_eq!(v, 136);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add prelude aliases `conj`, `assoc`, and `contains?` for common Clojure-style container calls

- keep the aliases on the existing mutable vector/map handle substrate
- document the expanded prelude surface and exercise the aliases in heap value tests



## Validation
- cargo fmt && cargo fmt --check

- cargo test -p kotoba-clj --test heap_values clojure_core_vector_aliases

- cargo test -p kotoba-clj --test heap_values clojure_core_map_aliases
- cargo test -p kotoba-clj

- cargo clippy -p kotoba-clj --all-targets -- -D warnings


