### PR TITLE
feat(kotoba-crypto): canonical multibase string form for actor identity + control proof

### DIFF
--- a/crates/kotoba-crypto/Cargo.toml
+++ b/crates/kotoba-crypto/Cargo.toml
@@ -13,6 +13,7 @@ hmac         = { workspace = true }
 rand         = { workspace = true }
 rand_core    = { workspace = true }
 base64       = { workspace = true }
+multibase    = { workspace = true }  # base58btc canonical string form for actor identity/proof
 zeroize      = { workspace = true }
 thiserror    = { workspace = true }
 x25519-dalek = { workspace = true }

--- a/crates/kotoba-crypto/src/proof_of_control.rs
+++ b/crates/kotoba-crypto/src/proof_of_control.rs
@@ -26,6 +26,7 @@ use curve25519_dalek::{
     ristretto::{CompressedRistretto, RistrettoPoint},
     scalar::Scalar,
 };
+use multibase::Base;
 use rand_core::{CryptoRng, RngCore};
 use sha2::{Digest, Sha512};
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -51,6 +52,20 @@ impl ActorIdentity {
             .ok()?
             .decompress()
             .map(ActorIdentity)
+    }
+
+    /// Canonical multibase (base58btc, `z…`) string — the form to store in a datom or surface in
+    /// a DID document, mirroring the project's `did:key` convention. NOTE: this encodes the raw
+    /// ristretto255 point; it is the kotoba actor-identity form, NOT a W3C `did:key` (ristretto255
+    /// has no registered did:key multicodec — when one lands, a `did:key` variant can wrap this).
+    pub fn to_multibase(&self) -> String {
+        multibase::encode(Base::Base58Btc, self.to_bytes())
+    }
+    /// Parse the multibase form. `None` on bad multibase, wrong length, or an invalid point.
+    pub fn from_multibase(s: &str) -> Option<Self> {
+        let (_, bytes) = multibase::decode(s).ok()?;
+        let arr: [u8; 32] = bytes.try_into().ok()?;
+        Self::from_bytes(&arr)
     }
 }
 
@@ -156,6 +171,18 @@ impl ControlProof {
         sb.copy_from_slice(&bytes[32..]);
         let response = Option::from(Scalar::from_canonical_bytes(sb))?;
         Some(ControlProof { commit, response })
+    }
+
+    /// Canonical multibase (base58btc, `z…`) string form, for transport/storage in the kotoba
+    /// ecosystem (datoms, JSON, DID-document proof values).
+    pub fn to_multibase(&self) -> String {
+        multibase::encode(Base::Base58Btc, self.to_bytes())
+    }
+    /// Parse the multibase form. `None` on bad multibase, wrong length, or malformed proof.
+    pub fn from_multibase(s: &str) -> Option<Self> {
+        let (_, bytes) = multibase::decode(s).ok()?;
+        let arr: [u8; 64] = bytes.try_into().ok()?;
+        Self::from_bytes(&arr)
     }
 }
 
@@ -286,6 +313,28 @@ mod tests {
         let id = key.identity();
         let b = id.to_bytes();
         assert_eq!(ActorIdentity::from_bytes(&b), Some(id));
+    }
+
+    #[test]
+    fn identity_multibase_roundtrip() {
+        let id = ActorKey::issue(&mut OsRng).identity();
+        let s = id.to_multibase();
+        assert!(s.starts_with('z')); // base58btc multibase prefix
+        assert_eq!(ActorIdentity::from_multibase(&s), Some(id));
+        assert!(ActorIdentity::from_multibase("not-multibase").is_none());
+        assert!(ActorIdentity::from_multibase("z11111").is_none()); // valid mb, wrong length
+    }
+
+    #[test]
+    fn proof_multibase_roundtrip() {
+        let key = ActorKey::issue(&mut OsRng);
+        let id = key.identity();
+        let proof = key.prove_control(b"ctx", &mut OsRng);
+        let s = proof.to_multibase();
+        assert!(s.starts_with('z'));
+        let parsed = ControlProof::from_multibase(&s).unwrap();
+        assert!(parsed.verify(&id, b"ctx"));
+        assert!(ControlProof::from_multibase("znope").is_none());
     }
 
     #[test]


### PR DESCRIPTION
## What

Follow-up to #171/#172. Adds `to_multibase`/`from_multibase` (base58btc, `z…`) to `ActorIdentity` and `ControlProof` — the idiomatic string form for storing in a datom, putting on the wire (JSON), or surfacing in a DID-document proof value, mirroring the project's existing `did:key` (multibase base58btc) convention.

**Honest scope note (in the docs):** this encodes the raw ristretto255 point as the *kotoba actor-identity* form — it is **not** a W3C `did:key`, because ristretto255 has no registered did:key multicodec. When/if one is assigned, a `did:key` variant can wrap this without changing the bytes.

## Why

`to_bytes`/`from_bytes` already exist, but every storage/transport surface in kotoba (datoms, JSON, DID docs) speaks multibase strings — this makes the new primitive first-class there with one canonical, round-trippable representation.

## Tests

2 new round-trips: `z`-prefix check, reject non-multibase, reject valid-multibase-wrong-length, proof parses + verifies after a multibase round-trip. **kotoba-crypto 115 passed / 0 failed**; `cargo fmt` + `clippy` clean.

No behavior change to the crypto; purely an additive encoding surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)