### PR TITLE
feat(kotoba-clj): higher-order sequence fns (map/filter/reduce/…) over closures

### DIFF
--- a/crates/kotoba-clj/src/codegen.rs
+++ b/crates/kotoba-clj/src/codegen.rs
@@ -180,6 +180,24 @@ pub fn compile_core(program: &Program, entry: Option<Entry>) -> Result<Vec<u8>, 
         }
     }
 
+    // An indirect closure call of N args needs the function type for arity N+1
+    // (the hidden `__self` pointer). A defined function of that arity may not
+    // exist (e.g. `map`'s `(f x)` when no arity-2 `defn` is present), so ensure
+    // every needed type is present and remember whether *any* indirect call
+    // exists — a `call_indirect` is only valid if the module has a table.
+    let indirect_arities = collect_call_value_arities(program);
+    let has_indirect = !indirect_arities.is_empty();
+    for a in &indirect_arities {
+        let arity = a + 1;
+        type_for_arity.entry(arity).or_insert_with(|| {
+            let idx = types.len();
+            types
+                .ty()
+                .function(std::iter::repeat_n(ValType::I64, arity), [ValType::I64]);
+            idx
+        });
+    }
+
     // cabi_realloc: (old:i32, old_sz:i32, align:i32, new_sz:i32) -> i32
     let realloc_type = types.len();
     types.ty().function(
@@ -275,11 +293,15 @@ pub fn compile_core(program: &Program, entry: Option<Entry>) -> Result<Vec<u8>, 
         );
     }
 
-    // Funcref table + element segment for closures (only when some exist).
+    // Funcref table + element segment for closures. The table must exist whenever
+    // the module contains *any* `call_indirect` (a CallValue) — even with zero
+    // lifted closures — or the indirect call fails validation. The element
+    // segment is only emitted when there are actual closures to install.
+    let needs_table = has_indirect || !table_funcs.is_empty();
     let mut tables = TableSection::new();
     let mut elements = ElementSection::new();
     let elem_offset = ConstExpr::i32_const(0);
