### PR TITLE
harden(kotoba-crypto): hedged synthetic nonce for proof-of-control (RNG-failure resilient)

### DIFF
--- a/crates/kotoba-crypto/src/proof_of_control.rs
+++ b/crates/kotoba-crypto/src/proof_of_control.rs
@@ -32,6 +32,8 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Domain-separation tag for the Fiat–Shamir challenge (versioned).
 const CHALLENGE_DOMAIN: &[u8] = b"kotoba.actor.proof-of-control.schnorr.v1";
+/// Domain-separation tag for the hedged synthetic nonce (versioned).
+const NONCE_DOMAIN: &[u8] = b"kotoba.actor.proof-of-control.nonce.v1";
 
 /// An actor's public identity: the commitment `P = x·G` to its secret `x`.
 /// Carries no secret; safe to publish (e.g. as the actor's `did:key`).
@@ -74,6 +76,28 @@ impl ActorKey {
         ActorIdentity(RistrettoPoint::mul_base(&self.secret))
     }
 
+    /// Hedged synthetic Schnorr nonce `k = H(NONCE_DOMAIN ‖ x ‖ rng32 ‖ len(ctx) ‖ ctx) mod ℓ`.
+    /// Internal-only: it reads the secret bytes WITHOUT exposing them outside the type. The rng
+    /// hedge keeps it randomized per call when the RNG works; the secret+context binding keeps it
+    /// unique (never reused across contexts) even if the RNG is broken — closing the nonce-reuse
+    /// key-leak hole that a pure `Scalar::random` would open under RNG failure.
+    fn synthetic_nonce<R: RngCore + CryptoRng>(&self, context: &[u8], rng: &mut R) -> Scalar {
+        let mut hedge = [0u8; 32];
+        rng.fill_bytes(&mut hedge);
+        let mut h = Sha512::new();
+        h.update(NONCE_DOMAIN);
+        h.update(self.secret.as_bytes());
+        h.update(hedge);
+        h.update((context.len() as u64).to_le_bytes());
+        h.update(context);
+        let mut wide = [0u8; 64];
+        wide.copy_from_slice(&h.finalize());
+        let k = Scalar::from_bytes_mod_order_wide(&wide);
+        wide.zeroize();
+        hedge.zeroize();
+        k
+    }
+
     /// Produce a non-interactive zero-knowledge proof that this key controls [`Self::identity`],
     /// bound to `context` (domain-separated — a proof minted for one purpose cannot be replayed
     /// for another). Reveals nothing about the secret.
@@ -83,7 +107,11 @@ impl ActorKey {
         rng: &mut R,
     ) -> ControlProof {
         // Schnorr: pick nonce k, commit T = k·G, challenge c = H(P, T, ctx), response s = k + c·x.
-        let mut k = Scalar::random(rng);
+        // The nonce is HEDGED-SYNTHETIC, not pure-RNG: k = H(domain ‖ x ‖ rng ‖ ctx). With a good
+        // RNG it is random per call; with a BROKEN rng (e.g. all-zero) it is still unique per
+        // (secret, context) and never repeats across distinct contexts — so a failed RNG cannot
+        // cause the nonce reuse that would leak the key. (RFC 6979 / Ed25519-style synthetic nonce.)
+        let mut k = self.synthetic_nonce(context, rng);
         let commit = RistrettoPoint::mul_base(&k);
         let p = RistrettoPoint::mul_base(&self.secret);
         let c = challenge(&p, &commit, context);
@@ -148,6 +176,58 @@ fn challenge(p: &RistrettoPoint, commit: &RistrettoPoint, context: &[u8]) -> Sca
 mod tests {
     use super::*;
     use rand_core::OsRng;
+
+    /// An adversarial RNG that always yields zeros — models a catastrophic RNG failure.
+    /// With a pure `Scalar::random` nonce this would force k = 0 (and leak the key); the hedged
+    /// synthetic nonce must stay safe under it.
+    struct ZeroRng;
+    impl RngCore for ZeroRng {
+        fn next_u32(&mut self) -> u32 {
+            0
+        }
+        fn next_u64(&mut self) -> u64 {
+            0
+        }
+        fn fill_bytes(&mut self, dest: &mut [u8]) {
+            dest.iter_mut().for_each(|b| *b = 0);
+        }
+        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_core::Error> {
+            self.fill_bytes(dest);
+            Ok(())
+        }
+    }
+    impl CryptoRng for ZeroRng {}
+
+    #[test]
+    fn hedged_nonce_survives_broken_rng() {
+        // Even with an all-zero RNG, the secret+context-derived nonce yields a valid proof.
+        let key = ActorKey::issue(&mut OsRng);
+        let id = key.identity();
+        let proof = key.prove_control(b"ctx", &mut ZeroRng);
+        assert!(proof.verify(&id, b"ctx"));
+    }
+
+    #[test]
+    fn broken_rng_distinct_contexts_distinct_commits() {
+        // The key safety property: under a broken RNG, different contexts must still use
+        // DIFFERENT nonces (different commits) — otherwise same-k-different-challenge leaks x.
+        let key = ActorKey::issue(&mut OsRng);
+        let p1 = key.prove_control(b"login", &mut ZeroRng).to_bytes();
+        let p2 = key.prove_control(b"transfer", &mut ZeroRng).to_bytes();
+        assert_ne!(p1[..32], p2[..32]); // commits differ
+    }
+
+    #[test]
+    fn broken_rng_same_context_is_deterministic_and_safe() {
+        // Same key + same context + broken RNG → identical proof (one statement, one nonce → no
+        // two distinct proofs ever share a nonce, so no key-leak hazard). Still verifies.
+        let key = ActorKey::issue(&mut OsRng);
+        let id = key.identity();
+        let p1 = key.prove_control(b"ctx", &mut ZeroRng);
+        let p2 = key.prove_control(b"ctx", &mut ZeroRng);
+        assert_eq!(p1.to_bytes(), p2.to_bytes());
+        assert!(p1.verify(&id, b"ctx"));
+    }
 
     #[test]
     fn issue_prove_verify_roundtrip() {


### PR DESCRIPTION
## What

Follow-up to #171 (the hardening I flagged in that review). The Schnorr proof-of-control used a pure `Scalar::random` nonce — correct, but a single RNG failure (repeated/zero output) triggers the classic Schnorr nonce-reuse leak that exposes the secret key.

Switch to a **hedged synthetic nonce**:
```
k = H(NONCE_DOMAIN ‖ x ‖ 32 rng bytes ‖ len(ctx) ‖ ctx) mod ℓ      (SHA-512 → ristretto scalar)
```
(RFC 6979 / Ed25519-style synthetic nonce, hedged with RNG.)

- **Working RNG** → randomized per call (the 32 rng bytes vary), exactly like before.
- **Broken RNG (zero/repeat)** → still **unique per `(secret, context)`** and never reused across distinct contexts → no nonce-reuse, **no key leak**.
- The secret is read only *inside* the type (`as_bytes` in a private method) — externally still **non-extractable**. Intermediate nonce material is zeroized.

## Tests

3 new, driven by an adversarial all-zero `ZeroRng`:
- `hedged_nonce_survives_broken_rng` — valid proof even with a dead RNG.
- `broken_rng_distinct_contexts_distinct_commits` — different contexts → different nonces/commits (the key safety property).
- `broken_rng_same_context_is_deterministic_and_safe` — same context → identical proof (one nonce per statement, no reuse hazard), still verifies.

**kotoba-crypto: 113 passed / 0 failed**; `cargo fmt` + `clippy` clean.

No API change — `prove_control` signature is unchanged; only the nonce derivation is hardened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)