### PR TITLE
[codex] add prelude container constructors

### DIFF
--- a/crates/kotoba-clj/README.md
+++ b/crates/kotoba-clj/README.md
@@ -166,6 +166,7 @@ non-zero); a **string** is a packed `(offset << 32) | len` handle into memory.
   `seq`, `not-empty`, `nth` (2- or 3-arity), `first`, `second`, `last`,
   `peek`, `subvec`, `rest`, `conj`, `conj!`, `get` (2- or 3-arity),
   `assoc`, `assoc!`, `contains?`, `contains-key?`, `keys`, `vals`,
+  `vector` (0-4 elements), `hash-map` / `array-map` (0-3 key/value pairs),
   `identity`, `constantly`
 - `clojure.core/`-qualified builtin calls are accepted for the supported core
   numeric/comparison/logical operations.

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -51,6 +51,8 @@
 //!   lowers to the referenced symbol name handle; vector literals (`[1 2]`) and
 //!   map literals (`{:k v}`) lower to the [`PRELUDE`] container handles when the
 //!   prelude is enabled
+//! - prelude container constructors: `vector` (0-4 elements), `hash-map` /
+//!   `array-map` (0-3 key/value pairs)
 //! - `defn` pre/post condition maps (`{:pre […] :post […]}`) are accepted for
 //!   source compatibility but not asserted
 //! - Clojure reader metadata (`^:private`, `^String`, `^long`) is stripped before
@@ -228,7 +230,7 @@ pub fn compile_file_with_prelude_reader_target_and_source_paths(
 /// Clojure-core compatibility layer: `count`, `empty?`, `seq`, `not-empty`,
 /// `nth`, `first`, `second`, `last`, `peek`, `subvec`, `rest`, `conj`,
 /// `conj!`, `get`, `assoc`, `assoc!`, `contains?`, `contains-key?`, `keys`,
-/// `vals`, `identity`, and `constantly`. The
+/// `vals`, `vector`, `hash-map`, `array-map`, `identity`, and `constantly`. The
 /// lowering phase also accepts vector and map destructuring in `defn`, `let`,
 /// `loop`, `if-let`, and `when-let`; map destructuring supports `{local :key}`,
 /// `{:keys [...]}`, `{:strs [...]}`, `:or`, and `:as`.
@@ -332,6 +334,22 @@ pub const PRELUDE: &str = r#"
 (defn assoc! [m k v] (map-assoc! m k v))
 (defn contains? [m k] (>= (map-find m k) 0))
 (defn contains-key? [m k] (>= (map-find m k) 0))
+(defn vector
+  ([] (vec-make 0))
+  ([x] (let [v (vec-make 1)] (vec-conj! v x) v))
+  ([x y] (let [v (vec-make 2)] (vec-conj! v x) (vec-conj! v y) v))
+  ([x y z] (let [v (vec-make 3)] (vec-conj! v x) (vec-conj! v y) (vec-conj! v z) v))
+  ([x y z w] (let [v (vec-make 4)] (vec-conj! v x) (vec-conj! v y) (vec-conj! v z) (vec-conj! v w) v)))
+(defn hash-map
+  ([] (map-make 0))
+  ([k v] (let [m (map-make 1)] (map-assoc! m k v) m))
+  ([k v k2 v2] (let [m (map-make 2)] (map-assoc! m k v) (map-assoc! m k2 v2) m))
+  ([k v k2 v2 k3 v3] (let [m (map-make 3)] (map-assoc! m k v) (map-assoc! m k2 v2) (map-assoc! m k3 v3) m)))
+(defn array-map
+  ([] (hash-map))
+  ([k v] (hash-map k v))
+  ([k v k2 v2] (hash-map k v k2 v2))
+  ([k v k2 v2 k3 v3] (hash-map k v k2 v2 k3 v3)))
 (defn identity [x] x)
 (defn constantly
   ([x] x)

--- a/crates/kotoba-clj/tests/heap_values.rs
+++ b/crates/kotoba-clj/tests/heap_values.rs
@@ -75,6 +75,23 @@ fn clojure_core_value_function_aliases() {
 }
 
 #[test]
+fn clojure_core_container_constructor_aliases() {
+    let v = eval(
+        "(let [v (vector 10 20 30 40)
+               m (hash-map \"a\" 5 \"b\" 7 \"c\" 11)
+               a (array-map \"x\" 13 \"y\" 17)]
+           (+ (count (vector))
+              (count v)
+              (nth v 2)
+              (get m \"b\")
+              (count m)
+              (get a \"y\")
+              (count a)))",
+    );
+    assert_eq!(v, 63);
+}
+
+#[test]
 fn vector_literals_lower_to_prelude_vectors() {
     let v = eval("(let [v [11 22 33]] (+ (count v) (first v) (nth v 1) (last v)))");
     assert_eq!(v, 69);


### PR DESCRIPTION
## Summary
- add PRELUDE aliases for direct-call Clojure container constructors: vector, hash-map, and array-map
- document the finite arities supported by the current non-variadic lowering model
- cover the constructors with an end-to-end heap_values test

## Notes
- vector supports 0-4 direct elements
- hash-map and array-map support 0-3 key/value pairs
- these return the existing mutable prelude container handles, matching current vector/map literal lowering

## Verification
- cargo fmt && cargo fmt --check
- cargo test -p kotoba-clj --test heap_values clojure_core_container_constructor_aliases
- cargo test -p kotoba-clj
- cargo clippy -p kotoba-clj --all-targets -- -D warnings