### PR TITLE
kotoba-clj: broaden Clojure coverage (clojure.core stdlib, iteration sugars, strings) + branch peephole

### DIFF
--- a/crates/kotoba-clj/src/ast.rs
+++ b/crates/kotoba-clj/src/ast.rs
@@ -973,6 +973,18 @@ fn lower_call(items: &[EdnValue]) -> Result<Expr, CljError> {
         "do" => Ok(Expr::Do(
             args.iter().map(lower_expr).collect::<Result<_, _>>()?,
         )),
+        // `(if-some [x e] then else?)` / `(when-some [x e] body…)`: in this
+        // i64/nil-as-0 value model a non-nil value is exactly a truthy value, so
+        // some-binding has the same lowering as the let-binding forms.
+        "if-some" => lower_if_let(args),
+        "when-some" => lower_when_let(args),
+        // Iteration sugars — pure desugaring into `loop`/`recur` (no new runtime
+        // node). They evaluate their body for side effects and yield nil (0).
+        // `doseq` walks a vector via the prelude `vec-count`/`vec-nth`, so it
+        // requires the prelude (the default).
+        "while" => lower_while(args),
+        "dotimes" => lower_dotimes(args),
+        "doseq" => lower_doseq(args),
         "comment" => Ok(Expr::Int(0)),
         name => {
             let lowered: Vec<Expr> = args.iter().map(lower_expr).collect::<Result<_, _>>()?;
@@ -1006,6 +1018,137 @@ fn lower_var(args: &[EdnValue]) -> Result<Expr, CljError> {
             "var requires a symbol, found {other:?}"
         ))),
     }
