### PR TITLE
fix(unispsc): correct openUnispsc commodity NSID (drop doubled etzhayyim segment)

### DIFF
--- a/crates/kotoba-kotodama/cells/deployment_planning/cell.py
+++ b/crates/kotoba-kotodama/cells/deployment_planning/cell.py
@@ -65,7 +65,7 @@ logger = logging.getLogger("DeploymentPlanningCell")
 UNISPSC_XRPC_ENDPOINT = os.environ.get(
     "UNISPSC_XRPC_ENDPOINT", "https://unispsc.etzhayyim.com"
 )
-UNISPSC_COMMODITY_NSID = "com.etzhayyim.etzhayyim.apps.openUnispsc.commodity"
+UNISPSC_COMMODITY_NSID = "com.etzhayyim.apps.openUnispsc.commodity"
 
 # Default UNSPSC code mapping per utility class. Codes target realistic
 # mid-segment commodities (8-digit) rather than bare segment roots; the

--- a/crates/kotoba-kotodama/cells/site_survey/cell.py
+++ b/crates/kotoba-kotodama/cells/site_survey/cell.py
@@ -52,7 +52,7 @@ logger = logging.getLogger("SiteSurveyCell")
 UNISPSC_XRPC_ENDPOINT = os.environ.get(
     "UNISPSC_XRPC_ENDPOINT", "https://unispsc.etzhayyim.com"
 )
-UNISPSC_COMMODITY_NSID = "com.etzhayyim.etzhayyim.apps.openUnispsc.commodity"
+UNISPSC_COMMODITY_NSID = "com.etzhayyim.apps.openUnispsc.commodity"
 
 UTILITY_TO_UNSPSC_SEGMENTS: dict[str, list[str]] = {
     # Maps the lexicon's utilityClass → likely UNSPSC segment prefixes that


### PR DESCRIPTION
Follow-up to #167. The re-point built the openUnispsc XRPC URL with a doubled namespace segment `com.etzhayyim.etzhayyim.apps.openUnispsc.commodity`; the canonical lexicon id is `com.etzhayyim.apps.openUnispsc.commodity` (a `procedure`), per `00-contracts/lexicons` + `lexicons.gen.json` + `apps.openapi.json`. The doubled form would NSID-mismatch the canonical `unispsc.etzhayyim.com` gateway.

Latent (live/operator-gated): tests point fan-out at an unreachable fixture endpoint, so CI is green either way and the synthesized-fallback path is exercised. This corrects both `deployment_planning/cell.py` and `site_survey/cell.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)