### PR TITLE
feat(kotoba-clj): generic kotoba-clj CLI (build/run)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4298,6 +4298,7 @@ dependencies = [
 name = "kotoba-clj"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "ciborium",
  "kotoba-clj",
  "kotoba-core",
@@ -4306,6 +4307,7 @@ dependencies = [
  "kotoba-query",
  "kotoba-runtime",
  "kotoba-vm",
+ "serde_json",
  "thiserror 1.0.69",
  "wasm-encoder 0.221.3",
  "wasmtime 22.0.1",

--- a/crates/kotoba-clj/Cargo.toml
+++ b/crates/kotoba-clj/Cargo.toml
@@ -24,6 +24,14 @@ wasmtime = { workspace = true, optional = true }
 wit-component = { version = "0.221", optional = true }
 wit-parser = { version = "0.221", optional = true }
 
+# `cli` feature deps — a generic `kotoba-clj` build/run command-line tool.
+# kotoba-runtime is a regular (optional) dep here for the `run` subcommand;
+# there is no cycle (kotoba-runtime does NOT depend on kotoba-clj).
+kotoba-runtime = { path = "../kotoba-runtime", optional = true }
+ciborium = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
+anyhow = { workspace = true, optional = true }
+
 [features]
 default = ["run", "component"]
 # `run` pulls in wasmtime and exposes the `run` module (standalone core-module
@@ -32,6 +40,14 @@ run = ["dep:wasmtime"]
 # `component` pulls in wit-component/wit-parser and exposes the `component`
 # module (core module → WASM Component). Implies `run` for the component runner.
 component = ["dep:wit-component", "dep:wit-parser", "run"]
+# `cli` builds the generic `kotoba-clj` binary (build a .clj cell → kais WASM
+# Component; run a Component on WasmExecutor with a CBOR ctx + Datom snapshot).
+cli = ["dep:kotoba-runtime", "dep:ciborium", "dep:serde_json", "dep:anyhow", "component"]
+
+[[bin]]
+name = "kotoba-clj"
+path = "src/bin/kotoba_clj.rs"
+required-features = ["cli"]
 
 [dev-dependencies]
 kotoba-clj = { path = ".", features = ["run", "component"] }

--- a/crates/kotoba-clj/Cargo.toml
+++ b/crates/kotoba-clj/Cargo.toml
@@ -40,14 +40,11 @@ run = ["dep:wasmtime"]
 # `component` pulls in wit-component/wit-parser and exposes the `component`
 # module (core module → WASM Component). Implies `run` for the component runner.
 component = ["dep:wit-component", "dep:wit-parser", "run"]
-# `cli` builds the generic `kotoba-clj` binary (build a .clj cell → kais WASM
-# Component; run a Component on WasmExecutor with a CBOR ctx + Datom snapshot).
+# `cli` adds the `build`/`run` toolchain subcommands to the `kotoba-clj` binary
+# (build a .clj cell → kais WASM Component; run a Component on WasmExecutor with a
+# CBOR ctx + Datom snapshot). The legacy `kotoba-clj <file.clj>` file runner stays
+# available; a `build`/`run` first arg routes to the subcommand dispatcher.
 cli = ["dep:kotoba-runtime", "dep:ciborium", "dep:serde_json", "dep:anyhow", "component"]
-
-[[bin]]
-name = "kotoba-clj"
-path = "src/bin/kotoba_clj.rs"
-required-features = ["cli"]
 
 [dev-dependencies]
 kotoba-clj = { path = ".", features = ["run", "component"] }

--- a/crates/kotoba-clj/src/ast.rs
+++ b/crates/kotoba-clj/src/ast.rs
@@ -309,7 +309,7 @@ pub enum Expr {
     },
     /// An anonymous function `(fn [params…] body…)` (also the target of the
     /// `#(…)` reader macro). This is a *transient* node: the lambda-lifting pass
-    /// ([`lift_program`]) rewrites every `Fn` site into a [`Expr::MakeClosure`]
+    /// (`lift_program`) rewrites every `Fn` site into a [`Expr::MakeClosure`]
     /// plus a synthetic top-level [`Function`], so codegen never sees a raw `Fn`.
     Fn {
         params: Vec<String>,

--- a/crates/kotoba-clj/src/ast.rs
+++ b/crates/kotoba-clj/src/ast.rs
@@ -600,9 +600,9 @@ fn free_walk(
     seen: &mut std::collections::HashSet<String>,
 ) {
     let refer = |name: &str,
-                     bound: &Vec<String>,
-                     acc: &mut Vec<String>,
-                     seen: &mut std::collections::HashSet<String>| {
+                 bound: &Vec<String>,
+                 acc: &mut Vec<String>,
+                 seen: &mut std::collections::HashSet<String>| {
         if !bound.iter().any(|b| b == name)
             && scope_get(scope, name).is_some()
             && seen.insert(name.to_string())
@@ -630,26 +630,32 @@ fn free_walk(
             bound.truncate(depth);
         }
         Expr::Do(es) | Expr::Recur(es) | Expr::Builtin { args: es, .. } => {
-            es.iter().for_each(|e| free_walk(e, bound, scope, acc, seen));
+            es.iter()
+                .for_each(|e| free_walk(e, bound, scope, acc, seen));
         }
         Expr::Call { name, args } => {
             refer(name, bound, acc, seen); // a call head may be a closure value
-            args.iter().for_each(|a| free_walk(a, bound, scope, acc, seen));
+            args.iter()
+                .for_each(|a| free_walk(a, bound, scope, acc, seen));
         }
         Expr::CallValue { f, args } => {
             free_walk(f, bound, scope, acc, seen);
-            args.iter().for_each(|a| free_walk(a, bound, scope, acc, seen));
+            args.iter()
+                .for_each(|a| free_walk(a, bound, scope, acc, seen));
         }
         // A nested `(fn …)` captures from us too, so descend with its params
         // added to `bound` (its own params are not our free vars).
         Expr::Fn { params, body } => {
             let depth = bound.len();
             bound.extend(params.iter().cloned());
-            body.iter().for_each(|e| free_walk(e, bound, scope, acc, seen));
+            body.iter()
+                .for_each(|e| free_walk(e, bound, scope, acc, seen));
             bound.truncate(depth);
         }
         Expr::MakeClosure { captures, .. } => {
-            captures.iter().for_each(|e| free_walk(e, bound, scope, acc, seen));
+            captures
+                .iter()
+                .for_each(|e| free_walk(e, bound, scope, acc, seen));
         }
     }
 }
@@ -1790,7 +1796,8 @@ fn lower_fn(args: &[EdnValue]) -> Result<Expr, CljError> {
     };
     if param_vec.iter().any(is_amp_symbol) {
         return Err(CljError::Lower(
-            "variadic `& rest` params in `(fn …)` / `#(… %&)` are not yet supported in kotoba-clj".into(),
+            "variadic `& rest` params in `(fn …)` / `#(… %&)` are not yet supported in kotoba-clj"
+                .into(),
         ));
     }
     let (params, destructured) = lower_param_list(param_vec, "fn parameter")?;

--- a/crates/kotoba-clj/src/bin/kotoba_clj.rs
+++ b/crates/kotoba-clj/src/bin/kotoba_clj.rs
@@ -1,0 +1,240 @@
+//! `kotoba-clj` — generic command-line tool for the Clojure→WASM cell toolchain.
+//!
+//! Domain-agnostic: it knows nothing about ISCO/APQC or any actor. It exposes
+//! the two engine capabilities an actor needs to build + smoke-test a cell:
+//!
+//!   kotoba-clj build <cell.clj> [-o out.wasm] [--wit <dir>]
+//!       Compile a kotoba-clj source file (prelude auto-prepended) into a
+//!       `kotoba:kais` WASM Component.
+//!
+//!   kotoba-clj run <component.wasm> [--ctx <json>] [--ctx-file <path>]
+//!                  [--snapshot <json>] [--snapshot-file <path>]
+//!                  [--gas <n>] [--agent <did>] [--echo-llm]
+//!       Instantiate the Component on WasmExecutor and invoke run(ctx). ctx is
+//!       a JSON value encoded to CBOR; snapshot is a JSON array of
+//!       {graph,subject,predicate,object} Datom quads (object CBOR-encoded).
+//!       Prints the output_cbor as hex and, when decodable, as a CBOR value.
+//!
+//! Build/install: `cargo build -p kotoba-clj --features cli` (or `--release`).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Context, Result};
+use kotoba_clj::component::compile_kais_component_str;
+use kotoba_clj::prelude;
+use kotoba_runtime::host::WitQuad;
+use kotoba_runtime::WasmExecutor;
+
+const DEFAULT_WIT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../kotoba-runtime/wit");
+const DEFAULT_GAS: u64 = 10_000_000;
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("error: {e:#}");
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match args.first().map(String::as_str) {
+        Some("build") => cmd_build(&args[1..]),
+        Some("run") => cmd_run(&args[1..]),
+        Some("-h") | Some("--help") | None => {
+            print_usage();
+            Ok(())
+        }
+        Some(other) => {
+            bail!("unknown subcommand '{other}' (expected: build | run)");
+        }
+    }
+}
+
+fn print_usage() {
+    eprintln!(
+        "kotoba-clj — Clojure→WASM cell toolchain\n\n\
+         USAGE:\n  \
+         kotoba-clj build <cell.clj> [-o <out.wasm>] [--wit <dir>]\n  \
+         kotoba-clj run <component.wasm> [--ctx <json> | --ctx-file <path>]\n                 \
+         [--snapshot <json> | --snapshot-file <path>] [--gas <n>] [--agent <did>] [--echo-llm]"
+    );
+}
+
+/// Pull `--flag value` out of args; returns the value if present.
+fn flag<'a>(args: &'a [String], name: &str) -> Option<&'a str> {
+    args.iter()
+        .position(|a| a == name)
+        .and_then(|i| args.get(i + 1))
+        .map(String::as_str)
+}
+
+fn has_flag(args: &[String], name: &str) -> bool {
+    args.iter().any(|a| a == name)
+}
+
+/// First arg that is not a flag and not a flag-value.
+fn positional(args: &[String]) -> Option<&str> {
+    let mut skip_next = false;
+    for (i, a) in args.iter().enumerate() {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if a.starts_with('-') {
+            // flags that take a value
+            if matches!(
+                a.as_str(),
+                "-o" | "--wit" | "--ctx" | "--ctx-file" | "--snapshot" | "--snapshot-file"
+                    | "--gas" | "--agent"
+            ) {
+                skip_next = true;
+            }
+            continue;
+        }
+        let _ = i;
+        return Some(a);
+    }
+    None
+}
+
+fn cmd_build(args: &[String]) -> Result<()> {
+    let cell = positional(args).ok_or_else(|| anyhow!("build: missing <cell.clj>"))?;
+    let wit = flag(args, "--wit").unwrap_or(DEFAULT_WIT_DIR);
+    let out = flag(args, "-o")
+        .map(str::to_string)
+        .unwrap_or_else(|| cell.trim_end_matches(".clj").to_string() + ".wasm");
+
+    let body = std::fs::read_to_string(cell).with_context(|| format!("read {cell}"))?;
+    let src = format!("{}\n{}", prelude(), body);
+    let wasm = compile_kais_component_str(&src, wit)
+        .map_err(|e| anyhow!("compile {cell}: {e:?}"))?;
+    std::fs::write(&out, &wasm).with_context(|| format!("write {out}"))?;
+    eprintln!("[build] {cell} -> {out} ({} bytes)", wasm.len());
+    Ok(())
+}
+
+fn cmd_run(args: &[String]) -> Result<()> {
+    let wasm_path = positional(args).ok_or_else(|| anyhow!("run: missing <component.wasm>"))?;
+    let wasm = std::fs::read(wasm_path).with_context(|| format!("read {wasm_path}"))?;
+
+    let ctx_json = match (flag(args, "--ctx"), flag(args, "--ctx-file")) {
+        (Some(s), _) => s.to_string(),
+        (None, Some(p)) => std::fs::read_to_string(p).with_context(|| format!("read {p}"))?,
+        (None, None) => "{}".to_string(),
+    };
+    let ctx_cbor = json_str_to_cbor(&ctx_json).context("encode ctx")?;
+
+    let snapshot_json = match (flag(args, "--snapshot"), flag(args, "--snapshot-file")) {
+        (Some(s), _) => Some(s.to_string()),
+        (None, Some(p)) => Some(std::fs::read_to_string(p).with_context(|| format!("read {p}"))?),
+        (None, None) => None,
+    };
+    let snapshot = match snapshot_json {
+        Some(s) => parse_snapshot(&s).context("parse snapshot")?,
+        None => Vec::new(),
+    };
+
+    let gas: u64 = flag(args, "--gas")
+        .map(|s| s.parse())
+        .transpose()
+        .context("--gas")?
+        .unwrap_or(DEFAULT_GAS);
+    let agent = flag(args, "--agent").unwrap_or("did:web:etzhayyim.com");
+
+    let exec = if has_flag(args, "--echo-llm") {
+        let engine = Arc::new(|prompt: &str, _max: usize| Ok(format!("echo:{prompt}")));
+        WasmExecutor::with_inference(gas, engine).map_err(|e| anyhow!("executor: {e:?}"))?
+    } else {
+        WasmExecutor::new(gas).map_err(|e| anyhow!("executor: {e:?}"))?
+    };
+
+    let result = exec
+        .execute(
+            "kotoba-clj-cli",
+            &wasm,
+            agent,
+            ctx_cbor,
+            snapshot,
+            HashMap::new(),
+        )
+        .map_err(|e| anyhow!("execute: {e:?}"))?;
+
+    let out = result.output_cbor;
+    println!("output.hex: {}", hex(&out));
+    match ciborium::from_reader::<ciborium::Value, _>(out.as_slice()) {
+        Ok(v) => println!("output.cbor: {v:?}"),
+        Err(_) => println!("output.utf8: {}", String::from_utf8_lossy(&out)),
+    }
+    println!("gas_used: {}", result.gas_used);
+    if !result.assert_quads.is_empty() {
+        println!("asserted: {} quad(s)", result.assert_quads.len());
+    }
+    Ok(())
+}
+
+fn json_str_to_cbor(s: &str) -> Result<Vec<u8>> {
+    let v: serde_json::Value = serde_json::from_str(s)?;
+    let c = json_to_cbor(&v);
+    let mut buf = Vec::new();
+    ciborium::into_writer(&c, &mut buf)?;
+    Ok(buf)
+}
+
+fn json_to_cbor(v: &serde_json::Value) -> ciborium::Value {
+    use ciborium::Value as C;
+    use serde_json::Value as J;
+    match v {
+        J::Null => C::Null,
+        J::Bool(b) => C::Bool(*b),
+        J::Number(n) => {
+            if let Some(u) = n.as_u64() {
+                C::Integer(u.into())
+            } else if let Some(i) = n.as_i64() {
+                C::Integer(i.into())
+            } else {
+                C::Float(n.as_f64().unwrap_or(0.0))
+            }
+        }
+        J::String(s) => C::Text(s.clone()),
+        J::Array(a) => C::Array(a.iter().map(json_to_cbor).collect()),
+        J::Object(o) => C::Map(
+            o.iter()
+                .map(|(k, val)| (C::Text(k.clone()), json_to_cbor(val)))
+                .collect(),
+        ),
+    }
+}
+
+fn parse_snapshot(s: &str) -> Result<Vec<WitQuad>> {
+    let rows: Vec<serde_json::Value> = serde_json::from_str(s)?;
+    let mut out = Vec::with_capacity(rows.len());
+    for (i, r) in rows.iter().enumerate() {
+        let get = |k: &str| -> Result<String> {
+            r.get(k)
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .ok_or_else(|| anyhow!("snapshot[{i}]: missing string field '{k}'"))
+        };
+        let object = r
+            .get("object")
+            .ok_or_else(|| anyhow!("snapshot[{i}]: missing 'object'"))?;
+        let mut object_cbor = Vec::new();
+        ciborium::into_writer(&json_to_cbor(object), &mut object_cbor)?;
+        out.push(WitQuad {
+            graph: get("graph")?,
+            subject: get("subject")?,
+            predicate: get("predicate")?,
+            object_cbor,
+        });
+    }
+    Ok(out)
+}
+
+fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}