-    if !table_funcs.is_empty() {
+    if needs_table {
         tables.table(TableType {
             element_type: RefType::FUNCREF,
             table64: false,
@@ -287,6 +309,8 @@ pub fn compile_core(program: &Program, entry: Option<Entry>) -> Result<Vec<u8>, 
             maximum: Some(table_funcs.len() as u64),
             shared: false,
         });
+    }
+    if !table_funcs.is_empty() {
         elements.active(
             Some(CLOSURE_TABLE),
             &elem_offset,
@@ -301,7 +325,7 @@ pub fn compile_core(program: &Program, entry: Option<Entry>) -> Result<Vec<u8>, 
         module.section(&imports); // 2
     }
     module.section(&funcs); // 3
-    if !table_funcs.is_empty() {
+    if needs_table {
         module.section(&tables); // 4
     }
     module.section(&memories); // 5
@@ -432,6 +456,46 @@ fn collect_host_imports(program: &Program) -> Vec<HostImport> {
         }
     }
     seen
+}
+
+/// Every distinct `args.len()` appearing in a `CallValue` (indirect closure
+/// call) anywhere in the program. Used to (a) pre-create the needed
+/// `call_indirect` function types and (b) decide whether a funcref table is
+/// required at all.
+fn collect_call_value_arities(program: &Program) -> std::collections::HashSet<usize> {
+    let mut out = std::collections::HashSet::new();
+    fn walk(e: &Expr, out: &mut std::collections::HashSet<usize>) {
+        match e {
+            Expr::Int(_) | Expr::Str(_) | Expr::Var(_) | Expr::ClosureRef(_) => {}
+            Expr::If { cond, then, els } => {
+                walk(cond, out);
+                walk(then, out);
+                walk(els, out);
+            }
+            Expr::Let { bindings, body } | Expr::Loop { bindings, body } => {
+                bindings.iter().for_each(|(_, v)| walk(v, out));
+                body.iter().for_each(|e| walk(e, out));
+            }
+            Expr::Do(es) | Expr::Recur(es) | Expr::Call { args: es, .. } => {
+                es.iter().for_each(|e| walk(e, out));
+            }
+            Expr::Builtin { args, .. } => args.iter().for_each(|e| walk(e, out)),
+            Expr::Fn { body, .. } => body.iter().for_each(|e| walk(e, out)),
+            Expr::MakeClosure { captures, .. } => captures.iter().for_each(|e| walk(e, out)),
+            Expr::CallValue { f, args } => {
+                out.insert(args.len());
+                walk(f, out);
+                args.iter().for_each(|e| walk(e, out));
+            }
+        }
+    }
+    for d in &program.defs {
+        walk(&d.value, &mut out);
+    }
+    for f in &program.functions {
+        f.body.iter().for_each(|e| walk(e, &mut out));
+    }
+    out
 }
 
 fn collect_literals(program: &Program) -> Literals {

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -230,7 +230,11 @@ pub fn compile_file_with_prelude_reader_target_and_source_paths(
 /// Clojure-core compatibility layer: `count`, `empty?`, `seq`, `not-empty`,
 /// `nth`, `first`, `second`, `last`, `peek`, `subvec`, `rest`, `conj`,
 /// `conj!`, `get`, `assoc`, `assoc!`, `contains?`, `contains-key?`, `keys`,
-/// `vals`, `vector`, `hash-map`, `array-map`, `identity`, and `constantly`. The
+/// `vals`, `vector`, `hash-map`, `array-map`, `identity`, and `constantly`.
+/// Higher-order sequence fns (driven by the closure / `call_indirect` path):
+/// `map`, `mapv`, `map-indexed`, `filter`, `filterv`, `remove`, `keep`,
+/// `reduce` (2/3-arity), `reduce-kv`, `range` (1/2-arity), `some`, `every?`,
+/// `not-any?`, `into`, `comp`, and `partial`. The
 /// lowering phase also accepts vector and map destructuring in `defn`, `let`,
 /// `loop`, `if-let`, and `when-let`; map destructuring supports `{local :key}`,
 /// `{:keys [...]}`, `{:strs [...]}`, `:or`, and `:as`.
@@ -371,6 +375,108 @@ pub const PRELUDE: &str = r#"
         out
         (do (vec-conj! out (map-val-at m i))
             (recur (+ i 1)))))))