+}
+
+// ---- desugaring helpers for iteration sugars -------------------------------
+// Each builds an equivalent EDN s-expression out of existing special forms and
+// re-lowers it, so no new AST node or codegen path is introduced.
+
+fn dsym(name: &str) -> EdnValue {
+    EdnValue::Symbol(Symbol {
+        namespace: None,
+        name: name.into(),
+    })
+}
+fn dlist(items: Vec<EdnValue>) -> EdnValue {
+    EdnValue::List(items)
+}
+fn dvec(items: Vec<EdnValue>) -> EdnValue {
+    EdnValue::Vector(items)
+}
+
+/// `(while test body…)` → `(loop [_while 0] (if test (do body… (recur 0)) 0))`.
+fn lower_while(args: &[EdnValue]) -> Result<Expr, CljError> {
+    let test = args
+        .first()
+        .ok_or_else(|| CljError::Lower("while takes: (while test body…)".into()))?
+        .clone();
+    let mut do_items = vec![dsym("do")];
+    do_items.extend(args[1..].iter().cloned());
+    do_items.push(dlist(vec![dsym("recur"), EdnValue::Integer(0)]));
+    let if_form = dlist(vec![dsym("if"), test, dlist(do_items), EdnValue::Integer(0)]);
+    let loop_form = dlist(vec![
+        dsym("loop"),
+        dvec(vec![dsym("_while"), EdnValue::Integer(0)]),
+        if_form,
+    ]);
+    lower_expr(&loop_form)
+}
+
+/// `(dotimes [i n] body…)` →
+/// `(let [_dotimes_n n] (loop [i 0] (if (< i _dotimes_n) (do body… (recur (+ i 1))) 0)))`.
+fn lower_dotimes(args: &[EdnValue]) -> Result<Expr, CljError> {
+    let binding = match args.first() {
+        Some(EdnValue::Vector(v)) if v.len() == 2 => v,
+        _ => {
+            return Err(CljError::Lower(
+                "dotimes takes: (dotimes [i n] body…)".into(),
+            ))
+        }
+    };
+    let i = binding[0].clone();
+    let n = binding[1].clone();
+    let limit = dsym("_dotimes_n");
+    let mut do_items = vec![dsym("do")];
+    do_items.extend(args[1..].iter().cloned());
+    do_items.push(dlist(vec![
+        dsym("recur"),
+        dlist(vec![dsym("+"), i.clone(), EdnValue::Integer(1)]),
+    ]));
+    let if_form = dlist(vec![
+        dsym("if"),
+        dlist(vec![dsym("<"), i.clone(), limit.clone()]),
+        dlist(do_items),
+        EdnValue::Integer(0),
+    ]);
+    let loop_form = dlist(vec![
+        dsym("loop"),
+        dvec(vec![i, EdnValue::Integer(0)]),
+        if_form,
+    ]);
+    let let_form = dlist(vec![dsym("let"), dvec(vec![limit, n]), loop_form]);
+    lower_expr(&let_form)
+}
+
+/// `(doseq [x coll] body…)` →
+/// `(let [_doseq_v coll _doseq_n (vec-count _doseq_v)]
+///    (loop [_doseq_i 0]
+///      (if (< _doseq_i _doseq_n)
+///        (do (let [x (vec-nth _doseq_v _doseq_i)] body…) (recur (+ _doseq_i 1)))
+///        0)))`.
+/// Single-binding only; needs the prelude (`vec-count`/`vec-nth`).
+fn lower_doseq(args: &[EdnValue]) -> Result<Expr, CljError> {
+    let binding = match args.first() {
+        Some(EdnValue::Vector(v)) if v.len() == 2 => v,
+        _ => {
+            return Err(CljError::Lower(
+                "doseq takes a single binding: (doseq [x coll] body…)".into(),
+            ))
+        }
+    };
+    let x = binding[0].clone();
+    let coll = binding[1].clone();
+    let v = dsym("_doseq_v");
+    let n = dsym("_doseq_n");
+    let i = dsym("_doseq_i");
+    let mut inner_let = vec![
+        dsym("let"),
+        dvec(vec![
+            x,
+            dlist(vec![dsym("vec-nth"), v.clone(), i.clone()]),
+        ]),
+    ];
+    inner_let.extend(args[1..].iter().cloned());
+    let do_form = dlist(vec![
+        dsym("do"),
+        dlist(inner_let),
+        dlist(vec![
+            dsym("recur"),
+            dlist(vec![dsym("+"), i.clone(), EdnValue::Integer(1)]),
+        ]),
+    ]);
+    let if_form = dlist(vec![
+        dsym("if"),
+        dlist(vec![dsym("<"), i.clone(), n.clone()]),
+        do_form,
+        EdnValue::Integer(0),
+    ]);
+    let loop_form = dlist(vec![
+        dsym("loop"),
+        dvec(vec![i, EdnValue::Integer(0)]),
+        if_form,
+    ]);
+    let let_form = dlist(vec![
+        dsym("let"),
+        dvec(vec![
+            v.clone(),
+            coll,
+            n,
+            dlist(vec![dsym("vec-count"), v]),
+        ]),
+        loop_form,
+    ]);
+    lower_expr(&let_form)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/kotoba-clj/src/codegen.rs
+++ b/crates/kotoba-clj/src/codegen.rs
@@ -970,10 +970,39 @@ fn compile_expr(cg: &mut FnCtx, expr: &Expr) -> Result<(), CljError> {
 /// Compile `expr` and convert the resulting i64 to an i32 truthiness flag
 /// (1 if non-zero, 0 if zero) suitable as a wasm `if`/`br_if` condition.
 fn compile_truthy_i32(cg: &mut FnCtx, expr: &Expr) -> Result<(), CljError> {
+    // Peephole: a binary comparison already yields an i32 0/1 — exactly what a
+    // wasm `if` wants. Emit `a; b; <cmp>` and stop, skipping the default
+    // `extend_i32_u; const 0; i64.ne` round-trip (3 dead ops per branch in the
+    // i64-everything model). Semantically identical: `(x cmp y) != 0` ⇔ `x cmp y`.
+    if let Expr::Builtin { op, args } = expr {
+        if args.len() == 2 {
+            if let Some(cmp) = comparison_i32_instruction(*op) {
+                compile_expr(cg, &args[0])?;
+                compile_expr(cg, &args[1])?;
+                cg.emit(cmp);
+                return Ok(());
+            }
+        }
+    }
     compile_expr(cg, expr)?;
     cg.emit(Instruction::I64Const(0));
     cg.emit(Instruction::I64Ne); // → i32: 1 if non-zero
     Ok(())
+}
+
+/// The i32-producing wasm instruction for a 2-arg comparison builtin, or `None`
+/// for anything else. Used by [`compile_truthy_i32`] to feed a comparison
+/// straight into an `if`/`br_if` condition.
+fn comparison_i32_instruction(op: Builtin) -> Option<Instruction<'static>> {
+    Some(match op {
+        Builtin::Eq => Instruction::I64Eq,
+        Builtin::NotEq => Instruction::I64Ne,
+        Builtin::Lt => Instruction::I64LtS,
+        Builtin::Gt => Instruction::I64GtS,
+        Builtin::Le => Instruction::I64LeS,
+        Builtin::Ge => Instruction::I64GeS,
+        _ => return None,
+    })
 }
 
 /// Compile `expr` to a normalised i64 boolean (1 if truthy, else 0).

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -345,7 +345,22 @@ pub const PRELUDE: &str = r#"
   ([x] (let [v (vec-make 1)] (vec-conj! v x) v))
   ([x y] (let [v (vec-make 2)] (vec-conj! v x) (vec-conj! v y) v))
   ([x y z] (let [v (vec-make 3)] (vec-conj! v x) (vec-conj! v y) (vec-conj! v z) v))
-  ([x y z w] (let [v (vec-make 4)] (vec-conj! v x) (vec-conj! v y) (vec-conj! v z) (vec-conj! v w) v)))
+  ([x y z w] (let [v (vec-make 4)] (vec-conj! v x) (vec-conj! v y) (vec-conj! v z) (vec-conj! v w) v))
+  ([a b c d e]
+   (let [v (vec-make 5)]
+     (vec-conj! v a) (vec-conj! v b) (vec-conj! v c) (vec-conj! v d) (vec-conj! v e) v))
+  ([a b c d e f]
+   (let [v (vec-make 6)]
+     (vec-conj! v a) (vec-conj! v b) (vec-conj! v c) (vec-conj! v d) (vec-conj! v e)
+     (vec-conj! v f) v))
+  ([a b c d e f g]
+   (let [v (vec-make 7)]
+     (vec-conj! v a) (vec-conj! v b) (vec-conj! v c) (vec-conj! v d) (vec-conj! v e)
+     (vec-conj! v f) (vec-conj! v g) v))
+  ([a b c d e f g h]
+   (let [v (vec-make 8)]
+     (vec-conj! v a) (vec-conj! v b) (vec-conj! v c) (vec-conj! v d) (vec-conj! v e)
+     (vec-conj! v f) (vec-conj! v g) (vec-conj! v h) v)))
 (defn hash-map
   ([] (map-make 0))
   ([k v] (let [m (map-make 1)] (map-assoc! m k v) m))
@@ -479,6 +494,189 @@ pub const PRELUDE: &str = r#"
 (defn partial
   ([f a] (fn [x] (f a x)))
   ([f a b] (fn [x] (f a b x))))
+
+;; ---- clojure.core coverage batch ------------------------------------------
+;; All pure-subset, built on the vec/map primitives above. Output vectors are
+;; pre-sized to an exact-or-upper-bound count (vec-conj!/map-assoc! never grow).
+;; Scalar equality (`=`) compares i64 handles, so element-membership fns
+;; (`distinct`, `vec-contains?`) compare by value for ints and by identity for
+;; string/collection handles — exact for the scalar case that dominates agents.
+
+;; --- subsequences -----------------------------------------------------------
+(defn take [n v]
+  (let [c (vec-count v)
+        m (if (< n c) n c)
+        out (vec-make m)]
+    (loop [i 0]
+      (if (>= i m) out (do (vec-conj! out (vec-nth v i)) (recur (+ i 1)))))))
+(defn drop [n v]
+  (let [c (vec-count v)
+        s (if (< n c) (if (< n 0) 0 n) c)
+        out (vec-make (- c s))]
+    (loop [i s]
+      (if (>= i c) out (do (vec-conj! out (vec-nth v i)) (recur (+ i 1)))))))
+(defn take-while [pred v]
+  (let [c (vec-count v) out (vec-make c)]
+    (loop [i 0]
+      (if (>= i c)
+        out
+        (let [x (vec-nth v i)]
+          (if (pred x) (do (vec-conj! out x) (recur (+ i 1))) out))))))
+(defn drop-while [pred v]
+  (let [c (vec-count v)]
+    (loop [i 0]
+      (if (>= i c)
+        (vec-make 0)
+        (if (pred (vec-nth v i)) (recur (+ i 1)) (subvec v i))))))
+(defn butlast [v] (take (- (vec-count v) 1) v))
+(defn take-last [n v] (drop (- (vec-count v) n) v))
+(defn reverse [v]
+  (let [c (vec-count v) out (vec-make c)]
+    (loop [i (- c 1)]
+      (if (< i 0) out (do (vec-conj! out (vec-nth v i)) (recur (- i 1)))))))
+(defn concat [a b]
+  (let [out (vec-make (+ (vec-count a) (vec-count b)))]
+    (vec-extend! out a)
+    (vec-extend! out b)
+    out))
+(defn repeat [n x]
+  (let [out (vec-make n)]
+    (loop [i 0] (if (>= i n) out (do (vec-conj! out x) (recur (+ i 1)))))))
+
+;; --- combining --------------------------------------------------------------
+(defn interpose [sep v]
+  (let [c (vec-count v)
+        out (vec-make (if (= c 0) 0 (- (* 2 c) 1)))]
+    (loop [i 0]
+      (if (>= i c)
+        out
+        (do (if (> i 0) (vec-conj! out sep) 0)
+            (vec-conj! out (vec-nth v i))
+            (recur (+ i 1)))))))
+(defn interleave [a b]
+  (let [ca (vec-count a) cb (vec-count b)
+        m (if (< ca cb) ca cb)
+        out (vec-make (* 2 m))]
+    (loop [i 0]
+      (if (>= i m)
+        out
+        (do (vec-conj! out (vec-nth a i))
+            (vec-conj! out (vec-nth b i))
+            (recur (+ i 1)))))))
+(defn partition [n v]
+  (let [c (vec-count v) k (/ c n) out (vec-make k)]
+    (loop [g 0]
+      (if (>= g k)
+        out
+        (let [seg (vec-make n)]
+          (loop [j 0]
+            (if (>= j n)
+              0
+              (do (vec-conj! seg (vec-nth v (+ (* g n) j))) (recur (+ j 1)))))
+          (do (vec-conj! out seg) (recur (+ g 1))))))))
+
+;; --- membership / dedup (scalar) -------------------------------------------
+(defn vec-contains? [v x]
+  (let [c (vec-count v)]
+    (loop [i 0]
+      (if (>= i c) 0 (if (= (vec-nth v i) x) 1 (recur (+ i 1)))))))
+(defn distinct [v]
+  (let [c (vec-count v) out (vec-make c)]
+    (loop [i 0]
+      (if (>= i c)
+        out
+        (let [x (vec-nth v i)]
+          (do (if (vec-contains? out x) 0 (vec-conj! out x))
+              (recur (+ i 1))))))))
+
+;; --- ordering (selection sort; scalar / key-projected) ---------------------
+(defn vec-swap! [v i j]
+  (let [tmp (vec-nth v i)]
+    (store64! (+ v (* 8 (+ 2 i))) (vec-nth v j))
+    (store64! (+ v (* 8 (+ 2 j))) tmp)
+    v))
+(defn sort [v]
+  (let [n (vec-count v) out (vec-make n)]
+    (vec-extend! out v)
+    (loop [i 0]
+      (if (>= i n)
+        out
+        (do (loop [j (+ i 1)]
+              (if (>= j n)
+                0
+                (do (if (< (vec-nth out j) (vec-nth out i)) (vec-swap! out i j) 0)
+                    (recur (+ j 1)))))
+            (recur (+ i 1)))))))
+(defn sort-by [keyfn v]
+  (let [n (vec-count v) out (vec-make n)]
+    (vec-extend! out v)
+    (loop [i 0]
+      (if (>= i n)
+        out
+        (do (loop [j (+ i 1)]
+              (if (>= j n)
+                0
+                (do (if (< (keyfn (vec-nth out j)) (keyfn (vec-nth out i)))
+                      (vec-swap! out i j)
+                      0)
+                    (recur (+ j 1)))))
+            (recur (+ i 1)))))))
+
+;; --- map (string-keyed) ----------------------------------------------------
+(defn merge [a b]
+  (let [out (map-make (+ (map-count a) (map-count b)))]
+    (loop [i 0]
+      (if (>= i (map-count a))
+        0
+        (do (map-assoc! out (map-key-at a i) (map-val-at a i)) (recur (+ i 1)))))
+    (loop [i 0]
+      (if (>= i (map-count b))
+        out
+        (do (map-assoc! out (map-key-at b i) (map-val-at b i)) (recur (+ i 1)))))))
+(defn merge-with [f a b]
+  (let [out (map-make (+ (map-count a) (map-count b)))]
+    (loop [i 0]
+      (if (>= i (map-count a))
+        0
+        (do (map-assoc! out (map-key-at a i) (map-val-at a i)) (recur (+ i 1)))))
+    (loop [i 0]
+      (if (>= i (map-count b))
+        out
+        (let [k (map-key-at b i) bv (map-val-at b i)]
+          (do (if (contains-key? out k)
+                (map-assoc! out k (f (map-get out k) bv))
+                (map-assoc! out k bv))
+              (recur (+ i 1))))))))
+(defn select-keys [m ks]
+  (let [n (vec-count ks) out (map-make n)]
+    (loop [i 0]
+      (if (>= i n)
+        out
+        (let [k (vec-nth ks i)]
+          (do (if (contains-key? m k) (map-assoc! out k (map-get m k)) 0)
+              (recur (+ i 1))))))))
+(defn zipmap [ks vs]
+  (let [n (vec-count ks) m (map-make n)]
+    (loop [i 0]
+      (if (>= i n)
+        m
+        (do (map-assoc! m (vec-nth ks i) (vec-nth vs i)) (recur (+ i 1)))))))
+(defn get-in [m ks]
+  (let [n (vec-count ks)]
+    (loop [i 0 cur m]
+      (if (>= i n)
+        cur
+        (if (nil? cur) 0 (recur (+ i 1) (map-get cur (vec-nth ks i))))))))
+(defn update [m k f] (map-assoc! m k (f (map-get m k))))
+
+;; --- functional combinators -------------------------------------------------
+(defn complement [f] (fn [x] (if (f x) 0 1)))
+(defn juxt
+  ([f g] (fn [x] (vector (f x) (g x))))
+  ([f g h] (fn [x] (vector (f x) (g x) (h x)))))
+(defn fnil [f d] (fn [x] (f (if (nil? x) d x))))
+(defn max-key [f a b] (if (>= (f a) (f b)) a b))
+(defn min-key [f a b] (if (<= (f a) (f b)) a b))
 "#;
 
 /// An **in-guest CBOR decoder** (subset) written in the kotoba-clj language,

--- a/crates/kotoba-clj/src/lib.rs
+++ b/crates/kotoba-clj/src/lib.rs
@@ -677,6 +677,108 @@ pub const PRELUDE: &str = r#"
 (defn fnil [f d] (fn [x] (f (if (nil? x) d x))))
 (defn max-key [f a b] (if (>= (f a) (f b)) a b))
 (defn min-key [f a b] (if (<= (f a) (f b)) a b))
+
+;; ---- string building (on the byte-builder; strings = (off<<32)|len handles) -
+;; `bytes-alloc`/`byte-append!`/`bytes-finish` build a fresh region; `byte-at`/
+;; `str-len` read string handles. Capacities are exact, so no grow is needed.
+(defn str-cat [a b]
+  (let [la (str-len a) lb (str-len b)
+        buf (bytes-alloc (+ la lb))]
+    (loop [i 0] (if (>= i la) 0 (do (byte-append! buf (byte-at a i)) (recur (+ i 1)))))
+    (loop [i 0] (if (>= i lb) 0 (do (byte-append! buf (byte-at b i)) (recur (+ i 1)))))
+    (bytes-finish buf)))
+(defn subs
+  ([s start] (subs s start (str-len s)))
+  ([s start end]
+   (let [buf (bytes-alloc (- end start))]
+     (loop [i start] (if (>= i end) 0 (do (byte-append! buf (byte-at s i)) (recur (+ i 1)))))
+     (bytes-finish buf))))
+(defn str-starts-with? [s prefix]
+  (let [lp (str-len prefix)]
+    (if (> lp (str-len s))
+      0
+      (loop [i 0]
+        (if (>= i lp) 1 (if (= (byte-at s i) (byte-at prefix i)) (recur (+ i 1)) 0))))))
+(defn str-includes? [s sub]
+  (let [ls (str-len s) lm (str-len sub)]
+    (if (= lm 0)
+      1
+      (loop [i 0]
+        (if (> (+ i lm) ls)
+          0
+          (if (loop [j 0]
+                (if (>= j lm) 1
+                  (if (= (byte-at s (+ i j)) (byte-at sub j)) (recur (+ j 1)) 0)))
+            1
+            (recur (+ i 1))))))))
+;; join string handles in a vector with a separator string (clojure.string/join)
+(defn str-join [sep v]
+  (let [n (vec-count v)]
+    (if (= n 0)
+      (bytes-finish (bytes-alloc 0))
+      (let [sl (str-len sep)
+            total (loop [i 0 t (* sl (- n 1))]
+                    (if (>= i n) t (recur (+ i 1) (+ t (str-len (vec-nth v i))))))
+            buf (bytes-alloc total)]
+        (loop [i 0]
+          (if (>= i n)
+            (bytes-finish buf)
+            (do
+              (if (> i 0)
+                (loop [j 0]
+                  (if (>= j sl) 0 (do (byte-append! buf (byte-at sep j)) (recur (+ j 1)))))
+                0)
+              (let [e (vec-nth v i) el (str-len e)]
+                (loop [j 0]
+                  (if (>= j el) 0 (do (byte-append! buf (byte-at e j)) (recur (+ j 1))))))
+              (recur (+ i 1)))))))))
+;; render a (possibly negative) integer to its decimal string handle
+(defn str-int [n]
+  (if (= n 0)
+    "0"
+    (let [neg (if (< n 0) 1 0)
+          m0 (if (< n 0) (- 0 n) n)
+          ds (vec-make 20)]
+      (loop [m m0]
+        (if (= m 0) 0 (do (vec-conj! ds (+ 48 (mod m 10))) (recur (/ m 10)))))
+      (let [k (vec-count ds)
+            buf (bytes-alloc (+ k neg))]
+        (if (= neg 1) (byte-append! buf 45) 0)
+        (loop [i (- k 1)]
+          (if (< i 0) 0 (do (byte-append! buf (vec-nth ds i)) (recur (- i 1)))))
+        (bytes-finish buf)))))
+
+;; ---- collection fns needing 2-pass / pre-sizing ---------------------------
+;; `mapcat`: f returns a vector per element; sum the lengths (1st pass) then
+;; concat (2nd pass). f is called twice per element — fine for pure f.
+(defn mapcat [f v]
+  (let [n (vec-count v)
+        total (loop [i 0 t 0]
+                (if (>= i n) t (recur (+ i 1) (+ t (vec-count (f (vec-nth v i)))))))
+        out (vec-make total)]
+    (loop [i 0]
+      (if (>= i n) out (do (vec-extend! out (f (vec-nth v i))) (recur (+ i 1)))))))
+;; `frequencies` of a vector of STRING handles -> map string->count.
+(defn frequencies [v]
+  (let [n (vec-count v) m (map-make n)]
+    (loop [i 0]
+      (if (>= i n)
+        m
+        (let [k (vec-nth v i)]
+          (do (map-assoc! m k (+ 1 (if (contains-key? m k) (map-get m k) 0)))
+              (recur (+ i 1))))))))
+;; `group-by` keyfn over a vector -> map (string key) -> vector of items.
+;; Each group is pre-sized to n (worst case) so vec-conj! never overflows.
+(defn group-by [keyfn v]
+  (let [n (vec-count v) m (map-make n)]
+    (loop [i 0]
+      (if (>= i n)
+        m
+        (let [x (vec-nth v i) k (keyfn x)]
+          (do (if (contains-key? m k)
+                (vec-conj! (map-get m k) x)
+                (map-assoc! m k (let [g (vec-make n)] (vec-conj! g x) g)))
+              (recur (+ i 1))))))))
 "#;
 
 /// An **in-guest CBOR decoder** (subset) written in the kotoba-clj language,

--- a/crates/kotoba-clj/tests/coverage.rs
+++ b/crates/kotoba-clj/tests/coverage.rs
@@ -247,3 +247,88 @@ fn if_some_when_some() {
     // when-some on non-nil runs the body
     assert_eq!(eval("(when-some [x 5] (+ x 1))"), 6);
 }
+
+// ---- strings ---------------------------------------------------------------
+
+#[test]
+fn str_cat_and_subs() {
+    assert_eq!(eval("(str-eq? (str-cat \"ab\" \"cd\") \"abcd\")"), 1);
+    assert_eq!(eval("(str-len (str-cat \"ab\" \"cd\"))"), 4);
+    assert_eq!(eval("(str-eq? (subs \"hello\" 1 4) \"ell\")"), 1);
+    assert_eq!(eval("(str-eq? (subs \"hello\" 2) \"llo\")"), 1);
+}
+
+#[test]
+fn str_predicates() {
+    assert_eq!(eval("(str-starts-with? \"hello\" \"he\")"), 1);
+    assert_eq!(eval("(str-starts-with? \"hello\" \"lo\")"), 0);
+    assert_eq!(eval("(str-includes? \"hello\" \"ell\")"), 1);
+    assert_eq!(eval("(str-includes? \"hello\" \"xyz\")"), 0);
+}
+
+#[test]
+fn str_join_strings() {
+    assert_eq!(
+        eval("(str-eq? (str-join \", \" (vector \"a\" \"b\" \"c\")) \"a, b, c\")"),
+        1
+    );
+    // single element: no separator
+    assert_eq!(eval("(str-eq? (str-join \"-\" (vector \"x\")) \"x\")"), 1);
+}
+
+#[test]
+fn str_int_render() {
+    assert_eq!(eval("(str-eq? (str-int 123) \"123\")"), 1);
+    assert_eq!(eval("(str-eq? (str-int -45) \"-45\")"), 1);
+    assert_eq!(eval("(str-eq? (str-int 0) \"0\")"), 1);
+    // composition: "n=" + str-int
+    assert_eq!(eval("(str-eq? (str-cat \"n=\" (str-int 7)) \"n=7\")"), 1);
+}
+
+// ---- 2-pass / pre-sized collections ----------------------------------------
+
+#[test]
+fn mapcat_concats_results() {
+    // (mapcat (fn [x] [x x]) [1 2 3]) -> [1 1 2 2 3 3], sum 12
+    assert_eq!(
+        eval(&format!(
+            "(reduce {SUMV} 0 (mapcat (fn [x] (vector x x)) (vector 1 2 3)))"
+        )),
+        12
+    );
+    assert_eq!(
+        eval("(vec-count (mapcat (fn [x] (vector x x)) (vector 1 2 3)))"),
+        6
+    );
+}
+
+#[test]
+fn frequencies_string_keyed() {
+    assert_eq!(
+        eval("(map-get (frequencies (vector \"a\" \"b\" \"a\" \"a\")) \"a\")"),
+        3
+    );
+    assert_eq!(
+        eval("(map-get (frequencies (vector \"a\" \"b\" \"a\" \"a\")) \"b\")"),
+        1
+    );
+}
+
+#[test]
+fn group_by_parity() {
+    // group 1..6 by even/odd; "e" group is {2,4,6} -> count 3, sum 12
+    assert_eq!(
+        eval(
+            "(vec-count (map-get (group-by (fn [x] (if (even? x) \"e\" \"o\"))
+                                           (vector 1 2 3 4 5 6)) \"e\"))"
+        ),
+        3
+    );
+    assert_eq!(
+        eval(&format!(
+            "(reduce {SUMV} 0 (map-get (group-by (fn [x] (if (even? x) \"e\" \"o\"))
+                                                 (vector 1 2 3 4 5 6)) \"e\"))"
+        )),
+        12
+    );
+}

