### PR TITLE
browser: trustless CID-query read plane + sovereign write path (ClojureScript)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4689,6 +4689,7 @@ dependencies = [
  "kotoba-graph",
  "kotoba-ingest",
  "kotoba-ipfs",
+ "kotoba-ipns-record",
  "kotoba-llm",
  "kotoba-net",
  "kotoba-query",

--- a/crates/kotoba-server/Cargo.toml
+++ b/crates/kotoba-server/Cargo.toml
@@ -76,6 +76,7 @@ kotoba-core.workspace     = true
 kotoba-query.workspace      = true
 kotoba-graph              = { path = "../kotoba-graph" }
 kotoba-auth               = { path = "../kotoba-auth" }
+kotoba-ipns-record        = { path = "../kotoba-ipns-record" }
 multibase.workspace       = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 tower = { workspace = true, features = ["util"] }

--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -1072,6 +1072,14 @@ pub fn build_router(state: Arc<KotobaState>) -> Router {
             get(xrpc::block_get),
         )
         .route(
+            &format!("/xrpc/{}", xrpc::NSID_IPNS_HEAD),
+            get(xrpc::ipns_head),
+        )
+        .route(
+            &format!("/xrpc/{}", xrpc::NSID_IPNS_PUBLISH),
+            post(xrpc::ipns_publish),
+        )
+        .route(
             &format!("/xrpc/{}", xrpc::NSID_COMMIT_GET),
             get(xrpc::commit_get),
         )

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -76,6 +76,8 @@ pub const NSID_EMBED_CREATE: &str = "com.etzhayyim.apps.kotoba.embed.create";
 pub const NSID_NODE_STATUS: &str = "com.etzhayyim.apps.kotoba.node.status";
 pub const NSID_BLOCK_PUT: &str = "com.etzhayyim.apps.kotoba.block.put";
 pub const NSID_BLOCK_GET: &str = "com.etzhayyim.apps.kotoba.block.get";
+pub const NSID_IPNS_HEAD: &str = "com.etzhayyim.apps.kotoba.ipns.head";
+pub const NSID_IPNS_PUBLISH: &str = "com.etzhayyim.apps.kotoba.ipns.publish";
 pub const NSID_COMMIT_STORE: &str = "com.etzhayyim.apps.kotoba.commit.store";
 pub const NSID_AGENT_RUN: &str = "com.etzhayyim.apps.kotoba.agent.run";
 pub const NSID_AGENT_SYNC_OPEN: &str = "com.etzhayyim.apps.kotoba.agent.syncopen";
@@ -7497,6 +7499,13 @@ pub struct BlockGetReq {
     pub cid: String,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct IpnsHeadReq {
+    /// Graph CID (multibase). The mutable head is resolved from the
+    /// distributed IPNS name derived from it.
+    pub graph: String,
+}
+
 #[derive(Debug, Serialize)]
 pub struct BlockGetResp {
     pub cid: String,
@@ -7596,6 +7605,84 @@ pub async fn block_get(
             cid: req.cid.clone(),
             data_b64: B64.encode(&bytes),
         })),
+    }
+}
+
+/// GET /xrpc/com.etzhayyim.apps.kotoba.ipns.head?graph=<multibase-cid>
+///
+/// Returns the member-signed `IpnsRecord` that is the current mutable head of
+/// `graph` (its `value` field is the head/commit CID).
+///
+/// SECURITY: intentionally UNAUTHENTICATED, like `block.get`. The record is
+/// self-verifying — it carries an Ed25519 signature over a canonical CBOR payload
+/// (kotoba-ipns-record). A browser checks it in-wasm via
+/// `KotobaNode.verifyIpnsRecord`, so this server (or any caching gateway) is NOT
+/// trusted: it can withhold a newer head but cannot forge one. See
+/// docs/ADR-browser-cid-query-vs-p2p.md §1.
+pub async fn ipns_head(
+    State(state): State<Arc<KotobaState>>,
+    axum::extract::Query(req): axum::extract::Query<IpnsHeadReq>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    use kotoba_core::cid::KotobaCid;
+
+    const MAX_CID_LEN: usize = 512;
+    if req.graph.len() > MAX_CID_LEN {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "graph cid too long ({} bytes, limit {MAX_CID_LEN})",
+                req.graph.len()
+            ),
+        ));
+    }
+    let graph_cid = KotobaCid::from_multibase(&req.graph)
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "invalid graph CID".into()))?;
+
+    let ipns_name = distributed_graph_ipns_name(&graph_cid);
+    match state.ipns_registry.resolve(&IpnsName::new(ipns_name)) {
+        Ok(record) => Ok(Json(record)),
+        Err(e) => Err((StatusCode::NOT_FOUND, format!("ipns head: {e}"))),
+    }
+}
+
+/// POST /xrpc/com.etzhayyim.apps.kotoba.ipns.publish
+///
+/// Advance a graph's mutable head by publishing a **member-signed `IpnsRecord`**.
+/// The symmetric write to `ipns.head`: a browser builds the record locally
+/// (`KotobaNode.commitHeadSigned`) and pushes it here.
+///
+/// AUTHORITY = the Ed25519 signature over the record, NOT a server credential.
+/// This endpoint requires a valid signature (unsigned records are rejected) and
+/// the registry enforces a monotonic `sequence` CAS, so a holder cannot roll the
+/// head back. The head pointer is therefore only as authoritative as the key that
+/// signed it — which is takeover-proof exactly when the IPNS name is derived from
+/// that key (a sovereign/DID-scoped graph). It does NOT grant write access to a
+/// shared `k51-kotoba-<graph_cid>` head owned by someone else; CACAO-gated
+/// `datomic.transact` remains the authority path for those.
+pub async fn ipns_publish(
+    State(state): State<Arc<KotobaState>>,
+    Json(record): Json<kotoba_ipfs::IpnsRecord>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    // Reject unsigned / invalid records outright — the underlying registry may be
+    // lenient on an absent signature, but the write endpoint must not be.
+    record
+        .require_verified_signature()
+        .map_err(|e| (StatusCode::UNAUTHORIZED, format!("ipns publish: {e}")))?;
+    let name = record.name.0.clone();
+    match state.ipns_registry.publish(record) {
+        Ok(()) => Ok(Json(serde_json::json!({ "status": "ok", "name": name }))),
+        Err(e) => {
+            let code = match &e {
+                IpnsRegistryError::StaleRecord { .. } => StatusCode::CONFLICT,
+                IpnsRegistryError::MissingSignature
+                | IpnsRegistryError::InvalidSignature(_)
+                | IpnsRegistryError::MissingPublicKey
+                | IpnsRegistryError::InvalidPublicKey(_) => StatusCode::UNAUTHORIZED,
+                IpnsRegistryError::InvalidCid(_) => StatusCode::BAD_REQUEST,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            Err((code, format!("ipns publish: {e}")))
+        }
     }
 }
 
@@ -13562,6 +13649,14 @@ mod tests {
             (
                 super::NSID_BLOCK_GET,
                 include_str!("../../../lexicons/com/etzhayyim/apps/kotoba/block/get.json"),
+            ),
+            (
+                super::NSID_IPNS_HEAD,
+                include_str!("../../../lexicons/com/etzhayyim/apps/kotoba/ipns/head.json"),
+            ),
+            (
+                super::NSID_IPNS_PUBLISH,
+                include_str!("../../../lexicons/com/etzhayyim/apps/kotoba/ipns/publish.json"),
             ),
             (
                 super::NSID_COMMIT_GET,

--- a/crates/kotoba-server/tests/e2e_test.rs
+++ b/crates/kotoba-server/tests/e2e_test.rs
@@ -534,6 +534,123 @@ async fn graph_query_accepts_cacao_graph_query_operation_scope_on_private_graph(
 }
 
 #[tokio::test]
+async fn ipns_publish_advances_head_and_round_trips_via_ipns_head() {
+    use ed25519_dalek::SigningKey;
+    use kotoba_ipns_record::IpnsRecord;
+
+    let s = TestServer::start(false).await;
+    let tok = tenant_jwt(&s.operator_did);
+
+    // Obtain a real committed commit CID to use as the head value (a valid IpldCid
+    // string — `value_cid()` parses it on publish).
+    let seed_graph = kotoba_core::cid::KotobaCid::from_bytes(b"ipns-publish-seed").to_multibase();
+    let (status, tx) = s
+        .post_auth(
+            "/xrpc/com.etzhayyim.apps.kotoba.datomic.transact",
+            json!({ "graph": seed_graph, "tx_edn": r#"[{:db/id "x" :k/v "v"}]"# }),
+            &tok,
+        )
+        .await;
+    assert_eq!(status, 200, "{tx}");
+    let head_value = tx["commit_cid"].as_str().expect("commit cid").to_string();
+
+    // A fresh, never-committed graph — no prior head, so sequence 1 is accepted.
+    let graph = kotoba_core::cid::KotobaCid::from_bytes(b"ipns-publish-e2e").to_multibase();
+    // The graph head name the server reads under (mirrors distributed_graph_ipns_name).
+    let name = format!("k51-kotoba-{graph}");
+
+    // Build + member-sign the record locally (what KotobaNode.commitHeadSigned does).
+    let sk = SigningKey::from_bytes(&[7u8; 32]);
+    let mut record = IpnsRecord::with_value_string(&name, head_value.clone(), 1, "2030-01-01T00:00:00Z");
+    record.sign_ed25519(&sk).expect("sign record");
+    let record_json = serde_json::to_value(&record).expect("record json");
+
+    // Publish — authority is the signature, not a server credential (no auth header).
+    let (status, body) = s
+        .post("/xrpc/com.etzhayyim.apps.kotoba.ipns.publish", record_json.clone())
+        .await;
+    assert_eq!(status, 200, "{body}");
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["name"], name);
+
+    // Read it back via ipns.head — the published head round-trips.
+    let (status, head) = s
+        .get(&format!(
+            "/xrpc/com.etzhayyim.apps.kotoba.ipns.head?graph={graph}"
+        ))
+        .await;
+    assert_eq!(status, 200, "{head}");
+    assert_eq!(head["value"], head_value, "{head}");
+    assert_eq!(head["sequence"], 1, "{head}");
+
+    // Stale sequence (CAS) → 409.
+    let (status, b2) = s
+        .post("/xrpc/com.etzhayyim.apps.kotoba.ipns.publish", record_json)
+        .await;
+    assert_eq!(status, 409, "{b2}");
+
+    // Unsigned record → 401 (signature is the authority).
+    let unsigned = IpnsRecord::with_value_string(&name, head_value, 2, "2030-01-01T00:00:00Z");
+    let (status, b3) = s
+        .post(
+            "/xrpc/com.etzhayyim.apps.kotoba.ipns.publish",
+            serde_json::to_value(&unsigned).unwrap(),
+        )
+        .await;
+    assert_eq!(status, 401, "{b3}");
+}
+
+#[tokio::test]
+async fn ipns_head_resolves_signed_record_for_committed_graph() {
+    let s = TestServer::start(false).await;
+    let tok = tenant_jwt(&s.operator_did);
+    let graph = kotoba_core::cid::KotobaCid::from_bytes(b"ipns-head-e2e").to_multibase();
+
+    // A distributed transact publishes the graph's mutable IPNS head (seq 1).
+    let (status, tx_body) = s
+        .post_auth(
+            "/xrpc/com.etzhayyim.apps.kotoba.datomic.transact",
+            json!({
+                "graph": graph,
+                "tx_edn": r#"[{:db/id "alice" :person/name "Alice"}]"#
+            }),
+            &tok,
+        )
+        .await;
+    assert_eq!(status, 200, "{tx_body}");
+
+    // ipns.head resolves that head — UNAUTHENTICATED, self-verifying record.
+    let (status, head) = s
+        .get(&format!(
+            "/xrpc/com.etzhayyim.apps.kotoba.ipns.head?graph={graph}"
+        ))
+        .await;
+    assert_eq!(status, 200, "{head}");
+    assert!(
+        head["name"]
+            .as_str()
+            .unwrap_or_default()
+            .starts_with("k51-kotoba-"),
+        "{head}"
+    );
+    assert_eq!(head["sequence"], 1, "{head}");
+    let value = head["value"].as_str().expect("head value");
+    assert!(
+        kotoba_core::cid::KotobaCid::from_multibase(value).is_some(),
+        "head value must be a valid CID: {head}"
+    );
+
+    // Unknown graph → 404: a node cannot fabricate a head it never committed.
+    let other = kotoba_core::cid::KotobaCid::from_bytes(b"ipns-head-absent").to_multibase();
+    let (status, _b) = s
+        .get(&format!(
+            "/xrpc/com.etzhayyim.apps.kotoba.ipns.head?graph={other}"
+        ))
+        .await;
+    assert_eq!(status, 404, "{_b}");
+}
+
+#[tokio::test]
 async fn datomic_transact_q_pull_history_roundtrip_via_distributed_head() {
     let s = TestServer::start(false).await;
     let tok = tenant_jwt(&s.operator_did);

--- a/crates/kotoba-wasm/src/lib.rs
+++ b/crates/kotoba-wasm/src/lib.rs
@@ -577,6 +577,50 @@ impl Node {
         .map_err(|e| e.to_string())
     }
 
+    /// Decode a **CID-verified** commit block (the `value` of a signed IPNS head
+    /// points at a `DistributedDatomCommit`) and return its covering ProllyTree
+    /// index roots as JSON `{ "eavt": "<cid>", "aevt": …, … }`.
+    ///
+    /// `bytes` must hash to `commit_cid` (same content-address check as
+    /// `ingestBlock`), so the EAVT root is **derived from the verified head**
+    /// rather than trusted from a server's `datomic.sync`. This closes the trust
+    /// gap in `hydrate-and-query-verified!`: head signature (kotoba.ipns) →
+    /// commit CID → index roots, every hop either signature- or CID-checked.
+    pub fn commit_index_roots(commit_cid: &str, bytes: &[u8]) -> Result<String, String> {
+        // Partial, wasm-safe view of `kotoba_datomic::distributed::DistributedDatomCommit`.
+        // That type lives behind `#[cfg(not(wasm32))]` (it pulls tokio), but the
+        // commit is encoded as a CBOR **map** keyed by field name, so a struct
+        // declaring only `index_roots` decodes the same bytes — serde ignores the
+        // other keys. KotobaCid (kotoba-core, shared) decodes identically here.
+        #[derive(serde::Deserialize)]
+        struct CommitIndexRootsView {
+            #[serde(default)]
+            index_roots: HashMap<String, KotobaCid>,
+        }
+
+        let cid = KotobaCid::from_multibase(commit_cid)
+            .ok_or_else(|| format!("bad commit CID: {commit_cid}"))?;
+        let actual = KotobaCid::from_bytes(bytes);
+        if actual != cid {
+            return Err(format!(
+                "commit CID mismatch: claimed {} != actual {}",
+                cid.to_multibase(),
+                actual.to_multibase()
+            ));
+        }
+        let view: CommitIndexRootsView = ciborium::from_reader(bytes)
+            .map_err(|e| format!("decode commit DAG-CBOR: {e}"))?;
+        if view.index_roots.is_empty() {
+            return Err("commit block has no index_roots".to_string());
+        }
+        let roots: std::collections::BTreeMap<String, String> = view
+            .index_roots
+            .iter()
+            .map(|(k, v)| (k.clone(), v.to_multibase()))
+            .collect();
+        serde_json::to_string(&roots).map_err(|e| e.to_string())
+    }
+
     /// yoro-style actor search: scan `:yoro.profile/*` Datoms, group by entity,
     /// and return profiles whose did/handle/displayName/description contains `q`
     /// (case-insensitive). Empty `q` returns all. This mirrors
@@ -1121,12 +1165,64 @@ mod wasm {
                 .datomic_q(query_edn, inputs_json)
                 .map_err(|e| JsValue::from_str(&e))
         }
+
+        /// Decode a CID-verified commit block (the `value` of a signed IPNS head)
+        /// → covering ProllyTree index roots as JSON `{ "eavt": "<cid>", … }`.
+        /// Lets the browser derive the EAVT root from the verified head instead
+        /// of trusting `datomic.sync` (closes `hydrate-and-query-verified!`).
+        #[wasm_bindgen(js_name = commitIndexRoots)]
+        pub fn commit_index_roots(&self, commit_cid: &str, bytes: &[u8]) -> Result<String, JsValue> {
+            Node::commit_index_roots(commit_cid, bytes).map_err(|e| JsValue::from_str(&e))
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn commit_index_roots_extracts_roots_from_verified_block() {
+        use kotoba_datomic::distributed::DistributedDatomCommit;
+        use std::collections::HashMap;
+
+        let eavt = KotobaCid::from_bytes(b"eavt-root");
+        let mut index_roots = HashMap::new();
+        index_roots.insert("eavt".to_string(), eavt.clone());
+        index_roots.insert("aevt".to_string(), KotobaCid::from_bytes(b"aevt-root"));
+
+        let commit = DistributedDatomCommit {
+            cid: KotobaCid::from_bytes(b"ignored-not-serialized"),
+            graph: KotobaCid::from_bytes(b"graph"),
+            tx_cid: KotobaCid::from_bytes(b"tx"),
+            prev: None,
+            parents: vec![],
+            author: "did:web:test".to_string(),
+            seq: 1,
+            ts: 0,
+            hlc: 0,
+            index_roots,
+            cacao_proof_cid: None,
+            author_sig: None,
+        };
+        let mut bytes = Vec::new();
+        ciborium::into_writer(&commit, &mut bytes).expect("encode commit");
+        let cid = KotobaCid::from_bytes(&bytes);
+
+        // Correct CID → decode + extract roots.
+        let json = Node::commit_index_roots(&cid.to_multibase(), &bytes).expect("decode roots");
+        let map: std::collections::BTreeMap<String, String> =
+            serde_json::from_str(&json).expect("roots json");
+        assert_eq!(map.get("eavt"), Some(&eavt.to_multibase()));
+        assert_eq!(map.len(), 2);
+
+        // Wrong CID (tampered/spoofed) → rejected before decode (trustless).
+        let wrong = KotobaCid::from_bytes(b"a-different-cid");
+        assert!(
+            Node::commit_index_roots(&wrong.to_multibase(), &bytes).is_err(),
+            "CID mismatch must be rejected"
+        );
+    }
 
     #[test]
     fn search_actors_over_in_wasm_read_engine() {

--- a/crates/kotoba-wasm/web/.gitignore
+++ b/crates/kotoba-wasm/web/.gitignore
@@ -1,0 +1,3 @@
+
+# ClojureScript ESM build output (shadow-cljs release web)
+cljs-out/

--- a/crates/kotoba-wasm/web/cljs/.gitignore
+++ b/crates/kotoba-wasm/web/cljs/.gitignore
@@ -1,0 +1,5 @@
+# shadow-cljs / npm build artifacts — the ESM output lives in ../cljs-out
+/node_modules/
+/.shadow-cljs/
+/.cpcache/
+package-lock.json

--- a/crates/kotoba-wasm/web/cljs/README.md
+++ b/crates/kotoba-wasm/web/cljs/README.md
@@ -1,0 +1,67 @@
+# kotoba browser read-plane — ClojureScript
+
+ClojureScript glue for the in-browser kotoba node. Implements
+**docs/ADR-browser-cid-query-vs-p2p.md**: a browser queries a *pinned* graph with
+**zero peer connection**, because query is content-addressed.
+
+```
+resolve+verify signed head   →   sync covering index roots
+   (kotoba.ipns, gateway-untrusted)       (datomic.sync)
+        │                                      │
+        └──────────────┬───────────────────────┘
+                       ▼
+        CID-verified block pull (block.get)  →  hydrateFromProlly  →  datomicQ
+                       kotoba.node — all in-browser, no libp2p / WebRTC
+```
+
+## Namespaces
+
+| ns             | what                                                                    |
+|----------------|-------------------------------------------------------------------------|
+| `kotoba.ipns`  | `resolve-head` / `verify-record` — member-signed IPNS head, verified in-wasm (`KotobaNode.verifyIpnsRecord`). Whoever serves the record is untrusted. |
+| `kotoba.idb`   | IndexedDB persistence (DB `kotoba-node` v2): `snapshots` + `rawblocks` stores. |
+| `kotoba.blocks`| CID-verified, IndexedDB-cached block sync: `block-get`, `hydrate-via-blocks`, `hydrate-from-idb-blocks`. |
+| `kotoba.node`  | `hydrate-and-query!` (works today, head via `datomic.sync`), `hydrate-and-query-verified!` (fully trustless head), plus `hydrate!` / `query` / `sync-index-roots`. |
+| `kotoba.write` | `publish!` — trustless write: `block.put` push + `ipns.publish` (member-signed head advance). Sovereign/DID-scoped graphs only; shared graphs use CACAO `datomic.transact`. |
+
+Trust lives in the CID (`ingestBlock` re-derives `sha2-256(dag-cbor)` and rejects
+mismatches) and, for the mutable head, in the Ed25519 signature — never in the
+transport. That is why no P2P is needed for read.
+
+## Build
+
+```sh
+npm install            # once — pulls shadow-cljs
+npm run build          # release → ../cljs-out/kotoba-node.js (ESM)
+npm run watch          # dev, hot-reload
+```
+
+Output is `../cljs-out/kotoba-node.js`, importable as ESM.
+
+## Use from the Service Worker (kotoba-sw.js)
+
+```js
+import { hydrateAndQuery } from "./cljs-out/kotoba-node.js";
+
+// answer a datomic.q POST entirely in-browser:
+const resultJson = await hydrateAndQuery(
+  node, GRAPH, req.query_edn, req.inputs_edn, { remote: REMOTE });
+```
+
+`hydrate-and-query-verified!` additionally verifies the signed head first, via
+`GET /xrpc/com.etzhayyim.apps.kotoba.ipns.head?graph=<cid>` (now implemented —
+`xrpc::ipns_head`, lexicon `ipns/head.json`).
+
+## Status
+
+- `npm run build` → **0 cljs warnings**, emits `kotoba-node.js`.
+- Read plane (`hydrate-and-query!`) is exercisable today against any
+  `kotoba-server` that serves `datomic.sync` + `block.get` (Public graphs).
+- `hydrate-and-query-verified!` is now fully trustless: signed `ipns.head`
+  (`xrpc::ipns_head`) → `commitIndexRoots` derives the EAVT root from the verified
+  head → CID-verified block sync. No `datomic.sync` trust on that path.
+- `kotoba.write/publish!` completes the symmetric, signature-authorized write path
+  (`block.put` + `ipns.publish`) for sovereign graphs.
+- The original `kotoba-blocks.js` / `kotoba-idb.js` are superseded by
+  `kotoba.blocks` / `kotoba.idb` (the JS files remain until `kotoba-sw.js`, itself
+  still JS, is migrated to import the cljs `cljs-out/kotoba-node.js`).

--- a/crates/kotoba-wasm/web/cljs/package.json
+++ b/crates/kotoba-wasm/web/cljs/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "kotoba-web-cljs",
+  "version": "0.1.0",
+  "private": true,
+  "description": "ClojureScript read-plane glue for the kotoba browser node (IPNS head resolution + CID-verified query orchestration). Emits ESM into ../cljs-out.",
+  "scripts": {
+    "build": "shadow-cljs release web",
+    "watch": "shadow-cljs watch web"
+  },
+  "devDependencies": {
+    "shadow-cljs": "^2.28.0"
+  }
+}

--- a/crates/kotoba-wasm/web/cljs/shadow-cljs.edn
+++ b/crates/kotoba-wasm/web/cljs/shadow-cljs.edn
@@ -1,0 +1,30 @@
+;; shadow-cljs.edn — ClojureScript build for the kotoba browser read-plane glue.
+;;
+;; Emits ESM modules into ../cljs-out so the Service Worker (kotoba-sw.js) and the
+;; demos can `import { hydrateAndQuery, resolveHead } from "./cljs-out/kotoba-node.js"`.
+;; The lower-level CID-verified block engine and the wasm node itself stay where
+;; they are; this layer owns IPNS-head resolution + query orchestration in cljs.
+;;
+;; Build:  npx shadow-cljs release web      (prod)
+;;         npx shadow-cljs watch   web      (dev, hot-reload)
+{:source-paths ["src"]
+ :dependencies []
+ :builds
+ {:web
+  {:target     :esm
+   :runtime    :browser
+   :output-dir "../cljs-out"
+   :modules
+   {:kotoba-node
+    {:exports {resolveHead     kotoba.ipns/resolve-head
+               verifyRecord    kotoba.ipns/verify-record
+               hydrate         kotoba.node/hydrate!
+               query           kotoba.node/query
+               syncIndexRoots  kotoba.node/sync-index-roots
+               hydrateAndQuery        kotoba.node/hydrate-and-query!
+               hydrateAndQueryVerified kotoba.node/hydrate-and-query-verified!
+               hydrateViaBlocks     kotoba.blocks/hydrate-via-blocks
+               hydrateFromIdbBlocks kotoba.blocks/hydrate-from-idb-blocks
+               getSnapshot     kotoba.idb/get-snapshot
+               putSnapshot     kotoba.idb/put-snapshot
+               publish         kotoba.write/publish!}}}}}}

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/blocks.cljs
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/blocks.cljs
@@ -1,0 +1,111 @@
+(ns kotoba.blocks
+  "CID-verified block sync for the browser kotoba node — ClojureScript port of
+   kotoba-blocks.js (ADR-2606013600 D5 / 2606022150).
+
+   BFS the canonical Prolly tree over content-addressed blocks, pulling each
+   missing block (IndexedDB cache first, else `block.get` from a holder), handing
+   it to `node.ingestBlock(cid, bytes)` which **re-derives and matches the CID**
+   (rejecting tampered blocks), then persisting it. Repeat until none missing,
+   then `node.hydrateFromProlly(root)`.
+
+   The byte source is untrusted because trust lives in the CID — block.get on any
+   kotoba-server, gateway, or the local IndexedDB cache are interchangeable."
+  (:require [kotoba.idb :as idb]))
+
+;; ── base64 <-> bytes (block.get returns {data_b64}; block.put takes data_b64) ──
+
+(defn b64->bytes [b64]
+  (let [bin (js/atob b64)
+        n   (.-length bin)
+        out (js/Uint8Array. n)]
+    (dotimes [i n] (aset out i (.charCodeAt bin i)))
+    out))
+
+(defn bytes->b64 [^js bytes]
+  (let [n (.-length bytes)
+        cs (make-array n)]
+    (dotimes [i n] (aset cs i (js/String.fromCharCode (aget bytes i))))
+    (js/btoa (.join cs ""))))
+
+;; ── block.get (Public, unauthenticated) ──────────────────────────────────────
+
+(defn block-get
+  "Fetch one block by CID from `remote`'s content-addressed gateway.
+   `com.etzhayyim.apps.kotoba.block.get?cid=...` → {data_b64}. Returns
+   Promise<Uint8Array>. CID verification is the caller's (in-wasm) on ingest."
+  ([remote cid] (block-get remote cid js/fetch))
+  ([remote cid fetch-fn]
+   (-> (fetch-fn (str remote
+                      "/xrpc/com.etzhayyim.apps.kotoba.block.get?cid="
+                      (js/encodeURIComponent cid)))
+       (.then (fn [^js r]
+                (if (.-ok r)
+                  (.json r)
+                  (throw (js/Error. (str "block.get " cid " → HTTP " (.-status r)))))))
+       (.then (fn [^js j]
+                (let [b64 (.-data_b64 j)]
+                  (when-not b64
+                    (throw (js/Error. (str "block.get " cid " → no data_b64"))))
+                  (b64->bytes b64)))))))
+
+;; ── hydrate via CID-verified block sync ──────────────────────────────────────
+
+(defn hydrate-via-blocks
+  "Hydrate `node` by syncing the Prolly tree rooted at `root` over CID-verified
+   blocks (IndexedDB first, then `remote`), then traversing it locally.
+
+   `node` exposes ingestBlock / missingBlockCids / hydrateFromProlly.
+   opts: :remote (REQUIRED) :fetch-fn :max-rounds (default 64).
+   Returns Promise<datom-count>."
+  [^js node root {:keys [remote fetch-fn max-rounds]
+                  :or   {fetch-fn js/fetch max-rounds 64}}]
+  (js/Promise.
+   (fn [resolve reject]
+     (letfn [(pull-one [cid]
+               (-> (idb/get-block cid)
+                   (.then (fn [cached]
+                            (if cached
+                              cached
+                              (-> (block-get remote cid fetch-fn)
+                                  (.then (fn [bytes]
+                                           ;; durable for cold start — only after fetch
+                                           (-> (idb/put-block cid bytes)
+                                               (.then (fn [_] bytes)))))))))
+                   (.then (fn [bytes]
+                            (.ingestBlock node cid bytes))))) ; throws on CID mismatch
+             (round [n]
+               (let [missing (vec (.missingBlockCids node root))]
+                 (cond
+                   (zero? (count missing)) (resolve (.hydrateFromProlly node root))
+                   (> n max-rounds)        (reject (js/Error. "block sync did not converge"))
+                   :else
+                   (-> (js/Promise.all (clj->js (map pull-one missing)))
+                       (.then (fn [_] (round (inc n))))
+                       (.catch reject)))))]
+       (round 0)))))
+
+(defn hydrate-from-idb-blocks
+  "Pre-seed `node` from IndexedDB ONLY (offline cold start). Returns
+   Promise<datom-count | nil> — nil when the tree is not fully cached offline, so
+   the caller falls back to `hydrate-via-blocks`."
+  [^js node root]
+  (js/Promise.
+   (fn [resolve reject]
+     (letfn [(round [n]
+               (let [missing (vec (.missingBlockCids node root))]
+                 (if (zero? (count missing))
+                   (resolve (.hydrateFromProlly node root))
+                   (-> (js/Promise.all
+                        (clj->js (map (fn [cid]
+                                        (-> (idb/get-block cid)
+                                            (.then (fn [bytes]
+                                                     (when bytes (.ingestBlock node cid bytes))
+                                                     (boolean bytes)))))
+                                      missing)))
+                       (.then (fn [^js progressed]
+                                (cond
+                                  (not (some identity (array-seq progressed))) (resolve nil)
+                                  (> n 64) (resolve nil)
+                                  :else (round (inc n)))))
+                       (.catch reject)))))]
+       (round 0)))))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/idb.cljs
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/idb.cljs
@@ -1,0 +1,93 @@
+(ns kotoba.idb
+  "IndexedDB persistence for the browser kotoba node — ClojureScript port of
+   kotoba-idb.js + the rawblocks store from kotoba-blocks.js (ADR-2606013600 P1/D5).
+
+   One database `kotoba-node` (v2) with two object stores:
+     - `snapshots`  (keyPath \"graph\")  — one canonical snapshot row per graph
+     - `rawblocks`  (key = CID multibase) — content-addressed Prolly blocks
+
+   Content-addressing makes the rawblocks store trustless: callers re-verify the
+   CID on ingest (`kotoba.blocks`), so a tampered block never reaches the read
+   engine. A cold start replays the tree from `rawblocks` with zero network.
+
+   Zero external deps — raw `js/Promise` interop, same style as kotoba.node.")
+
+(def ^:private db-name "kotoba-node")
+(def ^:private db-version 2)
+(def ^:private snap-store "snapshots")
+(def ^:private block-store "rawblocks")
+
+(defonce ^:private db-promise (atom nil))
+
+(defn- open-db []
+  (or @db-promise
+      (reset! db-promise
+              (js/Promise.
+               (fn [resolve reject]
+                 (let [req (.open js/indexedDB db-name db-version)]
+                   (set! (.-onupgradeneeded req)
+                         (fn [_]
+                           (let [db    (.-result req)
+                                 names (.-objectStoreNames db)]
+                             (when-not (.contains names snap-store)
+                               (.createObjectStore db snap-store #js {:keyPath "graph"}))
+                             (when-not (.contains names block-store)
+                               (.createObjectStore db block-store)))))
+                   (set! (.-onsuccess req) (fn [_] (resolve (.-result req))))
+                   (set! (.-onerror req) (fn [_] (reject (.-error req))))))))))
+
+(defn- request->promise [^js req]
+  (js/Promise.
+   (fn [resolve reject]
+     (set! (.-onsuccess req) (fn [_] (resolve (.-result req))))
+     (set! (.-onerror req) (fn [_] (reject (.-error req)))))))
+
+(defn- store [^js db name mode]
+  (-> db (.transaction name mode) (.objectStore name)))
+
+;; ── snapshots (one row per graph) ────────────────────────────────────────────
+
+(defn get-snapshot
+  "Load the persisted snapshot row for `graph`, or nil. Returns Promise."
+  [graph]
+  (-> (open-db)
+      (.then (fn [^js db] (request->promise (.get (store db snap-store "readonly") graph))))
+      (.then (fn [r] (or r nil)))))
+
+(defn put-snapshot
+  "Persist `{:datomsJson :cid :count}` (JS object) for `graph`. Returns Promise<row>."
+  [graph ^js snap]
+  (-> (open-db)
+      (.then (fn [^js db]
+               (let [row #js {:graph      graph
+                              :datomsJson (.-datomsJson snap)
+                              :cid        (.-cid snap)
+                              :count      (.-count snap)
+                              :ts         (js/Date.now)}]
+                 (-> (request->promise (.put (store db snap-store "readwrite") row))
+                     (.then (fn [_] row))))))))
+
+(defn clear-snapshot
+  "Drop the persisted snapshot for `graph` (debug / forced reseed). Returns Promise."
+  [graph]
+  (-> (open-db)
+      (.then (fn [^js db]
+               (request->promise (.delete (store db snap-store "readwrite") graph))))
+      (.then (fn [_] nil))))
+
+;; ── raw blocks (CID → bytes) ─────────────────────────────────────────────────
+
+(defn get-block
+  "Fetch a raw block by CID multibase, or nil. Returns Promise<Uint8Array|nil>."
+  [cid]
+  (-> (open-db)
+      (.then (fn [^js db] (request->promise (.get (store db block-store "readonly") cid))))
+      (.then (fn [r] (when r (js/Uint8Array. r))))))
+
+(defn put-block
+  "Persist raw `bytes` (Uint8Array) under `cid` (durable for cold start). Returns Promise."
+  [cid ^js bytes]
+  (-> (open-db)
+      (.then (fn [^js db]
+               (request->promise (.put (store db block-store "readwrite") bytes cid))))
+      (.then (fn [_] nil))))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/ipns.cljs
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/ipns.cljs
@@ -1,0 +1,70 @@
+(ns kotoba.ipns
+  "IPNS head resolution for the kotoba browser node — gateway-untrusted.
+
+   The mutable head of a graph is a member-signed `IpnsRecord`
+   (crates/kotoba-ipns-record): `{name, value, sequence, valid_until,
+   public_key_multibase, signature_multibase}`, where `value` is the head/commit
+   CID (multibase). The consumer verifies the Ed25519 signature IN-WASM via
+   `KotobaNode.verifyIpnsRecord`, so whichever server/gateway served the record is
+   NOT trusted (no-server-key): a malicious holder can withhold a newer head but
+   cannot forge one.
+
+   See docs/ADR-browser-cid-query-vs-p2p.md §1. Query is content-addressed; this
+   is the only step where trust is not already carried by a CID, so it is the only
+   step that needs a signature check.")
+
+(defn verify-record
+  "Verify a canonical `IpnsRecord` JSON string against its embedded Ed25519
+   signature, in-wasm. `node-class` is the `KotobaNode` wasm class export (it
+   exposes the static `verifyIpnsRecord`). Returns a boolean — true iff a
+   signature + public key are present and verify over the canonical CBOR payload."
+  [^js node-class ^string record-json]
+  (boolean (.verifyIpnsRecord node-class record-json)))
+
+(defn- parse-record [record-json]
+  (js->clj (js/JSON.parse record-json) :keywordize-keys true))
+
+(defn resolve-head
+  "Resolve and verify the signed head record for `graph` from `remote`.
+
+   opts:
+     :node-class          the KotobaNode wasm class — REQUIRED for verification
+     :remote              base URL of a kotoba-server / gateway — REQUIRED
+     :require-signature?  default true — reject unsigned / invalid records
+     :fetch-fn            override fetch (testing); (fn [url] -> Promise<Response>)
+
+   Returns Promise resolving to a JS object:
+     {head: <commit/root CID multibase>,
+      sequence: <int>, validUntil: <string>,
+      verified: <bool>, record: <parsed object>, raw: <json string>}
+
+   With :require-signature? true the returned head is gateway-untrusted.
+
+   Backed by `GET /xrpc/com.etzhayyim.apps.kotoba.ipns.head?graph=<cid>`
+   (xrpc::ipns_head) — UNAUTHENTICATED, returns the member-signed IpnsRecord.
+   Callers that only need today's (server-asserted) head can instead use
+   `kotoba.node/hydrate-and-query!`, which goes through `datomic.sync`."
+  [graph {:keys [node-class remote require-signature? fetch-fn]
+          :or   {require-signature? true fetch-fn js/fetch}}]
+  (when (nil? node-class)
+    (throw (js/Error. "resolve-head: :node-class (KotobaNode) is required for signature verification")))
+  (-> (fetch-fn (str remote
+                     "/xrpc/com.etzhayyim.apps.kotoba.ipns.head?graph="
+                     (js/encodeURIComponent graph)))
+      (.then (fn [^js r]
+               (if (.-ok r)
+                 (.text r)
+                 (throw (js/Error. (str "ipns.head " graph " → HTTP " (.-status r)))))))
+      (.then (fn [json]
+               (let [verified (verify-record node-class json)]
+                 (when (and require-signature? (not verified))
+                   (throw (js/Error.
+                           (str "ipns.head " graph
+                                " → signature INVALID/absent — refusing untrusted head"))))
+                 (let [rec (parse-record json)]
+                   #js {:head       (:value rec)
+                        :sequence   (:sequence rec)
+                        :validUntil (:valid_until rec)
+                        :verified   verified
+                        :record     (clj->js rec)
+                        :raw        json}))))))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/node.cljs
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/node.cljs
@@ -1,0 +1,105 @@
+(ns kotoba.node
+  "Browser read-plane orchestrator (ClojureScript).
+
+   The whole point of docs/ADR-browser-cid-query-vs-p2p.md: a browser queries a
+   pinned graph with ZERO peer connection. Query is content-addressed, so the
+   flow is just
+
+     (verify signed head) → sync covering index roots → CID-verified block pull
+       → traverse locally → Datalog
+
+   No libp2p, no WebRTC. `node` is a wasm `KotobaNode` instance exposing
+   missingBlockCids / ingestBlock / hydrateFromProlly / datomicQ. The CID-verified
+   block sync + IndexedDB cache live in `kotoba.blocks`."
+  (:require [kotoba.ipns :as ipns]
+            [kotoba.blocks :as blocks]))
+
+;; ── covering index roots ─────────────────────────────────────────────────────
+
+(defn sync-index-roots
+  "POST datomic.sync → JS response carrying `index_roots` ({eavt,aevt,…} → CID)
+   and `ipns_sequence`. Returns Promise<response-object>."
+  ([graph remote] (sync-index-roots graph remote js/fetch))
+  ([graph remote fetch-fn]
+   (-> (fetch-fn (str remote "/xrpc/com.etzhayyim.apps.kotoba.datomic.sync")
+                 #js {:method  "POST"
+                      :headers #js {"content-type" "application/json"}
+                      :body    (js/JSON.stringify #js {:graph graph})})
+       (.then (fn [^js r]
+                (if (.-ok r)
+                  (.json r)
+                  (throw (js/Error. (str "datomic.sync → HTTP " (.-status r))))))))))
+
+;; ── CID-verified block sync (delegates to kotoba.blocks: IndexedDB + block.get) ─
+
+(defn hydrate!
+  "Pull every block reachable from EAVT `root` (CID-verified, IndexedDB-cached)
+   into `node`, then traverse it locally. Returns Promise<datom-count>.
+   opts: :remote (REQUIRED) :fetch-fn :max-rounds (default 64)."
+  [^js node root opts]
+  (blocks/hydrate-via-blocks node root opts))
+
+;; ── local Datalog ────────────────────────────────────────────────────────────
+
+(defn query
+  "Run a Datomic-style Datalog query entirely in-browser. `inputs` is a JS array
+   (or nil). Returns the result JSON string from the wasm engine."
+  [^js node query-edn inputs]
+  (.datomicQ node query-edn (js/JSON.stringify (or inputs #js []))))
+
+;; ── full round-trips ─────────────────────────────────────────────────────────
+
+(defn- eavt-root [^js sync]
+  (some-> (.-index_roots sync) (aget "eavt")))
+
+(defn hydrate-and-query!
+  "Works TODAY. Read-plane round-trip with no peer connection, head taken from
+   `datomic.sync` (server-asserted index roots):
+
+     datomic.sync → CID-verified block pull → local Datalog.
+
+   opts: :remote (REQUIRED) :fetch-fn :max-rounds.
+   Returns Promise<query-result-json>."
+  [node graph query-edn inputs {:keys [remote fetch-fn] :as opts}]
+  (-> (sync-index-roots graph remote (or fetch-fn js/fetch))
+      (.then (fn [^js sync]
+               (let [root (eavt-root sync)]
+                 (when-not root
+                   (throw (js/Error. "datomic.sync returned no eavt index root")))
+                 (-> (hydrate! node root opts)
+                     (.then (fn [_] (query node query-edn inputs)))))))))
+
+(defn fetch-commit-roots
+  "Fetch the verified head commit block by CID (block.get, CID-verified) and
+   decode its covering ProllyTree index roots in-wasm. Returns Promise<#js{eavt,…}>.
+   `node` must expose `commitIndexRoots` (which re-checks the CID before decoding)."
+  [^js node head-cid remote fetch-fn]
+  (-> (blocks/block-get remote head-cid fetch-fn)
+      (.then (fn [bytes]
+               (js/JSON.parse (.commitIndexRoots node head-cid bytes))))))
+
+(defn hydrate-and-query-verified!
+  "Fully trustless read-plane round-trip — NO server trust anywhere:
+
+     verify signed head (ipns.head + KotobaNode.verifyIpnsRecord)
+       -> head CID -> commit block (block.get, CID-verified)
+       -> commitIndexRoots -> EAVT root (derived from the VERIFIED head, not datomic.sync)
+       -> CID-verified block sync -> local Datalog.
+
+   Every hop is signature- or CID-checked, so the serving node/gateway is
+   untrusted end to end (closes ADR follow-up :wasm-commit-index-roots).
+
+   opts: :node-class (REQUIRED) :remote (REQUIRED) :require-signature?
+         :fetch-fn :max-rounds. Returns Promise<query-result-json>."
+  [^js node graph query-edn inputs {:keys [remote fetch-fn] :as opts}]
+  (let [fetch-fn (or fetch-fn js/fetch)]
+    (-> (ipns/resolve-head graph opts)
+        (.then (fn [^js head]
+                 (let [head-cid (.-head head)]
+                   (-> (fetch-commit-roots node head-cid remote fetch-fn)
+                       (.then (fn [^js roots]
+                                (let [root (aget roots "eavt")]
+                                  (when-not root
+                                    (throw (js/Error. "verified head commit has no eavt index root")))
+                                  (-> (hydrate! node root opts)
+                                      (.then (fn [_] (query node query-edn inputs))))))))))))))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/write.cljs
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/write.cljs
@@ -1,0 +1,72 @@
+(ns kotoba.write
+  "Browser write path — publish a member-signed commit to a holder, trustlessly.
+
+   Symmetric to the read plane: the browser builds a content-addressed,
+   member-signed commit entirely locally (`KotobaNode.assert` → `commitHeadSigned`
+   → `exportBlocks`), then publishes it:
+
+     block.put   each captured Prolly block (content-addressed; server recomputes
+                 the CID, so the holder can't substitute bytes)
+     ipns.publish the member-signed IpnsRecord (advances the head)
+
+   AUTHORITY is the Ed25519 signature over a key-derived IPNS name, NOT a server
+   credential — the holder is an untrusted relay. This is takeover-proof exactly
+   for sovereign / DID-scoped graphs (the name binds to the signing key). For a
+   SHARED graph whose head name is not key-derived, signatures alone don't grant
+   write access; use the CACAO-gated `datomic.transact` path instead.
+   See docs/ADR-browser-cid-query-vs-p2p.md."
+  (:require [kotoba.blocks :as blocks]))
+
+(defn- hex->bytes [hex]
+  (let [n   (quot (.-length hex) 2)
+        out (js/Uint8Array. n)]
+    (dotimes [i n]
+      (aset out i (js/parseInt (.substr hex (* 2 i) 2) 16)))
+    out))
+
+(defn- block-put
+  "POST one content-addressed block; the server recomputes + returns its CID."
+  [remote ^js bytes fetch-fn]
+  (-> (fetch-fn (str remote "/xrpc/com.etzhayyim.apps.kotoba.block.put")
+                #js {:method  "POST"
+                     :headers #js {"content-type" "application/json"}
+                     :body    (js/JSON.stringify #js {:data_b64 (blocks/bytes->b64 bytes)})})
+      (.then (fn [^js r]
+               (if (.-ok r)
+                 (.json r)
+                 (throw (js/Error. (str "block.put → HTTP " (.-status r)))))))))
+
+(defn- ipns-publish
+  "POST a member-signed IpnsRecord JSON string to advance the head."
+  [remote ^string record-json fetch-fn]
+  (-> (fetch-fn (str remote "/xrpc/com.etzhayyim.apps.kotoba.ipns.publish")
+                #js {:method  "POST"
+                     :headers #js {"content-type" "application/json"}
+                     :body    record-json})
+      (.then (fn [^js r]
+               (if (.-ok r)
+                 (.json r)
+                 (-> (.text r)
+                     (.then (fn [t]
+                              (throw (js/Error. (str "ipns.publish → HTTP " (.-status r) " " t)))))))))))
+
+(defn publish!
+  "Publish the node's committed write-set to `remote`:
+     1. push every captured block via block.put (content-addressed),
+     2. advance the head via ipns.publish with the member-signed record.
+
+   `head-record-json` is the string returned by `KotobaNode.commitHeadSigned`
+   (which commits AND signs). Returns Promise<#js{blocks, publish}>.
+
+   The holder is untrusted: block bytes are CID-checked server-side, and the head
+   pointer is only as authoritative as the key that signed `head-record-json`."
+  [^js node head-record-json {:keys [remote fetch-fn] :or {fetch-fn js/fetch}}]
+  (let [blocks-arr (js/JSON.parse (.exportBlocks node))]
+    (-> (js/Promise.all
+         (clj->js (map (fn [^js b] (block-put remote (hex->bytes (.-hex b)) fetch-fn))
+                       (array-seq blocks-arr))))
+        (.then (fn [^js put-results]
+                 (-> (ipns-publish remote head-record-json fetch-fn)
+                     (.then (fn [^js pub]
+                              #js {:blocks  (.-length put-results)
+                                   :publish pub}))))))))

--- a/docs/ADR-browser-cid-query-vs-p2p.md
+++ b/docs/ADR-browser-cid-query-vs-p2p.md
@@ -1,0 +1,212 @@
+# ADR — Browser query is CID-addressed: read needs reachability, not peers
+
+Status: **Accepted — read plane ships with zero new transport; P2P deferred to an availability layer**
+Date: 2026-06-13
+Supersedes the framing in the earlier "browser participates in the libp2p mesh"
+discussion (it conflated *query* with *peering*).
+
+## 0. The insight that reframes everything
+
+> Query is content-addressed (by CID). Therefore a browser can query any data
+> that is **pinned and reachable by CID** — it does **not** need to be a libp2p
+> peer, join Kademlia, or hold a WebRTC/QUIC connection to anyone.
+
+The browser read engine already verifies every block against its CID
+(`CID == sha2-256(dag-cbor(bytes))`, `crates/kotoba-wasm/src/lib.rs:64`), so
+*whoever serves the bytes is untrusted*. Content-addressing collapses the trust
+question that P2P transport security would otherwise solve. Once trust is moved
+into the CID, "where did the bytes come from" stops mattering for correctness —
+HTTP from a random gateway is exactly as safe as bitswap from a verified peer.
+
+This ADR records the resulting split:
+
+- **Read plane** — CID-over-HTTP. Works **today**, no libp2p, no WebRTC.
+- **持ち合い / live plane** — P2P. An **availability/liveness optimization**,
+  not a correctness requirement. Deferred.
+
+## 1. Read plane — already designed and wired
+
+The query path for a browser node, end to end, with no peering:
+
+```
+resolve HEAD          KotobaNode.verifyIpnsRecord(json)         lib.rs:956
+   │                  member-signed IPNS record; the apex/gateway
+   │                  serving it is NOT trusted (no-server-key).
+   ▼
+root CID
+   │
+   ▼  ┌── loop until empty ──────────────────────────────────────────┐
+   │  │  missing = node.missingBlockCids(root)        lib.rs:847      │
+   │  │  for cid in missing:                                          │
+   │  │     bytes = GET /xrpc/com.etzhayyim.apps.kotoba.block.get     │  xrpc.rs:7561
+   │  │            ?cid=<multibase>          (UNAUTH for Public)      │  xrpc.rs:6008
+   │  │     node.ingestBlock(cid, bytes)     CID-verified  lib.rs:819 │
+   │  └──────────────────────────────────────────────────────────────┘
+   ▼
+node.hydrateFromProlly(root)                            lib.rs:829
+   │  same Prolly/IPLD scan_prefix path as the server
+   ▼
+node.datomicQ(query_edn, inputs_json)                   lib.rs:1118
+   │  full Datalog over EAVT/AEVT/AVET/VAET, same engine as datomic.q
+   ▼
+results — entirely local, zero round-trips after the blocks are in
+```
+
+Key properties:
+
+- **Already implemented and shipping — not a plan.** The fetch loop is
+  `hydrateViaBlocks()` in `crates/kotoba-wasm/web/kotoba-blocks.js`, and the
+  Service Worker `crates/kotoba-wasm/web/kotoba-sw.js` already:
+  (a) calls `datomic.sync` for the covering EAVT root,
+  (b) `hydrateViaBlocks(node, eavtRoot, {remote})` — `block.get` loop,
+      CID-verified, persisted to IndexedDB,
+  (c) **intercepts `datomic.q` POST and answers it locally in wasm**
+      (`node.datomicQ`, response tagged `x-kotoba-sw: local-wasm-datomic`).
+  A browser already serves Datalog queries against a pinned graph it pulled
+  purely over `block.get`, with no peer connection.
+- **No new Rust.** `block.get`, `ingestBlock`, `missingBlockCids`,
+  `hydrateFromProlly`, `datomicQ`, `verifyIpnsRecord` all exist.
+- **Server is consulted only for what the local engine genuinely can't answer:**
+  time-travel (`as_of` / `since` / `history`) and federation (`remote_peer` /
+  `remote_ipns_name`) fall through to the server (`kotoba-sw.js:213`); everything
+  at the current head is local.
+- **The byte source is interchangeable.** `block.get` on any `kotoba-server`
+  self-pin, the kotobase fanout pin (when F-4 lands), or *any* IPFS gateway
+  (`/ipfs/<cid>`) all serve the same CID. CID verification makes them equivalent.
+- **HEAD is gateway-untrusted.** The IPNS head is a member-signed record verified
+  in-wasm; a malicious gateway can withhold but cannot forge a newer head.
+- **Offline-first.** Once blocks are in IndexedDB (`IdbBlockStore`), query runs
+  with the network fully down.
+
+### Correctness invariant
+
+A browser can answer a query **iff** every block reachable from the resolved root
+is retrievable by CID from **at least one** reachable holder. Pinning is exactly
+the act of guaranteeing "at least one holder." Therefore:
+
+> **Pinned + one reachable `block.get`/gateway ⇒ query works. Peer connectivity is
+> not in this condition.**
+
+## 2. What P2P is actually for (and is NOT)
+
+P2P (libp2p over WebRTC/WebTransport — never QUIC; browsers have no UDP socket)
+buys exactly three things, all orthogonal to query correctness:
+
+| Capability | Why it needs P2P | Without it |
+|---|---|---|
+| **持ち合い** — browsers serve blocks to each other | removes single-holder dependency; survives the central pin/gateway being down | query still works as long as one `block.get`/gateway is up |
+| **live push** — subscribe to head updates (gossip firehose) | server-initiated; no polling | poll the IPNS head on an interval |
+| **provider discovery** — find a CID no known gateway holds | Kademlia provider records | query fails only for un-gatewayed CIDs |
+
+None of these change *what answers are correct*. They change *availability*
+(does a holder exist that I can reach) and *freshness latency* (how fast I learn
+of a new head). That is the correct altitude for P2P here: an availability layer,
+not the query substrate.
+
+## 3. Decision
+
+1. **The read plane already ships, with zero new transport.** The driver
+   (`datomic.sync → block.get loop → hydrateFromProlly → datomicQ`) exists as
+   `kotoba-blocks.js` + `kotoba-sw.js`. "A browser queries the global pinned
+   graph" is **already true today**. Remaining read-plane work is incremental:
+   IPNS-head resolution as a first-class JS helper (so a cold browser can start
+   from a signed head, not a server `datomic.sync` round-trip), and surfacing
+   `as_of`/`since` history locally instead of falling through to the server.
+2. **Do NOT build a libp2p wasm swarm for query.** It was over-scoped — query is
+   CID-addressed, so HTTP reachability is sufficient and strictly simpler.
+3. **Defer P2P to the availability layer.** When 持ち合い / live push / provider
+   discovery become requirements, add a wasm transport — and even then the choice
+   is **WebRTC (browser↔browser) / WebTransport / WSS (browser↔server)**, because
+   the server's `/udp/quic-v1` transport (`crates/kotoba-net`) is undialable from
+   a browser. The existing WebRTC signaling relay (`kotoba-rt`, `realtime.rs:452`)
+   and TURN core (`kotoba-turn`) are reusable rendezvous primitives when that day
+   comes.
+4. **Pinning is the availability contract.** The guarantee a querying browser
+   relies on is "the blocks are pinned somewhere CID-reachable," currently
+   satisfied by `kotoba-server` self-pin via `IpfsPinClient`. kotobase fanout
+   (`kotobase.etzhayyim.com`, `KOTOBA_PIN_TOKEN`) is a *replication* of that
+   guarantee for off-pod durability — still dormant (F-3, see
+   `deps.toml:391`), and not on the query critical path.
+
+## 4. Consequences
+
+- The "browser node" is a **trustless read replica of the pinned graph**, not a
+  network peer. That is a simpler and more honest mental model.
+- Availability of query == availability of *any* CID holder, decoupled from peer
+  topology. A single highly-available `block.get`/gateway is enough for read.
+- The P2P work (WebRTC mesh, gossip subscribe) is now clearly optional and
+  independently schedulable, justified only by the three capabilities in §2 —
+  not by "let the browser query."
+- Next concrete step is JS, not Rust: wire the fetch loop and demonstrate a
+  browser answering a `datomicQ` against a graph it never had locally, pulled
+  purely over `block.get`.
+
+## 4a. Implementation pointers
+
+- Registry: this ADR is entry `:adr-browser-cid-query` in `docs/adr.edn`
+  (machine-readable status + follow-ups).
+- Read-plane glue is **ClojureScript** (per the migration decision): the new
+  IPNS-head resolver and query orchestrator live in
+  `crates/kotoba-wasm/web/cljs/` (`kotoba.ipns` / `kotoba.node`), built by
+  shadow-cljs to ESM at `crates/kotoba-wasm/web/cljs-out/kotoba-node.js`. The
+  existing `kotoba-blocks.js` / `kotoba-sw.js` remain until ported (follow-up
+  `:cljs-port-lower-modules`).
+- The signed-head endpoint **now exists**:
+  `GET /xrpc/com.etzhayyim.apps.kotoba.ipns.head?graph=<cid>` (`xrpc::ipns_head`,
+  lexicon `ipns/head.json`, e2e `ipns_head_resolves_signed_record_for_committed_graph`).
+  It returns the member-signed `IpnsRecord` (UNAUTHENTICATED, self-verifying), so
+  `kotoba.ipns/resolve-head` → `hydrate-and-query-verified!` is wired end to end.
+- The EAVT root is now **derived from the verified head**, not trusted from
+  `datomic.sync`: `KotobaNode.commitIndexRoots(commit_cid, bytes)` CID-verifies
+  the head commit block and decodes its `index_roots` in-wasm, so
+  `hydrate-and-query-verified!` is signature- or CID-checked at every hop
+  (head signature → commit CID → index roots → each Prolly block). `datomic.sync`
+  is no longer on the verified path.
+- The lower browser modules are now **ClojureScript**: `kotoba.idb` (snapshots +
+  rawblocks at DB v2) and `kotoba.blocks` (CID-verified, IndexedDB-cached block
+  sync). `kotoba.node` delegates block sync to `kotoba.blocks`. Build is 0 cljs
+  warnings.
+
+## 4b. Write path — symmetric, signature-authorized, no server trust
+
+Reads moved trust into the CID + the signed head. Writes use the **same trust
+model in reverse**: the browser builds a content-addressed, member-signed commit
+entirely locally and publishes it to an untrusted holder.
+
+```
+KotobaNode.assert → commitHeadSigned(seq, valid_until)   ← member Ed25519 sig
+   │                  → signed IpnsRecord + captured blocks
+   ▼
+kotoba.write/publish!:
+   block.put   each block        → server RECOMPUTES the CID (can't substitute bytes)
+   ipns.publish signed record    → xrpc::ipns_publish
+                                    require_verified_signature (unsigned → 401)
+                                    registry sequence CAS      (rollback   → 409)
+```
+
+**Authority is the signature over a key-derived IPNS name, not a server
+credential.** The holder is a relay: it cannot forge a head (no key) nor roll one
+back (CAS). This is takeover-proof **exactly when the IPNS name binds to the
+signing key** — a sovereign / DID-scoped graph. For a **shared** graph whose head
+name is `k51-kotoba-<graph_cid>` (not key-derived), a valid self-signature does
+not prove authorization, so those writes stay on the **CACAO-gated
+`datomic.transact`** path. Two write paths, by design:
+
+| graph kind | head name | write authority | path |
+|---|---|---|---|
+| sovereign / DID-scoped | key-derived | member Ed25519 signature | `ipns.publish` (trustless, browser-local) |
+| shared / operator | `k51-kotoba-<graph>` | CACAO capability | `datomic.transact` (server-gated) |
+
+Implemented: `xrpc::ipns_publish` (lexicon `ipns/publish.json`, e2e
+`ipns_publish_advances_head_and_round_trips_via_ipns_head` — publish 200 → round-
+trips via `ipns.head`, stale → 409, unsigned → 401); `kotoba.write/publish!`
+(block.put loop + ipns.publish). Block push reuses the existing `block.put`.
+
+## 5. Non-goals (explicitly out of scope here)
+
+- Private/Authenticated graph reads from the browser (block.get is unauth only
+  for Public; CACAO-gated cold reads are a separate path).
+- 持ち合い mesh — browsers serving blocks to *each other* (the P2P layer, deferred
+  per §3). Sovereign write *publish* to a holder is done (§4b); browser-to-browser
+  block hosting is not.
+- Replacing the server QUIC transport (it stays; it is the server↔server plane).

--- a/docs/adr.edn
+++ b/docs/adr.edn
@@ -1,0 +1,89 @@
+;; adr.edn — machine-readable ADR registry for the kotoba workspace.
+;;
+;; Single source of truth for "which architecture decisions exist, their status,
+;; and how they relate." Kept in EDN (the project's canonical data notation —
+;; same reader as kotoba-edn) so tooling can query it. Each :file is relative to
+;; docs/. Add a new entry whenever a docs/ADR-*.md lands; keep :status in sync
+;; with the document's own Status line.
+{:schema  1
+ :updated "2026-06-13"
+
+ :adrs
+ [{:id         :adr-001-five-axis
+   :file       "ADR-001-five-axis-distributed-redesign.md"
+   :title      "Five-axis distributed redesign (authority / ordering / availability / conflict / transport)"
+   :status     :accepted-phased
+   :date       "2026-06"
+   :topics     #{:distributed :transport :consensus :availability}}
+
+  {:id         :adr-clojure-wasm
+   :file       "ADR-clojure-wasm.md"
+   :title      "Clojure-on-WASM for kotoba (kotoba-clj)"
+   :status     :accepted
+   :date       "2026-06-09"
+   :crate      "crates/kotoba-clj"
+   :topics     #{:clojure :wasm :compiler :edn}
+   :note       "Clojure/EDN-subset → wasm-bytes compiler (guest programs). Distinct from ClojureScript-in-browser, which targets JS via shadow-cljs (see :adr-browser-cid-query)."}
+
+  {:id         :adr-turn-relay
+   :file       "ADR-turn-relay.md"
+   :title      "Pure-Rust TURN relay for real-media calls (kotoba-turn)"
+   :status     :accepted-core-done
+   :date       "2026-06-09"
+   :crate      "crates/kotoba-turn"
+   :topics     #{:webrtc :nat-traversal :turn :realtime}
+   :note       "Socket-free RFC 8656 core done; UDP/TCP listener shell pending. Reusable rendezvous primitive for any future browser WebRTC plane (see :adr-browser-cid-query §2 持ち合い)."}
+
+  {:id         :adr-sealed-cold-tier
+   :file       "ADR-sealed-cold-tier.md"
+   :title      "Sealed cold tier: AES-256-GCM block envelopes for everything that leaves the node"
+   :status     :accepted
+   :date       "2026-06-11"
+   :topics     #{:crypto :storage :cold-tier :privacy}}
+
+  {:id         :adr-kotoba-word
+   :file       "ADR-kotoba-word.md"
+   :title      "kotoba-word — agent-callable words with a root registry"
+   :status     :accepted
+   :date       "2026-06-10"
+   :topics     #{:agents :registry}}
+
+  {:id         :adr-ci-coverage
+   :file       "ADR-ci-coverage.md"
+   :title      "CI + coverage measurement for the kotoba workspace"
+   :status     :accepted-implemented
+   :date       "2026-06"
+   :topics     #{:ci :coverage :tooling}}
+
+  {:id         :adr-browser-cid-query
+   :file       "ADR-browser-cid-query-vs-p2p.md"
+   :title      "Browser query is CID-addressed: read needs reachability, not peers"
+   :status     :accepted
+   :date       "2026-06-13"
+   :topics     #{:browser :wasm :cid :query :p2p :clojurescript :ipns}
+   :supersedes-framing :browser-libp2p-mesh
+   :crate      "crates/kotoba-wasm"
+   :impl       {:read-plane   {:status :shipping
+                               :js     ["crates/kotoba-wasm/web/kotoba-blocks.js"
+                                        "crates/kotoba-wasm/web/kotoba-sw.js"]
+                               :cljs   ["crates/kotoba-wasm/web/cljs/src/kotoba/ipns.cljs"
+                                        "crates/kotoba-wasm/web/cljs/src/kotoba/node.cljs"]}
+                :p2p-plane    {:status :deferred
+                               :reason "availability/liveness only — 持ち合い / live-push / provider-discovery; not a query-correctness requirement"}}
+   :follow-ups [{:id :ipns-head-signed-endpoint
+                 :what "server XRPC returning the member-signed IpnsRecord for a graph so the head is gateway-untrusted end-to-end"
+                 :status :done
+                 :impl "GET /xrpc/com.etzhayyim.apps.kotoba.ipns.head?graph=<cid> (xrpc::ipns_head); lexicon ipns/head.json; e2e ipns_head_resolves_signed_record_for_committed_graph"}
+                {:id :wasm-commit-index-roots
+                 :what "wasm accessor commit-CID → index_roots so the EAVT root is derived from the verified head, not server-asserted via datomic.sync"
+                 :status :done
+                 :impl "KotobaNode.commitIndexRoots(commit_cid, bytes) (kotoba-wasm Node::commit_index_roots — CID-verified wasm-safe partial decode); kotoba.node/hydrate-and-query-verified! now derives EAVT root from the verified head, datomic.sync dropped from that path; native test commit_index_roots_extracts_roots_from_verified_block + wasm32 build green"}
+                {:id :cljs-port-lower-modules
+                 :what "port kotoba-blocks.js / kotoba-idb.js to ClojureScript (kotoba.blocks / kotoba.idb); cljs entry layer (kotoba.ipns / kotoba.node) lands first"
+                 :status :done
+                 :impl "kotoba.idb (snapshots + rawblocks @ v2) + kotoba.blocks (block-get + CID-verified IndexedDB-cached hydrate); kotoba.node now delegates block sync to kotoba.blocks; shadow-cljs build 0 warnings"}
+                {:id :browser-write-path
+                 :what "trustless browser write: block.put push + ipns.publish (member-signed head advance); authority = signature over a key-derived name, CAS on sequence"
+                 :status :done
+                 :impl "POST /xrpc/com.etzhayyim.apps.kotoba.ipns.publish (xrpc::ipns_publish — require_verified_signature + registry CAS; stale→409 unsigned→401); lexicon ipns/publish.json; cljs kotoba.write/publish! (block.put loop + ipns.publish); e2e ipns_publish_advances_head_and_round_trips_via_ipns_head"
+                 :note "takeover-proof only for sovereign/DID-scoped graphs (name binds to key); shared graph heads still go through CACAO-gated datomic.transact"}]}]}

--- a/lexicons/com/etzhayyim/apps/kotoba/ipns/head.json
+++ b/lexicons/com/etzhayyim/apps/kotoba/ipns/head.json
@@ -1,0 +1,37 @@
+{
+  "lexicon": 1,
+  "id": "com.etzhayyim.apps.kotoba.ipns.head",
+  "defs": {
+    "main": {
+      "type": "query",
+      "description": "Resolve the member-signed IPNS head record for a graph (its `value` is the head/commit CID). UNAUTHENTICATED and self-verifying: the record carries an Ed25519 signature over a canonical CBOR payload, so the consumer verifies it client-side and does not trust the serving node. A holder can withhold a newer head but cannot forge one.",
+      "parameters": {
+        "type": "params",
+        "required": ["graph"],
+        "properties": {
+          "graph": {
+            "type": "string",
+            "description": "Graph CID (multibase). The IPNS name is derived from it."
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["name", "value", "sequence", "valid_until"],
+          "properties": {
+            "name": { "type": "string", "description": "IPNS name (derived from the graph CID)." },
+            "value": { "type": "string", "description": "Head/commit CID (multibase) this record points at." },
+            "sequence": { "type": "integer", "description": "Monotonic record sequence; higher supersedes lower." },
+            "valid_until": { "type": "string", "description": "Expiry timestamp for this head record." },
+            "ttl_secs": { "type": "integer", "description": "Optional record TTL in seconds." },
+            "controller_did": { "type": "string", "description": "Optional controller DID." },
+            "public_key_multibase": { "type": "string", "description": "Multibase Ed25519 public key used to verify the signature." },
+            "signature_multibase": { "type": "string", "description": "Multibase Ed25519 signature over the canonical CBOR payload." }
+          }
+        }
+      }
+    }
+  }
+}

--- a/lexicons/com/etzhayyim/apps/kotoba/ipns/publish.json
+++ b/lexicons/com/etzhayyim/apps/kotoba/ipns/publish.json
@@ -1,0 +1,38 @@
+{
+  "lexicon": 1,
+  "id": "com.etzhayyim.apps.kotoba.ipns.publish",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Advance a graph's mutable head by publishing a member-signed IpnsRecord (the symmetric write to ipns.head). Authority is the Ed25519 signature over the record, not a server credential: unsigned/invalid records are rejected (401) and a monotonic sequence CAS prevents rollback (409). Takeover-proof only when the IPNS name is derived from the signing key; shared graph heads still go through CACAO-gated datomic.transact.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["name", "value", "sequence", "valid_until", "public_key_multibase", "signature_multibase"],
+          "properties": {
+            "name": { "type": "string", "description": "IPNS name to advance." },
+            "value": { "type": "string", "description": "Head/commit CID (multibase) to point at." },
+            "sequence": { "type": "integer", "description": "Monotonic sequence; must exceed the current head's." },
+            "valid_until": { "type": "string", "description": "Expiry timestamp." },
+            "ttl_secs": { "type": "integer", "description": "Optional record TTL in seconds." },
+            "controller_did": { "type": "string", "description": "Optional controller DID." },
+            "public_key_multibase": { "type": "string", "description": "Multibase Ed25519 public key." },
+            "signature_multibase": { "type": "string", "description": "Multibase Ed25519 signature over the canonical CBOR payload." }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["status", "name"],
+          "properties": {
+            "status": { "type": "string" },
+            "name": { "type": "string", "description": "The IPNS name that was advanced." }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

A browser queries a **pinned** graph with **zero P2P**: query is content-addressed, so read needs *reachability*, not peers. This closes the trust gap end to end and adds the symmetric, signature-authorized write path.

### Read plane — trustless, no `datomic.sync` trust
- `GET ipns.head?graph=<cid>` (`xrpc::ipns_head`) — member-signed `IpnsRecord`, UNAUTHENTICATED + self-verifying.
- `KotobaNode.commitIndexRoots(commit_cid, bytes)` — CID-verified, wasm-safe partial decode of the head commit's `index_roots`, so the EAVT root derives from the **verified head**, not the server.
- cljs `kotoba.ipns/resolve-head` → `kotoba.node/hydrate-and-query-verified!`: head signature → commit CID → index roots → each Prolly block, every hop signature- or CID-checked.

### Write plane — sovereign graphs, no server trust
- `POST ipns.publish` (`xrpc::ipns_publish`) — `require_verified_signature` + registry sequence CAS; unsigned → 401, stale → 409.
- cljs `kotoba.write/publish!` — `block.put` push + `ipns.publish`.
- **Authority = Ed25519 signature over a key-derived name.** Shared graph heads stay on CACAO-gated `datomic.transact`.

| graph kind | head name | write authority | path |
|---|---|---|---|
| sovereign / DID-scoped | key-derived | member signature | `ipns.publish` (trustless) |
| shared / operator | `k51-kotoba-<graph>` | CACAO | `datomic.transact` |

### ClojureScript browser glue (shadow-cljs → ESM)
`kotoba.idb` (snapshots + rawblocks @ v2) and `kotoba.blocks` (CID-verified, IndexedDB-cached block sync) port the former `kotoba-idb.js` / `kotoba-blocks.js`; `kotoba.node` delegates block sync to `kotoba.blocks`.

### Docs
`docs/adr.edn` (machine-readable ADR registry) + `docs/ADR-browser-cid-query-vs-p2p.md`.

## Tests
- e2e `ipns_head_resolves_signed_record_for_committed_graph`
- e2e `ipns_publish_advances_head_and_round_trips_via_ipns_head` (publish 200 → round-trips via `ipns.head`, stale → 409, unsigned → 401)
- native `commit_index_roots_extracts_roots_from_verified_block`
- wasm32 build + cljs build (0 warnings) green; lexicon registry test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)