+
+;; ---- higher-order sequence fns --------------------------------------------
+;; These take a function argument and invoke it via the closure call path
+;; ((f x) → call_indirect). Output vectors are pre-sized to the input count
+;; (vec-conj! does not grow), which is exact for map and an upper bound for
+;; filter/remove/keep. Predicates are truthy on any non-zero value.
+(defn map [f v]
+  (let [n (vec-count v)
+        out (vec-make n)]
+    (loop [i 0]
+      (if (>= i n)
+        out
+        (do (vec-conj! out (f (vec-nth v i)))
+            (recur (+ i 1)))))))
+(defn mapv [f v] (map f v))
+(defn map-indexed [f v]
+  (let [n (vec-count v)
+        out (vec-make n)]
+    (loop [i 0]
+      (if (>= i n)
+        out
+        (do (vec-conj! out (f i (vec-nth v i)))
+            (recur (+ i 1)))))))
+(defn filter [pred v]
+  (let [n (vec-count v)
+        out (vec-make n)]
+    (loop [i 0]
+      (if (>= i n)
+        out
+        (let [x (vec-nth v i)]
+          (do (if (pred x) (vec-conj! out x) 0)
+              (recur (+ i 1))))))))
+(defn filterv [pred v] (filter pred v))
+(defn remove [pred v]
+  (let [n (vec-count v)
+        out (vec-make n)]
+    (loop [i 0]
+      (if (>= i n)
+        out
+        (let [x (vec-nth v i)]
+          (do (if (pred x) 0 (vec-conj! out x))
+              (recur (+ i 1))))))))
+(defn keep [f v]
+  (let [n (vec-count v)
+        out (vec-make n)]
+    (loop [i 0]
+      (if (>= i n)
+        out
+        (let [r (f (vec-nth v i))]
+          (do (if (nil? r) 0 (vec-conj! out r))
+              (recur (+ i 1))))))))
+(defn reduce
+  ([f init v]
+   (let [n (vec-count v)]
+     (loop [i 0 acc init]
+       (if (>= i n)
+         acc
+         (recur (+ i 1) (f acc (vec-nth v i)))))))
+  ([f v]
+   (let [n (vec-count v)]
+     (if (= n 0)
+       (f)
+       (loop [i 1 acc (vec-nth v 0)]
+         (if (>= i n)
+           acc
+           (recur (+ i 1) (f acc (vec-nth v i)))))))))
+(defn reduce-kv [f init m]
+  (let [n (map-count m)]
+    (loop [i 0 acc init]
+      (if (>= i n)
+        acc
+        (recur (+ i 1) (f acc (map-key-at m i) (map-val-at m i)))))))
+(defn range
+  ([n]
+   (let [out (vec-make n)]
+     (loop [i 0]
+       (if (>= i n) out (do (vec-conj! out i) (recur (+ i 1)))))))
+  ([start end]
+   (let [out (vec-make (- end start))]
+     (loop [i start]
+       (if (>= i end) out (do (vec-conj! out i) (recur (+ i 1))))))))
+(defn some [pred v]
+  (let [n (vec-count v)]
+    (loop [i 0]
+      (if (>= i n)
+        0
+        (let [r (pred (vec-nth v i))]
+          (if r r (recur (+ i 1))))))))
+(defn every? [pred v]
+  (let [n (vec-count v)]
+    (loop [i 0]
+      (if (>= i n)
+        1
+        (if (pred (vec-nth v i))
+          (recur (+ i 1))
+          0)))))
+(defn not-any? [pred v] (if (some pred v) 0 1))
+(defn into [dst src] (vec-extend! dst src))
+(defn comp [f g] (fn [x] (f (g x))))
+(defn partial
+  ([f a] (fn [x] (f a x)))
+  ([f a b] (fn [x] (f a b x))))
 "#;
 
 /// An **in-guest CBOR decoder** (subset) written in the kotoba-clj language,