--- a/crates/kotoba-clj/tests/coverage.rs
+++ b/crates/kotoba-clj/tests/coverage.rs
@@ -1,0 +1,249 @@
+//! Clojure-coverage batch — new `clojure.core` stdlib fns (PRELUDE) and the
+//! `while` / `dotimes` / `doseq` / `if-some` / `when-some` iteration sugars.
+//!
+//! Each test compiles `PRELUDE + (defn t [_] …)` and runs `t` on wasmtime,
+//! asserting an i64 derived from the result — full read→lower→codegen→run path.
+//! Higher-order args are passed as real `(fn …)` closures (the closure-table /
+//! `call_indirect` path), so these double as closure-capture coverage.
+
+use kotoba_clj::compile_str_with_prelude;
+use kotoba_clj::run::run;
+
+fn eval(body: &str) -> i64 {
+    let src = format!("(defn t [_] {body})");
+    let wasm = compile_str_with_prelude(&src).expect("compile");
+    run(&wasm, "t", &[0]).expect("run")
+}
+
+// a reusable summing closure
+const SUMV: &str = "(fn [a b] (+ a b))";
+
+// ---- subsequences ----------------------------------------------------------
+
+#[test]
+fn take_drop() {
+    // sum(take 3 [10 20 30 40 50]) = 60 ; sum(drop 2 [1 2 3 4 5]) = 12
+    assert_eq!(
+        eval(&format!(
+            "(reduce {SUMV} 0 (take 3 (vector 10 20 30 40 50)))"
+        )),
+        60
+    );
+    assert_eq!(
+        eval(&format!("(reduce {SUMV} 0 (drop 2 (vector 1 2 3 4 5)))")),
+        12
+    );
+}
+
+#[test]
+fn take_while_drop_while() {
+    assert_eq!(
+        eval(&format!(
+            "(reduce {SUMV} 0 (take-while (fn [x] (< x 4)) (vector 1 2 3 4 1)))"
+        )),
+        6
+    );
+    assert_eq!(
+        eval(&format!(
+            "(reduce {SUMV} 0 (drop-while (fn [x] (< x 3)) (vector 1 2 3 4)))"
+        )),
+        7
+    );
+}
+
+#[test]
+fn butlast_take_last() {
+    assert_eq!(eval("(vec-count (butlast (vector 1 2 3 4)))"), 3);
+    assert_eq!(
+        eval(&format!(
+            "(reduce {SUMV} 0 (take-last 2 (vector 1 2 3 4)))"
+        )),
+        7
+    );
+}
+
+#[test]
+fn reverse_concat_repeat() {
+    assert_eq!(eval("(vec-nth (reverse (vector 1 2 3)) 0)"), 3);
+    assert_eq!(eval("(vec-count (concat (vector 1 2) (vector 3 4 5)))"), 5);
+    assert_eq!(
+        eval(&format!("(reduce {SUMV} 0 (concat (vector 1 2) (vector 3 4)))")),
+        10
+    );
+    assert_eq!(eval(&format!("(reduce {SUMV} 0 (repeat 4 3))")), 12);
+}
+
+// ---- combining -------------------------------------------------------------
+
+#[test]
+fn interpose_interleave_partition() {
+    // interpose 0 into [5 5 5] -> [5 0 5 0 5], count 5, sum 15
+    assert_eq!(eval("(vec-count (interpose 0 (vector 5 5 5)))"), 5);
+    assert_eq!(
+        eval(&format!("(reduce {SUMV} 0 (interpose 0 (vector 5 5 5)))")),
+        15
+    );
+    // interleave [1 2] [3 4 5] -> [1 3 2 4], count 4
+    assert_eq!(eval("(vec-count (interleave (vector 1 2) (vector 3 4 5)))"), 4);
+    // partition 2 [1 2 3 4 5] -> [[1 2] [3 4]], 2 groups, first group sums 3
+    assert_eq!(eval("(vec-count (partition 2 (vector 1 2 3 4 5)))"), 2);
+    assert_eq!(
+        eval(&format!(
+            "(reduce {SUMV} 0 (vec-nth (partition 2 (vector 1 2 3 4 5)) 0))"
+        )),
+        3
+    );
+}
+
+// ---- dedup / ordering ------------------------------------------------------
+
+#[test]
+fn distinct_scalar() {
+    assert_eq!(eval("(vec-count (distinct (vector 1 1 2 2 3 3 3)))"), 3);
+    assert_eq!(
+        eval(&format!(
+            "(reduce {SUMV} 0 (distinct (vector 1 1 2 2 3 3 3)))"
+        )),
+        6
+    );
+}
+
+#[test]
+fn sort_ascending() {
+    // sort [3 1 2] -> [1 2 3]; encode as 100*a+10*b+c = 123
+    assert_eq!(
+        eval(
+            "(let [s (sort (vector 3 1 2))]
+               (+ (* 100 (vec-nth s 0)) (+ (* 10 (vec-nth s 1)) (vec-nth s 2))))"
+        ),
+        123
+    );
+}
+
+#[test]
+fn sort_by_key() {
+    // sort-by negate -> descending; first element of [1 3 2] is 3
+    assert_eq!(
+        eval("(vec-nth (sort-by (fn [x] (- 0 x)) (vector 1 3 2)) 0)"),
+        3
+    );
+}
+
+// ---- maps ------------------------------------------------------------------
+
+#[test]
+fn merge_and_merge_with() {
+    assert_eq!(
+        eval("(map-get (merge (hash-map \"a\" 1) (hash-map \"b\" 2)) \"b\")"),
+        2
+    );
+    // overlapping key folded with +
+    assert_eq!(
+        eval(
+            "(map-get (merge-with (fn [a b] (+ a b))
+                                  (hash-map \"x\" 1) (hash-map \"x\" 10)) \"x\")"
+        ),
+        11
+    );
+}
+
+#[test]
+fn select_keys_zipmap_update() {
+    assert_eq!(
+        eval(
+            "(map-count (select-keys (hash-map \"a\" 1 \"b\" 2 \"c\" 3)
+                                     (vector \"a\" \"c\")))"
+        ),
+        2
+    );
+    assert_eq!(
+        eval("(map-get (zipmap (vector \"k\") (vector 99)) \"k\")"),
+        99
+    );
+    assert_eq!(
+        eval("(map-get (update (hash-map \"n\" 5) \"n\" (fn [x] (+ x 1))) \"n\")"),
+        6
+    );
+}
+
+#[test]
+fn get_in_nested() {
+    assert_eq!(
+        eval(
+            "(get-in (hash-map \"a\" (hash-map \"b\" 42)) (vector \"a\" \"b\"))"
+        ),
+        42
+    );
+}
+
+// ---- functional combinators ------------------------------------------------
+
+#[test]
+fn juxt_complement_fnil_keys() {
+    // juxt -> [10 15], second element 15
+    assert_eq!(
+        eval("(vec-nth ((juxt (fn [x] (* x 2)) (fn [x] (* x 3))) 5) 1)"),
+        15
+    );
+    // complement of (> _ 0): on 5 -> 0, on -1 -> 1
+    assert_eq!(eval("((complement (fn [x] (> x 0))) 5)"), 0);
+    assert_eq!(eval("((complement (fn [x] (> x 0))) -1)"), 1);
+    // fnil: nonzero arg passes through
+    assert_eq!(eval("((fnil (fn [x] (+ x 1)) 100) 5)"), 6);
+    // max-key / min-key by negation
+    assert_eq!(eval("(max-key (fn [x] (- 0 x)) 3 7)"), 3);
+    assert_eq!(eval("(min-key (fn [x] (- 0 x)) 3 7)"), 7);
+}
+
+// ---- iteration sugars ------------------------------------------------------
+
+#[test]
+fn while_counts() {
+    assert_eq!(
+        eval(
+            "(let [c (alloc 8)]
+               (store64! c 0)
+               (while (< (load64 c) 5) (store64! c (+ (load64 c) 1)))
+               (load64 c))"
+        ),
+        5
+    );
+}
+
+#[test]
+fn dotimes_accumulates() {
+    // 0+1+2+3+4 = 10
+    assert_eq!(
+        eval(
+            "(let [c (alloc 8)]
+               (store64! c 0)
+               (dotimes [i 5] (store64! c (+ (load64 c) i)))
+               (load64 c))"
+        ),
+        10
+    );
+}
+
+#[test]
+fn doseq_walks_vector() {
+    // sum 3+4+5 = 12
+    assert_eq!(
+        eval(
+            "(let [c (alloc 8) v (vector 3 4 5)]
+               (store64! c 0)
+               (doseq [x v] (store64! c (+ (load64 c) x)))
+               (load64 c))"
+        ),
+        12
+    );
+}
+
+#[test]
+fn if_some_when_some() {
+    // if-some binds and returns the value when non-nil (non-zero)
+    assert_eq!(eval("(if-some [x 7] x 111)"), 7);
+    // when-some on nil (0) takes the else path -> nil (0)
+    assert_eq!(eval("(when-some [x 0] 99)"), 0);
+    // when-some on non-nil runs the body
+    assert_eq!(eval("(when-some [x 5] (+ x 1))"), 6);
+}

