### PR TITLE
feat(kotobase): add enterprise tier (5000 pins / 1 TiB)

### DIFF
--- a/crates/kotoba-server/src/kotobase_xrpc.rs
+++ b/crates/kotoba-server/src/kotobase_xrpc.rs
@@ -10,6 +10,7 @@
 //!   free:    3 pins,  100 MB
 //!   starter: 50 pins,   5 GB  ($9/mo — Stripe stub)
 //!   pro:    500 pins,  50 GB  ($49/mo — Stripe stub)
+//!   enterprise: 5000 pins, 1 TB
 
 pub const NSID_ACCOUNT_CREATE: &str = "com.etzhayyim.apps.kotobase.accountCreate";
 pub const NSID_ACCOUNT_STATUS: &str = "com.etzhayyim.apps.kotobase.accountStatus";
@@ -209,11 +210,14 @@ const QUOTA_STARTER_PINS: i64 = 50;
 const QUOTA_STARTER_BYTES: i64 = 5 * 1024 * 1024 * 1024;
 const QUOTA_PRO_PINS: i64 = 500;
 const QUOTA_PRO_BYTES: i64 = 50 * 1024 * 1024 * 1024;
+const QUOTA_ENTERPRISE_PINS: i64 = 5000;
+const QUOTA_ENTERPRISE_BYTES: i64 = 1024 * 1024 * 1024 * 1024; // 1 TiB
 
 fn quota_for_tier(tier: &str) -> (i64, i64) {
     match tier {
         "starter" => (QUOTA_STARTER_PINS, QUOTA_STARTER_BYTES),
         "pro" => (QUOTA_PRO_PINS, QUOTA_PRO_BYTES),
+        "enterprise" => (QUOTA_ENTERPRISE_PINS, QUOTA_ENTERPRISE_BYTES),
         _ => (QUOTA_FREE_PINS, QUOTA_FREE_BYTES),
     }
 }
@@ -646,7 +650,7 @@ pub async fn handle_account_create(
         ));
     }
     let tier = match tier_raw {
-        "free" | "starter" | "pro" => tier_raw.to_string(),
+        "free" | "starter" | "pro" | "enterprise" => tier_raw.to_string(),
         other => return Err((StatusCode::BAD_REQUEST, format!("unknown tier: {other:?}"))),
     };
     let now = now_unix_str();
@@ -1259,8 +1263,15 @@ mod tests {
     }
 
     #[test]
-    fn quota_unknown_tier_falls_back_to_free() {
+    fn quota_enterprise_tier() {
         let (pins, bytes) = quota_for_tier("enterprise");
+        assert_eq!(pins, QUOTA_ENTERPRISE_PINS);
+        assert_eq!(bytes, QUOTA_ENTERPRISE_BYTES);
+    }
+
+    #[test]
+    fn quota_unknown_tier_falls_back_to_free() {
+        let (pins, bytes) = quota_for_tier("platinum");
         assert_eq!(pins, QUOTA_FREE_PINS);
         assert_eq!(bytes, QUOTA_FREE_BYTES);
     }


### PR DESCRIPTION
## Add `enterprise` quota tier (5000 pins / 1 TiB)

The kotobase quota table had `free` (3 / 100 MB), `starter` (50 / 5 GB), `pro` (500 / 50 GB)
but no `enterprise` tier, and `accountCreate` rejected any tier outside `free|starter|pro`.

This adds:
- `QUOTA_ENTERPRISE_PINS = 5000`, `QUOTA_ENTERPRISE_BYTES = 1 TiB` (follows the ×10 pin ladder; 1 TiB bytes);
- `"enterprise" => (QUOTA_ENTERPRISE_PINS, QUOTA_ENTERPRISE_BYTES)` in `quota_for_tier`;
- `"enterprise"` to the `accountCreate` accepted-tier match (no longer `unknown tier`);
- doc-comment tier table line;
- tests: new `quota_enterprise_tier`; the existing fall-back test now uses an actually-unknown tier (`"platinum"`) since `enterprise` is no longer unknown.

Pairs with the gftdcojp/net-kotobase Worker change (tier allowlist `free|starter|pro|enterprise`).
After this lands, the operator rebuilds + redeploys the kotoba pod so the new tier takes effect.

> Authored via the GitHub API (the engine repo is large; no local clone). Please run
> `cargo test -p kotoba-server` in CI to confirm the two quota tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