--- a/crates/kotoba-clj/tests/hofs.rs
+++ b/crates/kotoba-clj/tests/hofs.rs
@@ -1,0 +1,132 @@
+//! Higher-order sequence functions (`map`/`filter`/`reduce`/…) from the prelude,
+//! driven by real closures over the WASM funcref table. Each test compiles
+//! `PRELUDE + (defn t [_] body)` and runs `t` on wasmtime, so green = the whole
+//! closures + call_indirect + heap-vector pipeline executes end to end.
+
+use kotoba_clj::compile_str_with_prelude;
+use kotoba_clj::run::run;
+
+fn eval(body: &str) -> i64 {
+    let src = format!("(defn t [_] {body})");
+    let wasm = compile_str_with_prelude(&src).expect("compile");
+    run(&wasm, "t", &[0]).expect("run")
+}
+
+#[test]
+fn map_then_reduce_sum() {
+    // sum (map *10 [1 2 3]) = 10+20+30 = 60
+    assert_eq!(
+        eval("(reduce (fn [a x] (+ a x)) 0 (map (fn [x] (* x 10)) (vector 1 2 3)))"),
+        60
+    );
+}
+
+#[test]
+fn map_reader_macro() {
+    // (map #(* % %) [1 2 3 4]) → [1 4 9 16]; nth 3 = 16
+    assert_eq!(eval("(vec-nth (map #(* % %) (vector 1 2 3 4)) 3)"), 16);
+}
+
+#[test]
+fn filter_even_count() {
+    assert_eq!(eval("(vec-count (filter (fn [x] (even? x)) (vector 1 2 3 4)))"), 2);
+}
+
+#[test]
+fn remove_even_count() {
+    assert_eq!(eval("(vec-count (remove (fn [x] (even? x)) (vector 1 2 3 4)))"), 2);
+}
+
+#[test]
+fn reduce_no_init_uses_first() {
+    // (reduce + [5 7 9]) = 21
+    assert_eq!(eval("(reduce (fn [a x] (+ a x)) (vector 5 7 9))"), 21);
+}
+
+#[test]
+fn closure_capture_inside_map() {
+    // captured `k` reaches the lifted map callback through the closure record
+    assert_eq!(
+        eval("(let [k 100] (vec-nth (map (fn [x] (+ x k)) (vector 1 2 3)) 0))"),
+        101
+    );
+}
+
+#[test]
+fn range_and_reduce() {
+    // (reduce + 0 (range 5)) = 0+1+2+3+4 = 10
+    assert_eq!(eval("(reduce (fn [a x] (+ a x)) 0 (range 5))"), 10);
+}
+
+#[test]
+fn range_start_end() {
+    // (range 3 7) = [3 4 5 6]; sum = 18
+    assert_eq!(eval("(reduce (fn [a x] (+ a x)) 0 (range 3 7))"), 18);
+}
+
+#[test]
+fn map_indexed_adds_index() {
+    // (map-indexed + [10 20 30]) → [10 21 32]; nth 2 = 32
+    assert_eq!(
+        eval("(vec-nth (map-indexed (fn [i x] (+ i x)) (vector 10 20 30)) 2)"),
+        32
+    );
+}
+
+#[test]
+fn some_returns_first_truthy() {
+    assert_eq!(eval("(some (fn [x] (if (> x 2) x 0)) (vector 1 2 3))"), 3);
+}
+
+#[test]
+fn every_true_and_false() {
+    assert_eq!(eval("(every? (fn [x] (> x 0)) (vector 1 2 3))"), 1);
+    assert_eq!(eval("(every? (fn [x] (> x 1)) (vector 1 2 3))"), 0);
+}
+
+#[test]
+fn comp_composes_two_fns() {
+    // ((comp *2 +1) 10) = (10+1)*2 = 22 — comp itself returns a closure
+    assert_eq!(
+        eval("((comp (fn [x] (* x 2)) (fn [x] (+ x 1))) 10)"),
+        22
+    );
+}
+
+#[test]
+fn partial_prefixes_args() {
+    // ((partial + 40) 2) = 42 — partial returns a closure capturing 40
+    assert_eq!(eval("((partial (fn [a b] (+ a b)) 40) 2)"), 42);
+}
+
+#[test]
+fn into_extends_presized_vector() {
+    // pre-size dst (vec-conj! does not grow), then into += [3 4 5]
+    assert_eq!(
+        eval("(let [d (vec-make 8)] (vec-conj! d 1) (vec-conj! d 2) (vec-count (into d (vector 3 4 5))))"),
+        5
+    );
+}
+
+#[test]
+fn keep_drops_nil_results() {
+    // keep f where f returns 0 (nil) for odds → keeps doubled evens
+    // [1 2 3 4] → f = (if even? (* x 10) nil) → [20 40]; count = 2
+    assert_eq!(
+        eval("(vec-count (keep (fn [x] (if (even? x) (* x 10) nil)) (vector 1 2 3 4)))"),
+        2
+    );
+}
+
+#[test]
+fn higher_order_chain_map_filter_reduce() {
+    // sum of squares of evens in 0..6: evens {0,2,4} → {0,4,16} → 20
+    assert_eq!(
+        eval(
+            "(reduce (fn [a x] (+ a x)) 0
+               (map (fn [x] (* x x))
+                 (filter (fn [x] (even? x)) (range 6))))"
+        ),
+        20
+    );
+}

--- a/docs/ADR-clojure-wasm.md
+++ b/docs/ADR-clojure-wasm.md
@@ -499,3 +499,41 @@ Verification: `cargo test -p kotoba-edn` (27, incl. 5 `#(…)` reader tests) and
 let/param capture, bound-then-called, higher-order param, distinct table slots,
 **escaping returned closure**, **nested transitive capture**) all green; clippy
 clean.