--- a/docs/ADR-clojure-wasm.md
+++ b/docs/ADR-clojure-wasm.md
@@ -576,3 +576,46 @@ agents, a DCE target later).
 Verification: `cargo test -p kotoba-clj` → **209 passed / 0 failed** (193 prior +
 16 new); a combined end-to-end program (`sort`+`take`+`reduce`+`merge`+`dotimes`)
 runs to the same result on **both** wasmtime and V8.
+
+---
+
+## Coverage batch 2 — strings, 2-pass collections, branch peephole (2026-06-21)
+
+Status: **Accepted.** Crate: `crates/kotoba-clj` (`tests/coverage.rs` → 23 tests).
+
+### Strings (PRELUDE, on the byte-builder)
+`str-cat` (concat 2 handles) · `subs` (2/3-arity substring) · `str-starts-with?` ·
+`str-includes?` (naive O(nm)) · `str-join` (single-alloc join of a vector of
+string handles by a separator) · `str-int` (signed integer → decimal string).
+Built on `bytes-alloc`/`byte-append!`/`bytes-finish` + `byte-at`/`str-len`; all
+capacities are computed exactly first (no grow). A generic variadic `str` is
+**not** provided — without runtime type tags the compiler can't tell an int
+handle from a string handle, so int rendering is the explicit `str-int`.
+
+### 2-pass / pre-sized collections (PRELUDE)
+`mapcat` (1st pass sums child lengths, 2nd concats — `f` called twice/elem,
+fine for pure `f`) · `frequencies` (vector of **string** handles → count map) ·
+`group-by` (keyfn → string key → vector; each group pre-sized to n). Map fns
+assume string keys (the `str-eq?` contract).
+
+### Branch peephole (`codegen.rs`)
+`compile_truthy_i32` now feeds a 2-arg comparison (`= != < > <= >=`) **straight
+into the `if`/`br_if`**, dropping the `i64.extend_i32_u; i64.const 0; i64.ne`
+round-trip the i64-everything model emitted. Verified on `fib`: body **20 → 17
+instructions, 34 B → 30 B**.
+
+**Honest perf note (measured):** the peephole shrinks the module and the
+instruction count but **does not change `fib` steady-state runtime on optimizing
+JITs** — wasmtime/Cranelift and V8/TurboFan already fold the round-trip, so the
+dead ops were free at steady state (fib(32) stays ≈2.2× rust `-O3`, unchanged).
+The real wins are (a) **smaller, cleaner modules** (faster parse/load, less to
+content-address) and (b) the **non-optimizing paths** — the browser metered
+interpreter (`kotoba-runtime-web`) and any per-instruction step/gas counting,
+where instruction count *is* the work. The residual fib gap is LLVM's
+recursion→accumulator-loop transform (identified earlier), which a peephole
+cannot reach; closing it needs a real optimizer pass and is out of scope for the
+agent workload (no numeric hot loops).
+
+Verification: `cargo test -p kotoba-clj` → **216 passed / 0 failed** (209 prior +
+7 new). End-to-end `sort`+`take`+`merge`+`dotimes` and the string/`str-int`
+paths run identically on wasmtime and V8.

