### PR TITLE
[codex] add prelude value function aliases

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -165,7 +165,8 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
 - prelude aliases for common Clojure-style container calls: `count`, `empty?`,
   `seq`, `not-empty`, `nth` (2- or 3-arity), `first`, `second`, `last`,
   `peek`, `subvec`, `rest`, `conj`, `conj!`, `get` (2- or 3-arity),
-  `assoc`, `assoc!`, `contains?`, `contains-key?`, `keys`, `vals`
+  `assoc`, `assoc!`, `contains?`, `contains-key?`, `keys`, `vals`,
+  `identity`, `constantly`
 - `clojure.core/`-qualified builtin calls are accepted for the supported core
   numeric/comparison/logical operations.
 - host calls: `(has-capability? resource ability)` → `auth.has-capability`;

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -228,7 +228,7 @@ pub fn compile_file_with_prelude_reader_target_and_source_paths(
 /// Clojure-core compatibility layer: `count`, `empty?`, `seq`, `not-empty`,
 /// `nth`, `first`, `second`, `last`, `peek`, `subvec`, `rest`, `conj`,
 /// `conj!`, `get`, `assoc`, `assoc!`, `contains?`, `contains-key?`, `keys`,
-/// and `vals`. The
+/// `vals`, `identity`, and `constantly`. The
 /// lowering phase also accepts vector and map destructuring in `defn`, `let`,
 /// `loop`, `if-let`, and `when-let`; map destructuring supports `{local :key}`,
 /// `{:keys [...]}`, `{:strs [...]}`, `:or`, and `:as`.
@@ -332,6 +332,11 @@ pub const PRELUDE: &str = r#"
 (defn assoc! [m k v] (map-assoc! m k v))
 (defn contains? [m k] (>= (map-find m k) 0))
 (defn contains-key? [m k] (>= (map-find m k) 0))
+(defn identity [x] x)
+(defn constantly
+  ([x] x)
+  ([x _] x)
+  ([x _ _] x))
 (defn keys [m]
   (let [n (map-count m)
         out (vec-make n)]

--- a/crates/kotoba-clj/tests/heap_values.rs
+++ b/crates/kotoba-clj/tests/heap_values.rs
@@ -69,6 +69,12 @@ fn clojure_core_vector_aliases() {
 }
 
 #[test]
+fn clojure_core_value_function_aliases() {
+    let v = eval("(+ (identity 10) (constantly 20) (constantly 5 999) (constantly 7 1 2))");
+    assert_eq!(v, 42);
+}
+
+#[test]
 fn vector_literals_lower_to_prelude_vectors() {
     let v = eval("(let [v [11 22 33]] (+ (count v) (first v) (nth v 1) (last v)))");
     assert_eq!(v, 69);


### PR DESCRIPTION
## Summary

- add prelude value-function aliases `identity` and `constantly`

- support direct-call `constantly` arities used by the current non-higher-order subset
- document the expanded prelude surface and cover the aliases in heap value tests



## Validation
- cargo fmt && cargo fmt --check

- cargo test -p kotoba-clj --test heap_values clojure_core_value_function_aliases

- cargo test -p kotoba-clj
- cargo clippy -p kotoba-clj --all-targets -- -D warnings




