### PR TITLE
feat(kotodama): maps3d photogrammetry primitive + py↔clj parity tests

### DIFF
--- a/crates/kotoba-kotodama/py/src/kotodama/primitives/maps3d.py
+++ b/crates/kotoba-kotodama/py/src/kotodama/primitives/maps3d.py
@@ -15,11 +15,14 @@ Env vars:
 from __future__ import annotations
 from kotodama.kotoba_datomic import get_kotoba_client
 
+import datetime as _dt
+import hashlib
 import json
 import os
 import time
 import urllib.error
 import urllib.request
+import uuid
 from typing import Any
 
 from kotodama import llm as _llm
@@ -109,6 +112,105 @@ def _h3_to_bbox(tile_h3: str) -> tuple[float, float, float, float]:
     lat_raw = ((idx >> 4) & 0xFFFFFF) / 0xFFFFFF * 180.0 - 90.0
     lng_raw = ((idx >> 28) & 0xFFFFFF) / 0xFFFFFF * 360.0 - 180.0
     return lng_raw - deg_pad, lat_raw - deg_pad, lng_raw + deg_pad, lat_raw + deg_pad
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Datom-log persistence (ADR-2605262130 / 2605312345: the kotoba Datom log
+# is first-class canonical state — Datomic-isomorphic EAVT, no RisingWave).
+#
+# processTile.bpmn's "mark tile done" step documents that "the worker tasks
+# have already INSERT-ed into vertex_spatial / vertex_vision_result / edge_*".
+# These helpers make that contract true: visionAnnotate lands its detections
+# in vertex_vision_result and linkActor lands its edges in
+# edge_maps3d_actor_link, both via the kotoba Datomic client's upsert surface
+# (:db.unique/identity on vertex_id → re-transact is idempotent).
+# ──────────────────────────────────────────────────────────────────────
+
+DEFAULT_REPO = "did:web:maps.etzhayyim.com"
+COLLECTION_VISION = "com.etzhayyim.apps.maps3d.visionResult"
+COLLECTION_ACTOR_LINK = "com.etzhayyim.apps.maps3d.actorLink"
+
+
+def _now_iso() -> str:
+    return (
+        _dt.datetime.now(tz=_dt.UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _stable_rkey(*parts: str) -> str:
+    """Deterministic rkey so re-running a tile upserts instead of duplicating."""
+    return hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()[:16]
+
+
+def _persist_vision_results(tile_h3: str, detections: list[dict]) -> int:
+    """Upsert vision detections into vertex_vision_result. Returns rows written.
+
+    Fail-open (matches the maps actor's kotoba-first/fail-open posture): a
+    substrate outage logs nothing-special and returns the count written so far
+    rather than failing the pipeline task.
+    """
+    if not tile_h3 or not detections:
+        return 0
+    client = get_kotoba_client()
+    now = _now_iso()
+    written = 0
+    for det in detections:
+        label = str(det.get("label") or "").strip()
+        if not label:
+            continue
+        image_ref = str(det.get("imageRef") or "")
+        rkey = _stable_rkey(tile_h3, label, image_ref)
+        row = {
+            "vertex_id": f"at://{DEFAULT_REPO}/{COLLECTION_VISION}/{rkey}",
+            "tile_h3": tile_h3,
+            "label": label,
+            "confidence": float(det.get("confidence") or 0),
+            "category": str(det.get("category") or "building"),
+            "image_ref": image_ref,
+            "source": "murakumo-vision",
+            "ingest_at": now,
+            "owner_did": DEFAULT_REPO,
+        }
+        try:
+            client.insert_row("vertex_vision_result", row)
+            written += 1
+        except Exception:
+            break  # substrate unavailable — fail-open, keep what landed
+    return written
+
+
+def _persist_actor_links(tile_h3: str, links: list[dict]) -> int:
+    """Upsert resolved actor links into edge_maps3d_actor_link. Returns rows written."""
+    if not tile_h3 or not links:
+        return 0
+    client = get_kotoba_client()
+    now = _now_iso()
+    written = 0
+    for lk in links:
+        actor_did = str(lk.get("actorDid") or "")
+        if not actor_did:
+            continue
+        label = str(lk.get("label") or lk.get("detectionId") or "")
+        rkey = _stable_rkey(tile_h3, label, actor_did)
+        row = {
+            "vertex_id": f"at://{DEFAULT_REPO}/{COLLECTION_ACTOR_LINK}/{rkey}",
+            "tile_h3": tile_h3,
+            "label": label,
+            "actor_did": actor_did,
+            "confidence": float(lk.get("confidence") or 0),
+            "source": str(lk.get("source") or "llm-disambiguate"),
+            "ingest_at": now,
+            "owner_did": DEFAULT_REPO,
+        }
+        try:
+            client.insert_row("edge_maps3d_actor_link", row)
+            written += 1
+        except Exception:
+            break  # fail-open
+    return written
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -512,7 +614,8 @@ async def task_maps3d_vision_annotate(
         except (json.JSONDecodeError, ValueError, TypeError):
             continue
 
-    return {"ok": True, "detections": all_detections}
+    persisted = _persist_vision_results(tileH3, all_detections)
+    return {"ok": True, "detections": all_detections, "persisted": persisted}
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -540,20 +643,18 @@ async def task_maps3d_link_actor(
         return {"ok": True, "links": []}
 
 
-    # Query actor_registry for nearby/relevant actors.
+    # Query the actor registry for candidate actors. Uses the kotoba Datomic
+    # client's Datalog-backed select shim (the prior SELECT-string passed to the
+    # Datalog `q()` endpoint never parsed, and its column list was always empty).
     registry_rows: list[dict] = []
     try:
-        if True:
-            client = get_kotoba_client()
-            _res = client.q(
-                "SELECT did, handle, display_name "
-                "FROM actor_registry "
-                "WHERE status = 'active' "
-                "LIMIT 200"
-            )
-            cols = [d[0] for d in ([] or [])]
-            for row in (_res or []):
-                registry_rows.append(dict(zip(cols, row)))
+        registry_rows = get_kotoba_client().select_where(
+            "vertex_actor_registry",
+            "status",
+            "active",
+            ["did", "handle", "display_name"],
+            limit=200,
+        )
     except Exception:
         pass  # registry unavailable; proceed with detection-only linkage
 
@@ -586,9 +687,10 @@ async def task_maps3d_link_actor(
             if float(lk.get("confidence") or 0) >= minConfidence
                and lk.get("actorDid")
         ]
-        return {"ok": True, "links": links}
+        persisted = _persist_actor_links(tileH3, links)
+        return {"ok": True, "links": links, "persisted": persisted}
 
-    return {"ok": True, "links": []}
+    return {"ok": True, "links": [], "persisted": 0}
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -596,7 +698,16 @@ async def task_maps3d_link_actor(
 # ──────────────────────────────────────────────────────────────────────
 
 def register(worker: Any, *, timeout_ms: int = 120_000) -> None:
-    """Wire all maps3d task types onto the shared LangServer worker."""
+    """Wire all maps3d task types onto the shared LangServer worker.
+
+    DEPRECATED (Zeebe path): the Zeebe/BPMN-engine execution of processTile is
+    being retired in favour of the kotoba + Datomic engine
+    ``maps.methods.maps3d-bpmn`` (Clojure), which drives the same flow over the
+    Datom log with no external workflow engine. These task *implementations*
+    stay live and are reused as injected handlers by the Datomic engine; only
+    the Zeebe *worker registration* is deprecated. Do not add new Zeebe-only
+    task types here — model new steps in the BPMN process-def datoms instead.
+    """
 
     def t(name: str, fn: Any, *, ms: int | None = None) -> None:
         worker.task(task_type=name, single_value=False, timeout_ms=ms or timeout_ms)(fn)

--- a/crates/kotoba-kotodama/py/tests/test_maps3d_parity.py
+++ b/crates/kotoba-kotodama/py/tests/test_maps3d_parity.py
@@ -1,0 +1,111 @@
+"""py↔clj parity cross-check for the maps3d decision tasks.
+
+The migration keeps the Python tasks (maps3d.py) and the Clojure reimplementation
+(20-actors/maps/methods/maps3d_tasks.cljc) in PARALLEL. This test feeds identical
+inputs to BOTH implementations and asserts they make the SAME deterministic
+decision — guarding the parallel pair against silent drift.
+
+Scope = the branches both implement identically with no LLM:
+  - curateImages: empty→abort, below-min→abort, top-N-by-quality fallback
+    (the Python LLM is forced to fail so its FALLBACK path — the one the clj
+    port mirrors — is exercised)
+  - replanReconstruction: attempt≥3→downgradeOsm, <5 images→requestMore
+
+Skipped when `bb` (babashka) is not on PATH.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_py_src = Path(__file__).resolve().parents[1] / "src"
+if str(_py_src) not in sys.path:
+    sys.path.insert(0, str(_py_src))
+
+from kotodama.primitives import maps3d as M
+
+_REPO_ROOT = Path(__file__).resolve().parents[6]
+_BB = shutil.which("bb")
+
+pytestmark = pytest.mark.skipif(_BB is None, reason="babashka (bb) not installed")
+
+
+def _bb(code: str) -> str:
+    """Run a bb expression from the repo root (so maps.methods.* is on cp)."""
+    out = subprocess.run([_BB, "-e", code], cwd=_REPO_ROOT,
+                         capture_output=True, text=True, timeout=120)
+    assert out.returncode == 0, f"bb failed: {out.stderr}"
+    return out.stdout.strip()
+
+
+def _clj_curate(candidates, target, min_count) -> tuple[bool, list[str]]:
+    code = (
+        "(require '[maps.methods.maps3d-tasks :as t] '[clojure.string :as s])"
+        f"(let [o (t/curate-images {{:candidates {_edn_cands(candidates)} "
+        f":target-count {target} :min-count {min_count}}})]"
+        "(println (str (:abort o) \"|\" (s/join \",\" (:selectedIds o)))))"
+    )
+    abort_s, _, ids_s = _bb(code).partition("|")
+    return abort_s == "true", ([x for x in ids_s.split(",") if x])
+
+
+def _clj_replan(attempt, image_count) -> str:
+    code = (
+        "(require '[maps.methods.maps3d-tasks :as t])"
+        f"(println (:action (t/replan {{:attempt {attempt} :image-count {image_count}}})))"
+    )
+    return _bb(code)
+
+
+def _edn_cands(cands) -> str:
+    return "[" + " ".join(
+        "{:id \"%s\" :qualityScore %s}" % (c["id"], c["qualityScore"]) for c in cands
+    ) + "]"
+
+
+def _py_curate(candidates, target, min_count) -> tuple[bool, list[str]]:
+    # force the LLM to fail so the deterministic fallback (mirrored by clj) runs
+    with patch.object(M._llm, "call_tier_json", side_effect=RuntimeError("no llm")):
+        out = asyncio.run(M.task_maps3d_curate_images(
+            tileH3="t", candidates=candidates, targetCount=target, minCount=min_count))
+    return bool(out["abort"]), list(out["selectedIds"])
+
+
+def _py_replan(attempt, image_count) -> str:
+    out = asyncio.run(M.task_maps3d_replan_reconstruction(
+        tileH3="t", imageCount=image_count, attempt=attempt))
+    return out["action"]
+
+
+# ─── curate parity ────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("cands,target,minc", [
+    ([], 30, 8),                                                   # empty → abort
+    ([{"id": "1", "qualityScore": 0.9}, {"id": "2", "qualityScore": 0.8}], 30, 8),  # below min
+    ([{"id": str(i), "qualityScore": round(1.0 - i * 0.01, 3)} for i in range(20)], 5, 3),  # top-N
+])
+def test_curate_parity(cands, target, minc):
+    py_abort, py_ids = _py_curate(cands, target, minc)
+    clj_abort, clj_ids = _clj_curate(cands, target, minc)
+    assert py_abort == clj_abort, f"abort differs: py={py_abort} clj={clj_abort}"
+    assert py_ids == clj_ids, f"selectedIds differ: py={py_ids} clj={clj_ids}"
+
+
+# ─── replan parity (deterministic rule branches) ─────────────────────────────
+
+@pytest.mark.parametrize("attempt,images", [
+    (3, 10),     # max attempts → downgradeOsm
+    (4, 99),     # >max attempts → downgradeOsm
+    (1, 2),      # too few images → requestMore
+    (2, 0),      # too few images → requestMore
+])
+def test_replan_parity(attempt, images):
+    assert _py_replan(attempt, images) == _clj_replan(attempt, images)

--- a/crates/kotoba-kotodama/py/tests/test_maps3d_persist.py
+++ b/crates/kotoba-kotodama/py/tests/test_maps3d_persist.py
@@ -1,0 +1,137 @@
+"""Datom-log persistence tests for the maps3d pipeline.
+
+Covers the gap closed in this change: the photogrammetry pipeline computed
+detections + actor links but never landed them in the kotoba Datom log, even
+though processTile.bpmn's "mark tile done" step documents that the worker tasks
+"have already INSERT-ed into vertex_vision_result / edge_*". These tests assert
+the helpers now upsert via the kotoba Datomic client (ADR-2605262130) and that
+the prior linkActor registry-read bug (SELECT string → Datalog q(), empty cols)
+is fixed to use the Datalog-backed select shim.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+_py_src = Path(__file__).resolve().parents[1] / "src"
+if str(_py_src) not in sys.path:
+    sys.path.insert(0, str(_py_src))
+
+from kotodama.primitives import maps3d as M
+
+
+class _FakeClient:
+    """Records insert_row upserts and serves a canned select_where result."""
+
+    def __init__(self, registry_rows=None):
+        self.inserts: list[tuple[str, dict]] = []
+        self._registry_rows = registry_rows or []
+        self.select_calls: list[tuple] = []
+
+    def insert_row(self, table, row):
+        self.inserts.append((table, dict(row)))
+        return {"datom_count": len(row)}
+
+    def select_where(self, table, column, value, columns=(), *, limit=100):
+        self.select_calls.append((table, column, value, tuple(columns), limit))
+        return list(self._registry_rows)
+
+
+# ─── _stable_rkey ───────────────────────────────────────────────────────────
+
+def test_stable_rkey_is_deterministic_and_collision_resistant():
+    a = M._stable_rkey("tileX", "Starbucks", "img1")
+    assert a == M._stable_rkey("tileX", "Starbucks", "img1")  # idempotent
+    assert a != M._stable_rkey("tileX", "Starbucks", "img2")  # field-sensitive
+    assert len(a) == 16
+
+
+# ─── _persist_vision_results ─────────────────────────────────────────────────
+
+def test_persist_vision_results_upserts_each_detection():
+    fake = _FakeClient()
+    detections = [
+        {"label": "Starbucks", "confidence": 0.9, "category": "business", "imageRef": "img1"},
+        {"label": "Tower", "confidence": 0.8, "category": "landmark", "imageRef": "img2"},
+    ]
+    with patch.object(M, "get_kotoba_client", return_value=fake):
+        n = M._persist_vision_results("tile-h3-abc", detections)
+
+    assert n == 2
+    assert {t for t, _ in fake.inserts} == {"vertex_vision_result"}
+    first = fake.inserts[0][1]
+    assert first["tile_h3"] == "tile-h3-abc"
+    assert first["label"] == "Starbucks"
+    assert first["vertex_id"].startswith("at://did:web:maps.etzhayyim.com/")
+
+
+def test_persist_vision_results_is_idempotent_across_reruns():
+    fake = _FakeClient()
+    dets = [{"label": "Cafe", "confidence": 0.7, "imageRef": "imgA"}]
+    with patch.object(M, "get_kotoba_client", return_value=fake):
+        M._persist_vision_results("t1", dets)
+        M._persist_vision_results("t1", dets)
+    # same vertex_id both times → re-transact upserts (unique/identity), no dup id
+    ids = [row["vertex_id"] for _, row in fake.inserts]
+    assert len(ids) == 2 and ids[0] == ids[1]
+
+
+def test_persist_vision_results_skips_blank_labels_and_empty_input():
+    fake = _FakeClient()
+    with patch.object(M, "get_kotoba_client", return_value=fake):
+        assert M._persist_vision_results("t1", [{"label": "  "}]) == 0
+        assert M._persist_vision_results("t1", []) == 0
+        assert M._persist_vision_results("", [{"label": "X"}]) == 0
+    assert fake.inserts == []
+
+
+def test_persist_vision_results_fails_open_on_substrate_error():
+    class _Boom(_FakeClient):
+        def insert_row(self, table, row):
+            raise RuntimeError("kotoba node down")
+
+    with patch.object(M, "get_kotoba_client", return_value=_Boom()):
+        # must not raise — pipeline task stays alive (kotoba-first/fail-open)
+        assert M._persist_vision_results("t1", [{"label": "X"}]) == 0
+
+
+# ─── _persist_actor_links ────────────────────────────────────────────────────
+
+def test_persist_actor_links_upserts_edges():
+    fake = _FakeClient()
+    links = [
+        {"label": "Starbucks", "actorDid": "did:web:maps.etzhayyim.com:registry:wikidata:Q38076",
+         "confidence": 0.95, "source": "wikidata"},
+        {"label": "NoDid", "actorDid": "", "confidence": 0.99},  # dropped: no DID
+    ]
+    with patch.object(M, "get_kotoba_client", return_value=fake):
+        n = M._persist_actor_links("tile-9", links)
+
+    assert n == 1
+    table, row = fake.inserts[0]
+    assert table == "edge_maps3d_actor_link"
+    assert row["actor_did"].endswith("Q38076")
+    assert row["source"] == "wikidata"
+
+
+# ─── registry-read bug fix (linkActor) ───────────────────────────────────────
+
+def test_link_actor_uses_select_shim_not_sql_string():
+    fake = _FakeClient(registry_rows=[{"did": "did:web:x", "handle": "x", "display_name": "X"}])
+    # Force the LLM path to fail so we exercise only the registry read + return,
+    # without needing a live Murakumo backend.
+    with patch.object(M, "get_kotoba_client", return_value=fake), \
+         patch.object(M._llm, "call_tier_json", side_effect=RuntimeError("no llm")):
+        out = asyncio.run(M.task_maps3d_link_actor(
+            tileH3="tile-1",
+            detections=[{"label": "Starbucks"}],
+        ))
+
+    assert out["ok"] is True
+    # the fix routes through select_where on the vertex_actor_registry table
+    assert fake.select_calls, "registry read must use the Datalog select shim"
+    table, column, value, _cols, _limit = fake.select_calls[0]
+    assert (table, column, value) == ("vertex_actor_registry", "status", "active")

--- a/crates/kotoba-kotodama/py/tests/test_maps3d_pipeline.py
+++ b/crates/kotoba-kotodama/py/tests/test_maps3d_pipeline.py
@@ -1,0 +1,158 @@
+"""Success / parse-path tests for the maps3d Python task bodies.
+
+The earlier suites (test_maps3d_tasks.py) covered the guard branches; this covers
+the network/LLM SUCCESS paths with mocked I/O (no COLMAP / Mapillary / Murakumo):
+the COLMAP + simplify poll loops, vision JSON-from-LLM parsing + dedup, and link
+disambiguation parsing + persistence. Keeps the Python side at parity with the
+Clojure reimplementation (maps3d_net_tasks.cljc).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+_py_src = Path(__file__).resolve().parents[1] / "src"
+if str(_py_src) not in sys.path:
+    sys.path.insert(0, str(_py_src))
+
+from kotodama.primitives import maps3d as M
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ─── colmapTile poll loop ─────────────────────────────────────────────────────
+
+def test_colmap_poll_done():
+    with patch.object(M, "_http_post", return_value={"jobId": "j1"}), \
+         patch.object(M, "_http_get", return_value={"status": "done", "rawMeshUri": "ipfs://m", "imageCount": 12}), \
+         patch.object(M.time, "sleep", lambda *_: None):
+        out = _run(M.task_maps3d_colmap_tile(tileH3="t", selectedIds=["a", "b"],
+                                             imageUrls=[{"id": "a", "thumbUrl": "u"}]))
+    assert out["ok"] is True
+    assert out["rawMeshUri"] == "ipfs://m"
+    assert out["imageCount"] == 12
+
+
+def test_colmap_poll_failed():
+    with patch.object(M, "_http_post", return_value={"job_id": "j1"}), \
+         patch.object(M, "_http_get", return_value={"status": "failed", "errorCode": "DEGENERATE", "imageCount": 3}), \
+         patch.object(M.time, "sleep", lambda *_: None):
+        out = _run(M.task_maps3d_colmap_tile(tileH3="t", selectedIds=["a"]))
+    assert out["ok"] is False
+    assert out["errorCode"] == "DEGENERATE"
+    assert out["imageCount"] == 3
+
+
+def test_colmap_poll_timeout():
+    with patch.object(M, "_http_post", return_value={"jobId": "j1"}), \
+         patch.object(M, "_http_get", return_value={"status": "running"}), \
+         patch.object(M.time, "sleep", lambda *_: None), \
+         patch.object(M, "_COLMAP_MAX_POLLS", 3):
+        out = _run(M.task_maps3d_colmap_tile(tileH3="t", selectedIds=["a"]))
+    assert out["errorCode"] == "POLL_TIMEOUT"
+
+
+def test_colmap_transient_get_error_keeps_polling():
+    calls = {"n": 0}
+
+    def flaky_get(*_a, **_k):
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise RuntimeError("transient")
+        return {"status": "done", "rawMeshUri": "ipfs://m"}
+
+    with patch.object(M, "_http_post", return_value={"jobId": "j1"}), \
+         patch.object(M, "_http_get", side_effect=flaky_get), \
+         patch.object(M.time, "sleep", lambda *_: None):
+        out = _run(M.task_maps3d_colmap_tile(tileH3="t", selectedIds=["a"]))
+    assert out["ok"] is True
+
+
+# ─── simplifyAndExport poll loop ──────────────────────────────────────────────
+
+def test_simplify_poll_done():
+    with patch.object(M, "_http_post", return_value={"jobId": "s1"}), \
+         patch.object(M, "_http_get", return_value={"status": "done", "tileMeshUri": "ipfs://glb", "triangleCount": 4800}), \
+         patch.object(M.time, "sleep", lambda *_: None):
+        out = _run(M.task_maps3d_simplify_and_export(tileH3="t", rawMeshUri="ipfs://m"))
+    assert out["ok"] is True
+    assert out["tileMeshUri"] == "ipfs://glb"
+    assert out["triangleCount"] == 4800
+
+
+def test_simplify_poll_failed():
+    with patch.object(M, "_http_post", return_value={"jobId": "s1"}), \
+         patch.object(M, "_http_get", return_value={"status": "failed", "errorMessage": "non-manifold"}), \
+         patch.object(M.time, "sleep", lambda *_: None):
+        out = _run(M.task_maps3d_simplify_and_export(tileH3="t", rawMeshUri="ipfs://m"))
+    assert out["ok"] is False
+    assert "non-manifold" in out["error"]
+
+
+# ─── visionAnnotate: parse LLM JSON, dedup, confidence filter ─────────────────
+
+def test_vision_parses_and_filters():
+    content = ('noise {"detections":[{"label":"Starbucks","confidence":0.9,"category":"business"},'
+               '{"label":"Blur","confidence":0.2}]} trailing')
+    with patch.object(M._llm, "call_tier", return_value={"content": content}), \
+         patch.object(M, "get_kotoba_client", return_value=_FakeClient()):
+        out = _run(M.task_maps3d_vision_annotate(tileH3="t",
+                                                 imageRefs=[{"id": "i1", "thumbUrl": "http://x/1"}],
+                                                 minConfidence=0.55))
+    assert len(out["detections"]) == 1               # low-confidence dropped
+    assert out["detections"][0]["label"] == "Starbucks"
+
+
+def test_vision_dedupes_labels_across_images():
+    with patch.object(M._llm, "call_tier", return_value={"content": '{"detections":[{"label":"Tower","confidence":0.9}]}'}), \
+         patch.object(M, "get_kotoba_client", return_value=_FakeClient()):
+        out = _run(M.task_maps3d_vision_annotate(tileH3="t",
+                                                 imageRefs=[{"id": "i1", "thumbUrl": "u1"},
+                                                            {"id": "i2", "thumbUrl": "u2"}]))
+    assert len(out["detections"]) == 1               # same label deduped
+
+
+def test_vision_persists_detections():
+    fake = _FakeClient()
+    with patch.object(M._llm, "call_tier", return_value={"content": '{"detections":[{"label":"Cafe","confidence":0.9}]}'}), \
+         patch.object(M, "get_kotoba_client", return_value=fake):
+        out = _run(M.task_maps3d_vision_annotate(tileH3="t", imageRefs=[{"id": "i1", "thumbUrl": "u1"}]))
+    assert out["persisted"] == 1
+    assert fake.inserts and fake.inserts[0][0] == "vertex_vision_result"
+
+
+# ─── linkActor: parse links, confidence filter, persist ──────────────────────
+
+def test_link_parses_and_filters_and_persists():
+    fake = _FakeClient()
+    llm_ret = {"ok": True, "data": {"links": [
+        {"label": "Starbucks", "actorDid": "did:web:a", "confidence": 0.95},
+        {"label": "Weak", "actorDid": "did:web:b", "confidence": 0.4},   # below min
+        {"label": "NoDid", "actorDid": "", "confidence": 0.99},          # no DID
+    ]}}
+    with patch.object(M, "get_kotoba_client", return_value=fake), \
+         patch.object(M._llm, "call_tier_json", return_value=llm_ret):
+        out = _run(M.task_maps3d_link_actor(tileH3="t", detections=[{"label": "Starbucks"}], minConfidence=0.7))
+    assert len(out["links"]) == 1
+    assert out["links"][0]["actorDid"] == "did:web:a"
+    assert out["persisted"] == 1
+    assert fake.inserts[0][0] == "edge_maps3d_actor_link"
+
+
+class _FakeClient:
+    """Records insert_row upserts; serves empty registry for select_where."""
+
+    def __init__(self):
+        self.inserts = []
+
+    def insert_row(self, table, row):
+        self.inserts.append((table, dict(row)))
+        return {"datom_count": len(row)}
+
+    def select_where(self, *_a, **_k):
+        return []

--- a/crates/kotoba-kotodama/py/tests/test_maps3d_tasks.py
+++ b/crates/kotoba-kotodama/py/tests/test_maps3d_tasks.py
@@ -1,0 +1,197 @@
+"""Guard-branch + pure-helper tests for the maps3d pipeline task functions.
+
+These exercise the no-network / no-LLM code paths of every task (input guards,
+rule-based early returns, deterministic fallbacks) to raise branch-coverage
+maturity of kotodama.primitives.maps3d without standing up COLMAP / Mapillary /
+Murakumo. Network/LLM-bound success paths are deliberately out of scope here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+_py_src = Path(__file__).resolve().parents[1] / "src"
+if str(_py_src) not in sys.path:
+    sys.path.insert(0, str(_py_src))
+
+from kotodama.primitives import maps3d as M
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ─── _h3_to_bbox (fallback path, no h3 library) ──────────────────────────────
+
+def test_h3_to_bbox_returns_ordered_box():
+    # With or without the h3 library installed, the result must be a valid
+    # (west, south, east, north) box with west<east and south<north.
+    west, south, east, north = M._h3_to_bbox("8f2830828052d25")
+    assert west < east
+    assert south < north
+
+
+def test_h3_to_bbox_bad_input_falls_back_to_tokyo_default():
+    # Non-hex, non-int garbage hits the ValueError fallback → Tokyo centre box.
+    box = M._h3_to_bbox("not-a-real-h3-!@#")
+    # h3 lib (if present) would raise→handled; fallback path yields the Tokyo box.
+    assert box == (139.6, 35.5, 139.8, 35.7) or (box[0] < box[2] and box[1] < box[3])
+
+
+# ─── fetchMapillary guards ───────────────────────────────────────────────────
+
+def test_fetch_mapillary_requires_tile():
+    out = _run(M.task_maps3d_fetch_mapillary(tileH3=""))
+    assert out["ok"] is False
+    assert out["error"] == "tileH3 required"
+    assert out["candidates"] == [] and out["totalAvailable"] == 0
+
+
+def test_fetch_mapillary_requires_token(monkeypatch=None):
+    with patch.object(M, "_MAPILLARY_TOKEN", ""):
+        out = _run(M.task_maps3d_fetch_mapillary(tileH3="8f2830828052d25"))
+    assert out["ok"] is False
+    assert out["error"] == "MAPILLARY_TOKEN not set"
+
+
+def test_fetch_mapillary_filters_by_quality_and_maps_fields():
+    fake_resp = {"data": [
+        {"id": "a", "thumb_1024_url": "http://x/a.jpg",
+         "computed_geometry": {"coordinates": [139.7, 35.6]},
+         "quality_score": 0.9, "captured_at": "t", "compass_angle": 12.0},
+        {"id": "b", "quality_score": 0.1},  # below minQuality → dropped
+    ]}
+    with patch.object(M, "_MAPILLARY_TOKEN", "tok"), \
+         patch.object(M, "_http_get", return_value=fake_resp):
+        out = _run(M.task_maps3d_fetch_mapillary(tileH3="8f2830828052d25", minQuality=0.5))
+    assert out["ok"] is True
+    assert out["totalAvailable"] == 1
+    cand = out["candidates"][0]
+    assert cand["id"] == "a" and cand["lng"] == 139.7 and cand["lat"] == 35.6
+
+
+def test_fetch_mapillary_handles_http_error():
+    with patch.object(M, "_MAPILLARY_TOKEN", "tok"), \
+         patch.object(M, "_http_get", side_effect=RuntimeError("HTTP 429")):
+        out = _run(M.task_maps3d_fetch_mapillary(tileH3="8f2830828052d25"))
+    assert out["ok"] is False and "429" in out["error"]
+
+
+# ─── curateImages guards + fallback ──────────────────────────────────────────
+
+def test_curate_images_no_candidates_aborts():
+    out = _run(M.task_maps3d_curate_images(tileH3="t", candidates=[]))
+    assert out["ok"] is False and out["abort"] is True
+
+
+def test_curate_images_below_min_count_aborts():
+    cands = [{"id": "1", "qualityScore": 0.9}, {"id": "2", "qualityScore": 0.8}]
+    out = _run(M.task_maps3d_curate_images(tileH3="t", candidates=cands, minCount=8))
+    assert out["abort"] is True
+    assert out["selectedIds"] == ["1", "2"]
+
+
+def test_curate_images_llm_failure_falls_back_to_top_n():
+    cands = [{"id": str(i), "qualityScore": 1.0 - i * 0.01, "compassAngle": i}
+             for i in range(20)]
+    with patch.object(M._llm, "call_tier_json", side_effect=RuntimeError("no llm")):
+        out = _run(M.task_maps3d_curate_images(
+            tileH3="t", candidates=cands, targetCount=5, minCount=3))
+    assert out["ok"] is True
+    assert "fallback" in out
+    assert len(out["selectedIds"]) == 5
+    assert out["selectedIds"][0] == "0"  # highest quality first
+
+
+def test_curate_images_uses_llm_selection_when_available():
+    cands = [{"id": str(i), "qualityScore": 0.9, "compassAngle": i} for i in range(20)]
+    llm_ret = {"ok": True, "data": {"selected": ["3", "7", "9"], "abort": False}}
+    with patch.object(M._llm, "call_tier_json", return_value=llm_ret):
+        out = _run(M.task_maps3d_curate_images(
+            tileH3="t", candidates=cands, targetCount=5, minCount=3))
+    assert out["selectedIds"] == ["3", "7", "9"]
+    assert out["abort"] is False
+
+
+# ─── colmapTile guard ────────────────────────────────────────────────────────
+
+def test_colmap_tile_missing_input_guard():
+    out = _run(M.task_maps3d_colmap_tile(tileH3="", selectedIds=[]))
+    assert out["ok"] is False
+    assert out["errorCode"] == "MISSING_INPUT"
+
+
+def test_colmap_tile_submit_failure():
+    with patch.object(M, "_http_post", side_effect=RuntimeError("conn refused")):
+        out = _run(M.task_maps3d_colmap_tile(tileH3="t", selectedIds=["a"]))
+    assert out["ok"] is False and out["errorCode"] == "SUBMIT_FAILED"
+
+
+def test_colmap_tile_no_job_id():
+    with patch.object(M, "_http_post", return_value={"unexpected": 1}):
+        out = _run(M.task_maps3d_colmap_tile(tileH3="t", selectedIds=["a"]))
+    assert out["ok"] is False and out["errorCode"] == "NO_JOB_ID"
+
+
+# ─── replanReconstruction rule branches (no LLM) ─────────────────────────────
+
+def test_replan_max_attempts_downgrades_to_osm():
+    out = _run(M.task_maps3d_replan_reconstruction(tileH3="t", attempt=3))
+    assert out["action"] == "downgradeOsm"
+
+
+def test_replan_too_few_images_requests_more():
+    out = _run(M.task_maps3d_replan_reconstruction(
+        tileH3="t", imageCount=2, attempt=1))
+    assert out["action"] == "requestMore"
+
+
+def test_replan_llm_unavailable_defaults_to_retry():
+    with patch.object(M._llm, "call_tier_json", side_effect=RuntimeError("no llm")):
+        out = _run(M.task_maps3d_replan_reconstruction(
+            tileH3="t", errorCode="X", imageCount=20, attempt=1))
+    assert out["action"] == "retry"
+
+
+def test_replan_llm_sanitizes_unknown_action():
+    bad = {"ok": True, "data": {"action": "explode", "rationale": "?"}}
+    with patch.object(M._llm, "call_tier_json", return_value=bad):
+        out = _run(M.task_maps3d_replan_reconstruction(
+            tileH3="t", imageCount=20, attempt=1))
+    assert out["action"] == "retry"  # unknown action coerced to retry
+
+
+# ─── simplifyAndExport guards ────────────────────────────────────────────────
+
+def test_simplify_requires_raw_mesh():
+    out = _run(M.task_maps3d_simplify_and_export(tileH3="t", rawMeshUri=""))
+    assert out["ok"] is False and "rawMeshUri" in out["error"]
+
+
+def test_simplify_submit_failure():
+    with patch.object(M, "_http_post", side_effect=RuntimeError("boom")):
+        out = _run(M.task_maps3d_simplify_and_export(tileH3="t", rawMeshUri="ipfs://m"))
+    assert out["ok"] is False and "boom" in out["error"]
+
+
+def test_simplify_no_job_id():
+    with patch.object(M, "_http_post", return_value={}):
+        out = _run(M.task_maps3d_simplify_and_export(tileH3="t", rawMeshUri="ipfs://m"))
+    assert out["ok"] is False and "no job_id" in out["error"]
+
+
+# ─── visionAnnotate empty-input fast path ────────────────────────────────────
+
+def test_vision_annotate_empty_image_refs_returns_empty():
+    out = _run(M.task_maps3d_vision_annotate(tileH3="t", imageRefs=[]))
+    assert out["ok"] is True and out["detections"] == []
+
+
+# ─── linkActor empty-detections fast path ────────────────────────────────────
+
+def test_link_actor_no_detections_returns_empty():
+    out = _run(M.task_maps3d_link_actor(tileH3="t", detections=[]))
+    assert out["ok"] is True and out["links"] == []


### PR DESCRIPTION
Matures the kotodama `maps3d` primitive (the Python parallel implementation of the maps3d BPMN pipeline whose Clojure engine landed in `etzhayyim/root` ADR-2606162041) and adds 46 tests.

## What
- `crates/kotoba-kotodama/py/src/kotodama/primitives/maps3d.py` — matured primitive (+127/-16).
- 4 new test modules: parity, persist, pipeline, tasks.

## Why
Keeps the Python path as a **drift-guarded parallel implementation** per the operator "keep py parallel" directive: identical inputs to the Python and Clojure decision tasks must yield identical decisions (`test_maps3d_parity.py`). The clj engine is substrate-pure; the Python primitive stays usable without a Clojure runtime.

## Tests
`46 passed` (pytest). Covers py↔clj decision parity (curate fallback + replan rules), persist round-trip, pipeline success paths, and task guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)