+
+## Higher-order sequence functions (`map`/`filter`/`reduce`/…) — 2026-06-14
+
+With closures + `call_indirect` in place (previous section), the seq HOFs are
+written as **ordinary prelude `defn`s** in the kotoba-clj subset itself — no new
+codegen. Each takes a function argument and invokes it through the closure path
+(`(f x)` → `CallValue` → `call_indirect`), iterating the heap vector with
+`loop`/`recur` + `vec-nth`/`vec-conj!`.
+
+Added to `PRELUDE`: `map`, `mapv`, `map-indexed`, `filter`, `filterv`, `remove`,
+`keep`, `reduce` (2- and 3-arity), `reduce-kv`, `range` (1- and 2-arity), `some`,
+`every?`, `not-any?`, `into`, `comp`, `partial`. `comp`/`partial` *return*
+closures (`(fn [x] (f (g x)))`), exercising closure construction from inside the
+prelude. Output vectors are pre-sized to the input count (exact for `map`, an
+upper bound for `filter`/`remove`/`keep`) because `vec-conj!` does not grow.
+
+Because the prelude now always contains `call_indirect`, **every** compiled
+module needs a funcref table to exist (an indirect call to a missing table is a
+validation error). Codegen therefore emits the table whenever the program
+contains any `CallValue` *or* any lifted closure (`needs_table = has_indirect ||
+!table_funcs.is_empty()`), and `collect_call_value_arities` pre-creates the
+`(N+1)×i64 → i64` function types that `call_indirect` needs even when no `defn`
+of that arity exists.
+
+### Honest scope / known limits
+
+`reduce` with no init over an empty coll calls `(f)` (Clojure semantics) which
+traps on a binary reducer — caller's bug, fails cleanly. `into`/`conj!` onto a
+fixed-capacity literal vector can overflow (pre-existing `vec-conj!` footgun —
+vectors don't auto-grow); pre-size with `vec-make`. `apply` (dynamic arity),
+multi-collection `map`, and lazy seqs are not provided. Remaining for full
+langgraph-clj: protocols / `defrecord` dispatch.
+
+Verification: `cargo test -p kotoba-clj --features run,component` green incl. the
+new 16-test `tests/hofs.rs` (map→filter→reduce chains, reader-macro callbacks,
+captured-variable callbacks, `comp`/`partial` returning closures, `range`,
+`some`/`every?`/`keep`, `map-indexed`); clippy clean; no regressions across the
+component/kqe/pregel suites that compile with the now-table-bearing prelude.


### PR DESCRIPTION
## What

**Milestone 2** toward running `langgraph-clj`/`langchain-clj` on kotoba-clj/WASM. Adds the seq higher-order functions they depend on: `map`, `mapv`, `map-indexed`, `filter`, `filterv`, `remove`, `keep`, `reduce` (2/3-arity), `reduce-kv`, `range` (1/2-arity), `some`, `every?`, `not-any?`, `into`, `comp`, `partial`.

## How

With closures + `call_indirect` from #157 in place, the HOFs are written as **ordinary prelude `defn`s in the subset itself** — no new codegen. Each takes a function arg and invokes it through the closure path (`(f x)` → `CallValue` → `call_indirect`), iterating the heap vector with `loop`/`recur`. `comp`/`partial` *return* closures (`(fn [x] (f (g x)))`), exercising closure construction from inside the prelude.

**Codegen change:** the prelude now always contains `call_indirect`, so every module needs a funcref table to *exist* (an indirect call to a missing table fails validation). The table is emitted whenever the program has any `CallValue` **or** any lifted closure (`needs_table = has_indirect || !table_funcs.is_empty()`), and `collect_call_value_arities` pre-creates the `(N+1)×i64 → i64` types `call_indirect` needs even when no `defn` of that arity exists.

## Honest scope

`reduce` with no init over an empty coll calls `(f)` (Clojure semantics) — traps on a binary reducer (caller's bug, clean fail). `into`/`conj!` onto a fixed-capacity literal vector can overflow (pre-existing `vec-conj!` footgun — vectors don't auto-grow; pre-size with `vec-make`). No `apply` (dynamic arity), multi-collection `map`, or lazy seqs. **Remaining for full langgraph-clj: protocols / `defrecord` dispatch.**

## Verification

`cargo test -p kotoba-clj --features run,component` green incl. new **16-test `tests/hofs.rs`**: `map`→`filter`→`reduce` chains, reader-macro callbacks, captured-variable callbacks, `comp`/`partial` returning closures, `range`/`some`/`every?`/`keep`/`map-indexed`. Clippy clean. No regressions across the component/kqe/pregel suites that compile with the now-table-bearing prelude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)