--- a/docs/ADR-clojure-wasm.md
+++ b/docs/ADR-clojure-wasm.md
@@ -537,3 +537,42 @@ new 16-test `tests/hofs.rs` (map→filter→reduce chains, reader-macro callback
 captured-variable callbacks, `comp`/`partial` returning closures, `range`,
 `some`/`every?`/`keep`, `map-indexed`); clippy clean; no regressions across the
 component/kqe/pregel suites that compile with the now-table-bearing prelude.
+
+---
+
+## Coverage batch — clojure.core stdlib + iteration sugars (2026-06-21)
+
+Status: **Accepted.** Crate: `crates/kotoba-clj` (`tests/coverage.rs`, 16 tests).
+
+Broadens Clojure-language coverage with **no new codegen path or runtime node** —
+everything is either a pure-subset `PRELUDE` function (compiled through the
+existing vec/map + closure-table machinery) or an AST desugar into existing
+special forms.
+
+**New special forms (`ast.rs` desugar):**
+
+| form | desugars to |
+|------|-------------|
+| `(while test body…)` | `(loop [_ 0] (if test (do body… (recur 0)) 0))` |
+| `(dotimes [i n] body…)` | `(let [_n n] (loop [i 0] (if (< i _n) (do body… (recur (+ i 1))) 0)))` |
+| `(doseq [x coll] body…)` | `vec-count`/`vec-nth` walk in a `loop` (single binding; needs the prelude) |
+| `(if-some [x e] t e?)` / `(when-some [x e] body…)` | alias `if-let`/`when-let` (nil≡0≡falsy in the i64 model) |
+
+**New `PRELUDE` fns** (all output containers pre-sized; `vec-conj!`/`map-assoc!`
+never grow): `take` `drop` `take-while` `drop-while` `butlast` `take-last`
+`reverse` `concat` `repeat` `interpose` `interleave` `partition` `vec-contains?`
+`distinct` `sort` `sort-by` `vec-swap!` `merge` `merge-with` `select-keys`
+`zipmap` `get-in` `update` `complement` `juxt` `fnil` `max-key` `min-key`; plus
+`vector` arity extended 4→8.
+
+**Honest limits** (the i64 / mutable-bump model, unchanged): `distinct` /
+`vec-contains?` compare scalars by value but collection/string handles by
+identity; map fns assume **string keys** (the `str-eq?` contract); `sort` is
+O(n²) selection sort; there is still no number tower (i64 only), no lazy seqs,
+no persistent-immutable structures, and no dead-code elimination (every prelude
+fn is emitted, so a prelude-on module grew ~5.5 KB → ~8.7 KB — negligible for
+agents, a DCE target later).
+
+Verification: `cargo test -p kotoba-clj` → **209 passed / 0 failed** (193 prior +
+16 new); a combined end-to-end program (`sort`+`take`+`reduce`+`merge`+`dotimes`)
+runs to the same result on **both** wasmtime and V8.


