### PR TITLE
fix(kotoba-server): owner-bind datomic.transact + per-tier datom write quota (kotobase BaaS)

### DIFF
--- a/crates/kotoba-auth/src/did_key.rs
+++ b/crates/kotoba-auth/src/did_key.rs
@@ -212,7 +212,10 @@ mod tests {
         let op = "did:key:z35dec6b49a374eec5711a4f3ccaf66b944ecae6773766e62d71c86ff8e3b5a37";
         let pk = parse_ed25519_did_key(op).expect("hex operator DID must parse");
         assert_eq!(ed25519_pubkey_to_did_key_hex(&pk), op);
-        assert_eq!(to_canonical_did_key(op).unwrap(), ed25519_pubkey_to_did_key(&pk));
+        assert_eq!(
+            to_canonical_did_key(op).unwrap(),
+            ed25519_pubkey_to_did_key(&pk)
+        );
     }
 
     #[test]

--- a/crates/kotoba-server/src/kotobase_xrpc.rs
+++ b/crates/kotoba-server/src/kotobase_xrpc.rs
@@ -1311,7 +1311,10 @@ mod tests {
         assert_eq!(write_datom_cap_for_tier("free"), WRITE_DATOM_CAP_FREE);
         assert_eq!(write_datom_cap_for_tier("starter"), WRITE_DATOM_CAP_STARTER);
         assert_eq!(write_datom_cap_for_tier("pro"), WRITE_DATOM_CAP_PRO);
-        assert_eq!(write_datom_cap_for_tier("enterprise"), WRITE_DATOM_CAP_ENTERPRISE);
+        assert_eq!(
+            write_datom_cap_for_tier("enterprise"),
+            WRITE_DATOM_CAP_ENTERPRISE
+        );
     }
 
     #[test]

--- a/crates/kotoba-server/src/kotobase_xrpc.rs
+++ b/crates/kotoba-server/src/kotobase_xrpc.rs
@@ -222,6 +222,34 @@ fn quota_for_tier(tier: &str) -> (i64, i64) {
     }
 }
 
+// ── Datom write quota (ADR-2606201700 follow-up 3) ──────────────────────────
+//
+// Per-transaction datom cap by tenant tier — the write-plane analogue of the
+// pin/byte quotas above. `datomic.transact` enforces it against the resolved
+// datom count (`TransactReport::tx_data.len()`). Caps scale with tier; the
+// operator is exempt (enforced at the call site). Periodic (windowed) write
+// quotas are a further follow-up — this bounds per-transaction size only.
+
+const WRITE_DATOM_CAP_FREE: usize = 1_000;
+const WRITE_DATOM_CAP_STARTER: usize = 10_000;
+const WRITE_DATOM_CAP_PRO: usize = 100_000;
+const WRITE_DATOM_CAP_ENTERPRISE: usize = 1_000_000;
+
+/// Per-transaction datom cap for a tier. `None` => unlimited (quota disabled).
+pub(crate) fn write_datom_cap_for_tier(tier: &str) -> usize {
+    match tier {
+        "starter" => WRITE_DATOM_CAP_STARTER,
+        "pro" => WRITE_DATOM_CAP_PRO,
+        "enterprise" => WRITE_DATOM_CAP_ENTERPRISE,
+        _ => WRITE_DATOM_CAP_FREE,
+    }
+}
+
+/// Read a tenant's tier from `kotobase/accounts/<did>` (defaults to "free").
+pub(crate) async fn tier_for(state: &KotobaState, tenant_did: &str) -> String {
+    read_tier(state, tenant_did).await
+}
+
 // ── CID helpers ────────────────────────────────────────────────────────────
 
 fn cid(s: &str) -> KotobaCid {
@@ -1274,6 +1302,24 @@ mod tests {
         let (pins, bytes) = quota_for_tier("platinum");
         assert_eq!(pins, QUOTA_FREE_PINS);
         assert_eq!(bytes, QUOTA_FREE_BYTES);
+    }
+
+    // ── write_datom_cap_for_tier (ADR-2606201700 f/3) ──────────────────────────
+
+    #[test]
+    fn write_datom_cap_scales_with_tier() {
+        assert_eq!(write_datom_cap_for_tier("free"), WRITE_DATOM_CAP_FREE);
+        assert_eq!(write_datom_cap_for_tier("starter"), WRITE_DATOM_CAP_STARTER);
+        assert_eq!(write_datom_cap_for_tier("pro"), WRITE_DATOM_CAP_PRO);
+        assert_eq!(write_datom_cap_for_tier("enterprise"), WRITE_DATOM_CAP_ENTERPRISE);
+    }
+
+    #[test]
+    fn write_datom_cap_is_monotonic_and_unknown_tier_is_free() {
+        assert!(WRITE_DATOM_CAP_FREE < WRITE_DATOM_CAP_STARTER);
+        assert!(WRITE_DATOM_CAP_STARTER < WRITE_DATOM_CAP_PRO);
+        assert!(WRITE_DATOM_CAP_PRO < WRITE_DATOM_CAP_ENTERPRISE);
+        assert_eq!(write_datom_cap_for_tier("platinum"), WRITE_DATOM_CAP_FREE);
     }
 
     // ── validate_name ─────────────────────────────────────────────────────────

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -5009,9 +5009,7 @@ pub async fn datomic_transact(
         if datom_count > cap {
             return Err((
                 StatusCode::TOO_MANY_REQUESTS,
-                format!(
-                    "QuotaExceeded: tier={tier} datoms={datom_count}>{cap} per transaction"
-                ),
+                format!("QuotaExceeded: tier={tier} datoms={datom_count}>{cap} per transaction"),
             ));
         }
     }

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -4864,6 +4864,37 @@ pub async fn datomic_transact(
                 kotoba_auth::CacaoPayload::OP_TX_CREATE,
             ],
         )?;
