### PR TITLE
test(kotoba-server): cover datomic.transact owner-binding (cross-tenant write deny)

### DIFF
--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -9944,6 +9944,69 @@ mod tests {
         );
     }
 
+    // ADR-2606201700: the transact CACAO path binds the issuer to the graph owner
+    // for Private graphs — a self-signed CACAO scoped to ANOTHER tenant's graph CID
+    // must not authorize a cross-tenant WRITE (the write analogue of the read gate
+    // above). Verified by signing with key [42] while the graph is owned by key [7].
+    #[tokio::test]
+    async fn datomic_transact_private_graph_rejects_non_owner_cacao() {
+        std::env::set_var("KOTOBA_IPFS", "off");
+        std::env::set_var("KOTOBA_IPNS_REQUIRE_SIGNATURE", "false");
+        let state = Arc::new(KotobaState::new(None).unwrap());
+
+        let owner_did = kotoba_auth::ed25519_pubkey_to_did_key(
+            &ed25519_dalek::SigningKey::from_bytes(&[7u8; 32])
+                .verifying_key()
+                .to_bytes(),
+        );
+        let g = KotobaCid::from_bytes(b"transact-owner-bind-graph");
+        state.graph_registry.write().await.insert(
+            g.clone(),
+            (
+                "priv".into(),
+                GraphVisibility::Private {
+                    owner_did: owner_did.clone(),
+                },
+            ),
+        );
+        let g_mb = g.to_multibase();
+
+        // CACAO signed by [42] (issuer != the [7] owner), granting datom:transact + tx:create.
+        let cacao = signed_cacao_b64(
+            &state,
+            &g_mb,
+            kotoba_auth::CacaoPayload::OP_DATOM_TRANSACT,
+            "tob-nonce-1",
+            [format!(
+                "kotoba://op/{}",
+                kotoba_auth::CacaoPayload::OP_TX_CREATE
+            )],
+        );
+
+        let err = datomic_transact(
+            axum::extract::State(Arc::clone(&state)),
+            axum::http::HeaderMap::new(),
+            axum::Json(DatomicTransactReq {
+                graph: g_mb,
+                tx_edn: "[]".into(),
+                ipns_name: None,
+                cacao_b64: Some(cacao),
+                cacao_proof_cid: None,
+                expected_parent: None,
+                presentation: None,
+            }),
+        )
+        .await
+        .err()
+        .expect("non-owner CACAO must be rejected on a private graph");
+        assert_eq!(err.0, axum::http::StatusCode::UNAUTHORIZED);
+        assert!(
+            err.1.to_lowercase().contains("owner"),
+            "deny must be the owner-binding gate, got: {}",
+            err.1
+        );
+    }
+
     #[test]
     fn datomic_range_tx_scope_requires_requested_start_and_end_scopes() {
         let start = KotobaCid::from_bytes(b"range-start").to_multibase();


### PR DESCRIPTION
Adds the missing test for the ADR-2606201700 write-path owner-binding (#174): a Private graph owned by key `[7]` rejects a CACAO self-signed by key `[42]` (issuer != owner), even though that CACAO validly grants `datom:transact` + `tx:create` on the graph scope — asserting the 401 owner-binding deny that blocks cross-tenant writes. Mirrors the existing `datomic_q` private-read harness. `cargo test -p kotoba-server` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)