### PR DESCRIPTION
## Summary

Broadens the Clojure-language surface of `kotoba-clj` (the Clojure/EDN-subset → WASM AOT compiler) with **no new codegen path** beyond one branch peephole — everything else is pure-subset `PRELUDE` functions (compiled through the existing vec/map + closure-table machinery) or AST desugars into existing special forms.

Two commits:

### 1. clojure.core stdlib + iteration sugars (`e59f60ba`)
- **New special forms** (`ast.rs` desugar): `while`, `dotimes`, `doseq` (single binding) → `loop`/`recur`; `if-some`/`when-some` aliased to the let-binding forms (nil≡0≡falsy in the i64 model).
- **New PRELUDE fns**: `take` `drop` `take-while` `drop-while` `butlast` `take-last` `reverse` `concat` `repeat` `interpose` `interleave` `partition` `vec-contains?` `distinct` `sort` `sort-by` `merge` `merge-with` `select-keys` `zipmap` `get-in` `update` `complement` `juxt` `fnil` `max-key` `min-key`; `vector` arity extended 4→8.

### 2. Strings, 2-pass collections, branch peephole (`5ed286e9`)
- **Strings** (PRELUDE, on the byte-builder): `str-cat`, `subs` (2/3-arity), `str-starts-with?`, `str-includes?`, `str-join` (single-alloc), `str-int` (signed int → decimal). No generic variadic `str` (the i64 model has no runtime type tags to distinguish an int handle from a string handle).
- **2-pass / pre-sized collections**: `mapcat` (sum-then-concat), `frequencies`, `group-by` (string-keyed maps).
- **Branch peephole** (`codegen.rs`): `compile_truthy_i32` feeds a 2-arg comparison (`= != < > <= >=`) straight into `if`/`br_if`, dropping the `extend_i32_u; const 0; i64.ne` round-trip the i64-everything model emitted. `fib` body **20 → 17 instrs, 34 → 30 B**.