--- a/crates/kotoba-clj/src/bin/kotoba_clj.rs
+++ b/crates/kotoba-clj/src/bin/kotoba_clj.rs
@@ -85,8 +85,13 @@ fn positional(args: &[String]) -> Option<&str> {
             // flags that take a value
             if matches!(
                 a.as_str(),
-                "-o" | "--wit" | "--ctx" | "--ctx-file" | "--snapshot" | "--snapshot-file"
-                    | "--gas" | "--agent"
+                "-o" | "--wit"
+                    | "--ctx"
+                    | "--ctx-file"
+                    | "--snapshot"
+                    | "--snapshot-file"
+                    | "--gas"
+                    | "--agent"
             ) {
                 skip_next = true;
             }
@@ -107,8 +112,8 @@ fn cmd_build(args: &[String]) -> Result<()> {
 
     let body = std::fs::read_to_string(cell).with_context(|| format!("read {cell}"))?;
     let src = format!("{}\n{}", prelude(), body);
-    let wasm = compile_kais_component_str(&src, wit)
-        .map_err(|e| anyhow!("compile {cell}: {e:?}"))?;
+    let wasm =
+        compile_kais_component_str(&src, wit).map_err(|e| anyhow!("compile {cell}: {e:?}"))?;
     std::fs::write(&out, &wasm).with_context(|| format!("write {out}"))?;
     eprintln!("[build] {cell} -> {out} ({} bytes)", wasm.len());
     Ok(())

--- a/crates/kotoba-clj/src/cli.rs
+++ b/crates/kotoba-clj/src/cli.rs
@@ -21,44 +21,34 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Context, Result};
-use kotoba_clj::component::compile_kais_component_str;
-use kotoba_clj::prelude;
 use kotoba_runtime::host::WitQuad;
 use kotoba_runtime::WasmExecutor;
+
+use crate::component::compile_kais_component_str;
+use crate::prelude;
 
 const DEFAULT_WIT_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../kotoba-runtime/wit");
 const DEFAULT_GAS: u64 = 10_000_000;
 
-fn main() {
-    if let Err(e) = run() {
-        eprintln!("error: {e:#}");
-        std::process::exit(1);
-    }
-}
+/// One-line summary of the `build`/`run` subcommands, surfaced by `src/main.rs`
+/// in the binary's `--help` output.
+pub const SUBCOMMAND_USAGE: &str = "\
+     kotoba-clj build <cell.clj> [-o <out.wasm>] [--wit <dir>]\n  \
+     kotoba-clj run <component.wasm> [--ctx <json> | --ctx-file <path>] \
+     [--snapshot <json> | --snapshot-file <path>] [--gas <n>] [--agent <did>] [--echo-llm]";
 
-fn run() -> Result<()> {
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    match args.first().map(String::as_str) {
-        Some("build") => cmd_build(&args[1..]),
-        Some("run") => cmd_run(&args[1..]),
-        Some("-h") | Some("--help") | None => {
-            print_usage();
-            Ok(())
-        }
-        Some(other) => {
-            bail!("unknown subcommand '{other}' (expected: build | run)");
-        }
+/// Dispatch the `kotoba-clj <subcommand> …` interface.
+///
+/// `subcommand` is the already-matched `build`|`run` token and `argv` is the
+/// process arguments that follow it; `src/main.rs` routes here when the first
+/// argument is a recognised subcommand, otherwise it runs the legacy file
+/// runner.
+pub fn run(subcommand: &str, argv: &[String]) -> Result<()> {
+    match subcommand {
+        "build" => cmd_build(argv),
+        "run" => cmd_run(argv),
+        other => bail!("unknown subcommand '{other}' (expected: build | run)"),
     }
-}
-
-fn print_usage() {
-    eprintln!(
-        "kotoba-clj — Clojure→WASM cell toolchain\n\n\
-         USAGE:\n  \
-         kotoba-clj build <cell.clj> [-o <out.wasm>] [--wit <dir>]\n  \
-         kotoba-clj run <component.wasm> [--ctx <json> | --ctx-file <path>]\n                 \
-         [--snapshot <json> | --snapshot-file <path>] [--gas <n>] [--agent <did>] [--echo-llm]"
-    );
 }
 
 /// Pull `--flag value` out of args; returns the value if present.

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -116,6 +116,8 @@
 //! loops + byte-building (CBOR decode). See `docs/ADR-clojure-wasm.md`.
 
 pub mod ast;
+#[cfg(feature = "cli")]
+pub mod cli;
 pub mod codegen;
 pub mod compat;
 #[cfg(feature = "component")]

--- a/crates/kotoba-clj/src/main.rs
+++ b/crates/kotoba-clj/src/main.rs
@@ -1,6 +1,24 @@
 use std::path::PathBuf;
 
 fn main() {
+    // `cli` feature: the `kotoba-clj build|run …` toolchain subcommands share this
+    // binary with the legacy file runner. A first arg of `build`/`run` routes to the
+    // subcommand dispatcher; anything else (a source file) falls through to the runner.
+    #[cfg(feature = "cli")]
+    {
+        let mut args = std::env::args().skip(1);
+        if let Some(sub) = args.next() {
+            if sub == "build" || sub == "run" {
+                let rest: Vec<String> = args.collect();
+                if let Err(err) = kotoba_clj::cli::run(&sub, &rest) {
+                    eprintln!("kotoba-clj: {err:#}");
+                    std::process::exit(1);
+                }
+                return;
+            }
+        }
+    }
+
     if let Err(err) = real_main() {
         eprintln!("kotoba-clj: {err}");
         std::process::exit(1);
@@ -144,14 +162,21 @@ fn is_supported_source_ext(path: &std::path::Path) -> bool {
 }
 
 fn usage() -> String {
-    "usage: kotoba-clj [--func NAME|-f NAME] [--no-prelude] [--reader-target kotoba|clj|cljs] [--source-path DIR|-S DIR] [--wasm-out OUT.wasm] [--allow-any-ext] FILE.{kotoba,clj,cljc,cljs} [i64 args...]\n\
+    #[allow(unused_mut)]
+    let mut s = "usage: kotoba-clj [--func NAME|-f NAME] [--no-prelude] [--reader-target kotoba|clj|cljs] [--source-path DIR|-S DIR] [--wasm-out OUT.wasm] [--allow-any-ext] FILE.{kotoba,clj,cljc,cljs} [i64 args...]\n\
      examples:\n\
        kotoba-clj app.kotoba\n\
        kotoba-clj --func fact math.kotoba 10\n\
        kotoba-clj -S src app.clj\n\
        kotoba-clj --reader-target kotoba agent.cljc\n\
        chmod +x app.kotoba && ./app.kotoba"
-        .to_string()
+        .to_string();
+    #[cfg(feature = "cli")]
+    {
+        s.push_str("\n\n  ");
+        s.push_str(kotoba_clj::cli::SUBCOMMAND_USAGE);
+    }
+    s
 }
 
 #[cfg(test)]

--- a/crates/kotoba-clj/tests/hofs.rs
+++ b/crates/kotoba-clj/tests/hofs.rs
@@ -29,12 +29,18 @@ fn map_reader_macro() {
 
 #[test]
 fn filter_even_count() {
-    assert_eq!(eval("(vec-count (filter (fn [x] (even? x)) (vector 1 2 3 4)))"), 2);
+    assert_eq!(
+        eval("(vec-count (filter (fn [x] (even? x)) (vector 1 2 3 4)))"),
+        2
+    );
 }
 
 #[test]
 fn remove_even_count() {
-    assert_eq!(eval("(vec-count (remove (fn [x] (even? x)) (vector 1 2 3 4)))"), 2);
+    assert_eq!(
+        eval("(vec-count (remove (fn [x] (even? x)) (vector 1 2 3 4)))"),
+        2
+    );
 }
 
 #[test]
@@ -87,10 +93,7 @@ fn every_true_and_false() {
 #[test]
 fn comp_composes_two_fns() {
     // ((comp *2 +1) 10) = (10+1)*2 = 22 — comp itself returns a closure
-    assert_eq!(
-        eval("((comp (fn [x] (* x 2)) (fn [x] (+ x 1))) 10)"),
-        22
-    );
+    assert_eq!(eval("((comp (fn [x] (* x 2)) (fn [x] (+ x 1))) 10)"), 22);
 }
 
 #[test]


### PR DESCRIPTION
Adds a domain-agnostic `kotoba-clj` command-line tool behind the optional `cli`
feature so external actors can compile + smoke-test Clojure cells **without
embedding actor-specific tests in the engine**.

## Commands
- `kotoba-clj build <cell.clj> [-o out.wasm] [--wit <dir>]` → kotoba:kais WASM Component
- `kotoba-clj run <component.wasm> --ctx <json> [--snapshot <json>] [--echo-llm]` → run on WasmExecutor, print output_cbor (hex + decoded)

## Notes
- Gated behind `cli` (pulls kotoba-runtime/ciborium/serde_json/anyhow); default builds and `cargo test -p kotoba-clj` unaffected.
- No dependency cycle — kotoba-runtime does not depend on kotoba-clj.
- Motivation: consumed by the `etzhayyim/root` actors `20-actors/{isco,apqc}` (their `build.sh`/`run_tests.sh` call this CLI). This keeps ISCO/APQC out of the substrate engine — engine stays generic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)