+        // ADR-2606131600 P1 owner-binding — write-path mirror (BaaS tenant writes).
+        // The CACAO grant above verifies capability + graph scope + aud==operator +
+        // signature, but not WHO signed it. A self-signed CACAO scoped to another
+        // tenant's graph CID (the CID is derivable from a known DID) would otherwise
+        // authorize a cross-tenant WRITE — the same leak the read path already closes
+        // for reads (see require_datomic_read_any_operation). For a Private graph the
+        // verified issuer must be the graph owner (delegation to others is the owner's
+        // prerogative, expressed as a chain rooted at owner; payload.iss is that root).
+        // Public/Authenticated and not-yet-materialised graphs have no owner to bind to
+        // — the kotobase edge BFF gates those structurally via its
+        // kotobase/db/<tenant_did>/<name> namespace.
+        if let kotoba_core::named_graph::GraphVisibility::Private { owner_did } =
+            &state.graph_visibility(&graph_cid).await
+        {
+            if &payload.iss != owner_did {
+                tracing::warn!(
+                    issuer = %payload.iss,
+                    owner = %owner_did,
+                    graph = %graph_cid.to_multibase(),
+                    "datomic transact: CACAO issuer is not the graph owner"
+                );
+                return Err((
+                    StatusCode::UNAUTHORIZED,
+                    format!(
+                        "CACAO issuer {:?} is not the owner of private graph {}",
+                        payload.iss,
+                        graph_cid.to_multibase()
+                    ),
+                ));
+            }
+        }
         write_author = payload.iss.clone();
         cacao_payload = Some(payload);
     } else if let Some(presentation) = &req.presentation {

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -4997,6 +4997,24 @@ pub async fn datomic_transact(
         .transact(tx_data.clone())
         .await
         .map_err(|e| (StatusCode::BAD_REQUEST, format!("datomic transact: {e}")))?;
+    // Tier write quota (ADR-2606201700 follow-up 3) — bound the per-transaction
+    // datom count by the writer's tenant tier (kotobase/accounts/<did>). The
+    // operator is exempt; KOTOBA_TIER_WRITE_QUOTA=off disables enforcement.
+    if write_author != state.operator_did
+        && std::env::var("KOTOBA_TIER_WRITE_QUOTA").as_deref() != Ok("off")
+    {
+        let tier = crate::kotobase_xrpc::tier_for(&state, &write_author).await;
+        let cap = crate::kotobase_xrpc::write_datom_cap_for_tier(&tier);
+        let datom_count = tx_preview.tx_data.len();
+        if datom_count > cap {
+            return Err((
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "QuotaExceeded: tier={tier} datoms={datom_count}>{cap} per transaction"
+                ),
+            ));
+        }
+    }
     if let Some(payload) = &cacao_payload {
         enforce_datomic_write_tx_scope(payload, &tx_preview.tx_cid)?;
     }


### PR DESCRIPTION
Pod-side support for the kotobase tenant Datom write plane (gftdcojp/net-kotobase#111, ADR-2606201700).

## Changes
1. **Owner-binding on the transact CACAO path** (`xrpc.rs::datomic_transact`). The grant verified capability + graph scope + aud + signature, but not WHO signed it. Since a tenant graph CID is the deterministic hash of `kotobase/db/<did>/<name>` (derivable from a known DID), a self-signed CACAO scoped to another tenant's graph would authorize a cross-tenant **write** — the write analogue of the read leak already closed in `require_datomic_read_any_operation`. Now, for a Private graph the verified issuer must be the owner (`state.graph_visibility`). Public / Authenticated / not-yet-materialised graphs have no owner to bind to — the kotobase edge BFF gates those structurally.

2. **Per-tier datom write quota** (`kotobase_xrpc.rs` + transact enforcement). Bounds the per-transaction datom count by the writer's tenant tier — free 1k / starter 10k / pro 100k / enterprise 1M datoms/tx — the write-plane analogue of the pin/byte quotas. Operator-exempt; `KOTOBA_TIER_WRITE_QUOTA=off` disables; over-cap → 429.

## Tests
`cargo test -p kotoba-server` green (2 new unit tests for the write quota; owner-binding compiles clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)