## Honest limits (the i64 / mutable-bump model, unchanged)
- `distinct`/`vec-contains?` compare scalars by value, collection/string handles by identity.
- Map fns assume **string keys** (the `str-eq?` contract).
- `sort` is O(n²) selection sort; no number tower (i64 only); no lazy seqs / persistent structures; no dead-code elimination (a prelude-on module grew ~5.5 KB → ~8.7 KB — negligible for agents, a DCE target later).
- **Peephole perf (measured):** shrinks module size + instruction count but does **not** change `fib` steady-state on optimizing JITs — wasmtime/Cranelift and V8/TurboFan already fold the round-trip (fib(32) stays ≈2.2× rust `-O3`). The real wins are smaller/cleaner modules and the non-optimizing paths (browser metered interpreter, per-instruction gas). The residual fib gap is LLVM's recursion→accumulator-loop transform, beyond a peephole.

## Verification
- `cargo test -p kotoba-clj` → **216 passed / 0 failed** (193 prior + 23 new in `tests/coverage.rs`).
- A combined end-to-end program (`sort`+`take`+`reduce`+`merge`+`dotimes`) and the string/`str-int` paths run to identical results on **both** wasmtime and V8.
- `docs/ADR-clojure-wasm.md` records both batches incl. the honest peephole evaluation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AY3jaZ8RuZnE6Jy9EsawaL)_