### PR TITLE
docs: interactive explainer videos + GitHub Pages docs site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: Deploy docs site to GitHub Pages
+
+# Serves the static site under docs/ (landing page + interactive explainers + ADR/SVG)
+# at https://com-junkawasaki.github.io/kotoba/ . No Jekyll build (.nojekyll).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+# Allow the workflow to publish to Pages; one concurrent deploy.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload docs/ artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ for decentralized AI agent systems.  It combines Datomic-style immutable
 datoms, Pregel BSP graph computation, an auxiliary SPARQL 1.1 executor over IPFS
 storage, native CACAO authentication, and WASM Component Model execution.
 
+## 📺 Explainers & Docs site
+
+A static documentation site (landing page + **two interactive, auto-playing
+explainer videos** with Japanese narration) lives under [`docs/`](docs/) and is
+published via GitHub Pages:
+
+> **🌐 [com-junkawasaki.github.io/kotoba](https://com-junkawasaki.github.io/kotoba/)**
+
+| explainer | what it covers |
+|---|---|
+| **Part 1 — [Datomic × IPFS × Prolly Tree](https://com-junkawasaki.github.io/kotoba/explainer/kotoba-datomic-ipfs-explainer.html)** | how a Datomic-style query runs over a Prolly-Tree index that is DAG-CBOR/IPLD content-addressed and pinned to IPFS — write → 4-index build → CID → CommitDag → query `scan_prefix` → result provenance CID |
+| **Part 2 — [Query / CACAO / Signal](https://com-junkawasaki.github.io/kotoba/explainer/kotoba-query-auth-signal-explainer.html)** | complex/large queries (BGP join, MaterializedView), multihop (property paths, Pregel BSP), federation (`SERVICE`), the transact write path, CACAO auth/authz (depth-2 delegation), and Signal E2E (X3DH → Double Ratchet) + t-of-N custody |
+
+> These are self-contained HTML (open the Pages links above, or open the files
+> in [`docs/explainer/`](docs/explainer/) directly in a browser). GitHub does not
+> render the interactive HTML inline in this README. Every claim is grounded in
+> the actual source (`prolly.rs`, `arrangement.rs`, `cacao.rs`, `delegation.rs`,
+> `x3dh.rs`, `ratchet.rs`, `shares.rs`).
+
+See [**Documentation**](#documentation) below for the full ADR / design index.
+
 ## Install
 
 ### Homebrew (macOS / Linux)
@@ -250,6 +271,28 @@ Measurements taken on M4 Mac, release build, `KOTOBA_IPFS=off`,
 | 32          | **12753**   | 2.15 ms  |
 
 Trust-boundary throughput **12.8K QPS** at c=32, 100% replay-protected.
+
+## Documentation
+
+The published docs site — [**com-junkawasaki.github.io/kotoba**](https://com-junkawasaki.github.io/kotoba/)
+— is the entry point (overview, the two explainers, architecture, crates,
+security, and this index). It is the static site under [`docs/`](docs/), served
+by [`.github/workflows/pages.yml`](.github/workflows/pages.yml).
+
+| doc | topic |
+|---|---|
+| [`docs/index.html`](docs/index.html) | docs-site landing page (hub) |
+| [`docs/explainer/`](docs/explainer/) | the two interactive explainer videos |
+| [`docs/SECURITY-ARCHITECTURE.md`](docs/SECURITY-ARCHITECTURE.md) | X-Road-style accountability, R0–R3 custody, threat model |
+| [`docs/ADR-001-five-axis-distributed-redesign.md`](docs/ADR-001-five-axis-distributed-redesign.md) | five-axis distributed redesign |
+| [`docs/ADR-sealed-cold-tier.md`](docs/ADR-sealed-cold-tier.md) | encrypted cold tier + t-of-N custody |
+| [`docs/ADR-clojure-wasm.md`](docs/ADR-clojure-wasm.md) | Clojure/EDN-subset → WebAssembly compiler |
+| [`docs/ADR-browser-cid-query-vs-p2p.md`](docs/ADR-browser-cid-query-vs-p2p.md) | browser execution boundary |
+| [`docs/ADR-turn-relay.md`](docs/ADR-turn-relay.md) | pure-Rust TURN relay for WebRTC |
+| [`docs/ADR-kotoba-word.md`](docs/ADR-kotoba-word.md) | word/root registry + capability boundary |
+| [`docs/WASI-HTTP-EGRESS-XRPC-INGRESS.md`](docs/WASI-HTTP-EGRESS-XRPC-INGRESS.md) | I/O boundary (egress/ingress) |
+
+The cross-cutting design SSoT remains the parent-monorepo ADR (see [ADR](#adr) below).
 
 ## Build
 

--- a/docs/explainer/kotoba-datomic-ipfs-explainer.html
+++ b/docs/explainer/kotoba-datomic-ipfs-explainer.html
@@ -1,0 +1,580 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>net-kotoba ｜ Datomic query × IPFS / IPLD / Prolly Tree ─ 説明動画</title>
+<style>
+  :root{
+    --bg:#0b0f1a; --bg2:#0f1626; --ink:#e8eefc; --dim:#9fb0d0; --line:#26344f;
+    --eavt:#5fd0ff; --aevt:#7af0c0; --avet:#ffd166; --vaet:#ff7eb6;
+    --cid:#b78cff; --ipfs:#65c7ff; --b2:#ff9a62; --ok:#62e08a; --warn:#ff6b6b;
+    --card:#121b2e; --accent:#7aa2ff;
+    --mono:"SFMono-Regular",ui-monospace,Menlo,Consolas,monospace;
+    --sans:system-ui,-apple-system,"Hiragino Kaku Gothic ProN","Noto Sans JP",sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;height:100%}
+  body{
+    background:radial-gradient(1200px 800px at 70% -10%,#16213b 0%,var(--bg) 55%) fixed;
+    color:var(--ink); font-family:var(--sans); overflow:hidden;
+    -webkit-font-smoothing:antialiased;
+  }
+  #stage{
+    position:relative; width:100vw; height:100vh; max-height:100vh;
+    display:flex; align-items:center; justify-content:center;
+  }
+  .frame{
+    position:relative; width:min(1180px,94vw); aspect-ratio:16/9; max-height:84vh;
+    background:linear-gradient(180deg,var(--bg2),#0a1120);
+    border:1px solid var(--line); border-radius:18px; overflow:hidden;
+    box-shadow:0 30px 90px rgba(0,0,0,.55), inset 0 1px 0 rgba(255,255,255,.04);
+  }
+  /* top bar */
+  .topbar{
+    position:absolute; top:0; left:0; right:0; height:46px; z-index:6;
+    display:flex; align-items:center; gap:10px; padding:0 16px;
+    background:linear-gradient(180deg,rgba(10,16,30,.9),rgba(10,16,30,0));
+    font-size:12px; color:var(--dim);
+  }
+  .dot{width:10px;height:10px;border-radius:50%;background:#2a3a5a}
+  .dot.r{background:#ff5f57}.dot.y{background:#febc2e}.dot.g{background:#28c840}
+  .topbar b{color:var(--ink);font-weight:600;letter-spacing:.02em}
+  .badge{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--dim);
+    border:1px solid var(--line);border-radius:999px;padding:3px 9px}
+
+  /* scenes */
+  .scene{position:absolute; inset:46px 0 96px 0; padding:8px 40px 0;
+    opacity:0; visibility:hidden; transition:opacity .5s ease;}
+  .scene.active{opacity:1; visibility:visible}
+  .scene h2{margin:6px 0 2px; font-size:25px; letter-spacing:.01em}
+  .scene .sub{color:var(--dim); font-size:14px; margin:0 0 10px;
+    font-family:var(--mono)}
+  .chip{display:inline-block;font-family:var(--mono);font-size:11px;color:var(--accent);
+    border:1px solid var(--line);border-radius:6px;padding:2px 7px;margin-bottom:8px}
+
+  /* reveal animation helper: only runs when scene is active */
+  .anim{opacity:0; transform:translateY(8px)}
+  .scene.active .anim{animation:rise .6s ease forwards}
+  .scene.active .anim.d1{animation-delay:.15s}
+  .scene.active .anim.d2{animation-delay:.4s}
+  .scene.active .anim.d3{animation-delay:.7s}
+  .scene.active .anim.d4{animation-delay:1.0s}
+  .scene.active .anim.d5{animation-delay:1.35s}
+  .scene.active .anim.d6{animation-delay:1.7s}
+  .scene.active .anim.d7{animation-delay:2.1s}
+  @keyframes rise{to{opacity:1;transform:none}}
+  @keyframes pop{0%{transform:scale(.7);opacity:0}60%{transform:scale(1.06)}100%{transform:scale(1);opacity:1}}
+  @keyframes pulse{0%,100%{box-shadow:0 0 0 0 rgba(122,162,255,.0)}50%{box-shadow:0 0 0 6px rgba(122,162,255,.16)}}
+
+  /* generic boxes */
+  .box{background:var(--card);border:1px solid var(--line);border-radius:12px;
+    padding:12px 14px;font-size:13px}
+  .row{display:flex;gap:14px;align-items:stretch}
+  .col{display:flex;flex-direction:column;gap:12px}
+  .mono{font-family:var(--mono)}
+  .small{font-size:12px;color:var(--dim)}
+  .tag{font-family:var(--mono);font-size:11px;padding:2px 6px;border-radius:5px;
+    border:1px solid var(--line)}
+
+  /* caption / narration */
+  .caption{
+    position:absolute; left:0; right:0; bottom:54px; z-index:6;
+    display:flex; justify-content:center; padding:0 60px; pointer-events:none;
+  }
+  .caption .bubble{
+    max-width:92%; background:rgba(8,12,22,.78); border:1px solid var(--line);
+    backdrop-filter:blur(6px); border-radius:12px; padding:10px 18px;
+    font-size:16px; line-height:1.55; text-align:center; color:#eef3ff;
+    box-shadow:0 10px 30px rgba(0,0,0,.4);
+  }
+  .caption .bubble .k{color:var(--accent);font-family:var(--mono)}
+  .caption b{color:#fff}
+
+  /* controls */
+  .controls{
+    position:absolute; left:0; right:0; bottom:0; z-index:7; height:54px;
+    display:flex; align-items:center; gap:12px; padding:0 16px;
+    background:linear-gradient(0deg,rgba(8,12,22,.92),rgba(8,12,22,0));
+  }
+  .controls button{
+    background:#16213a;color:var(--ink);border:1px solid var(--line);
+    border-radius:9px;padding:7px 12px;font-size:13px;cursor:pointer;
+    font-family:var(--sans);transition:.15s;
+  }
+  .controls button:hover{background:#1d2c4d;border-color:#3a4f7a}
+  .controls .play{min-width:92px;font-weight:600}
+  .progress{flex:1;height:8px;background:#10182a;border-radius:999px;overflow:hidden;
+    border:1px solid var(--line);position:relative;cursor:pointer}
+  .progress .seg{position:absolute;top:0;bottom:0;width:1px;background:#1d2a44}
+  .progress .fill{position:absolute;left:0;top:0;bottom:0;width:0;
+    background:linear-gradient(90deg,#3a6cff,#65c7ff)}
+  .counter{font-family:var(--mono);font-size:12px;color:var(--dim);min-width:74px;text-align:right}
+  .spd{font-family:var(--mono);font-size:12px;color:var(--dim)}
+
+  /* ---- diagram primitives ---- */
+  .pipe{display:flex;align-items:center;gap:0;justify-content:center;margin-top:4px}
+  .node{
+    position:relative;background:var(--card);border:1px solid var(--line);border-radius:12px;
+    padding:12px 14px;min-width:120px;text-align:center;
+  }
+  .node .t{font-weight:600;font-size:14px}
+  .node .d{font-size:11px;color:var(--dim);font-family:var(--mono);margin-top:3px}
+  .arrow{width:54px;height:2px;background:linear-gradient(90deg,#2c3e63,#3a5a93);position:relative;margin:0 6px}
+  .arrow::after{content:"";position:absolute;right:-1px;top:-4px;border:5px solid transparent;border-left-color:#3a5a93}
+  .arrow .pkt{position:absolute;top:-3px;left:0;width:8px;height:8px;border-radius:50%;
+    background:#65c7ff;box-shadow:0 0 10px #65c7ff}
+  .scene.active .arrow .pkt{animation:flow 1.6s linear infinite}
+  @keyframes flow{0%{left:-4px;opacity:0}10%{opacity:1}90%{opacity:1}100%{left:52px;opacity:0}}
+
+  .tree{position:relative}
+  .tnode{position:absolute;background:var(--card);border:1px solid var(--line);
+    border-radius:9px;padding:5px 8px;font-family:var(--mono);font-size:11px;text-align:center}
+  .tnode.root{border-color:var(--accent)}
+  .tnode.leaf{border-style:dashed}
+  .tline{position:absolute;height:1px;transform-origin:left center;background:#33466e}
+
+  .blk{display:inline-flex;flex-direction:column;gap:2px;align-items:center;
+    border:1px solid var(--line);border-radius:9px;padding:8px 10px;background:#0e1626;min-width:96px}
+  .blk .cid{font-family:var(--mono);font-size:10px;color:var(--cid)}
+  .blk .ty{font-size:11px;color:var(--dim)}
+
+  .legend{display:flex;gap:14px;flex-wrap:wrap;margin-top:8px;font-size:12px}
+  .legend span{display:inline-flex;align-items:center;gap:6px;color:var(--dim)}
+  .sw{width:11px;height:11px;border-radius:3px;display:inline-block}
+
+  .kvs{font-family:var(--mono);font-size:12.5px;line-height:1.7}
+  .kvs .e{color:var(--eavt)}.kvs .a{color:var(--avet)}.kvs .v{color:var(--vaet)}
+  .kvs .t{color:var(--ipfs)}.kvs .add{color:var(--ok)}
+
+  .hl{color:#fff;background:rgba(122,162,255,.16);border-radius:4px;padding:0 4px}
+  .grid4{display:grid;grid-template-columns:repeat(4,1fr);gap:10px}
+  .idx{border:1px solid var(--line);border-radius:10px;padding:10px;text-align:center;background:#0e1626}
+  .idx .n{font-family:var(--mono);font-weight:700;font-size:15px}
+  .idx .u{font-size:11px;color:var(--dim);margin-top:3px}
+
+  .floatcid{position:absolute;font-family:var(--mono);font-size:11px;color:var(--cid);
+    border:1px solid #3a2d63;background:#160f2b;border-radius:6px;padding:2px 7px}
+
+  .endlist{font-size:13.5px;line-height:1.9}
+  .endlist code{font-family:var(--mono);color:var(--accent);font-size:12px}
+  .checkmk{color:var(--ok);font-weight:700;margin-right:6px}
+  a.cred{position:absolute;right:14px;bottom:60px;font-size:11px;color:#43597f;text-decoration:none;font-family:var(--mono)}
+</style>
+</head>
+<body>
+<div id="stage">
+  <div class="frame">
+    <div class="topbar">
+      <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+      <b>net-kotoba</b> ｜ Datomic query × IPFS / IPLD / Prolly Tree
+      <span class="badge" id="enginebadge">kotoba ≝ Datom[CID/T] × EAVT × Prolly × Datalog[Δ]</span>
+    </div>
+
+    <!-- ============ SCENE 0 : TITLE ============ -->
+    <section class="scene" data-dur="9">
+      <div style="height:100%;display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center">
+        <div class="chip anim">CONTENT-ADDRESSED DISTRIBUTED DATALOG DB</div>
+        <h2 class="anim d1" style="font-size:40px;margin:.2em 0">Datomic query を<br>
+          <span style="color:var(--ipfs)">IPFS</span> /
+          <span style="color:var(--cid)">IPLD</span> /
+          <span style="color:var(--avet)">Prolly&nbsp;Tree</span> で動かす</h2>
+        <p class="sub anim d2" style="font-size:15px">net-kotobase (kotobase.net) ← etzhayyim/kotoba ｜ Rust + WASM</p>
+        <div class="pipe anim d3" style="margin-top:18px">
+          <div class="node"><div class="t">Datom log</div><div class="d">(E,A,V,T,Added)</div></div>
+          <div class="arrow"><i class="pkt"></i></div>
+          <div class="node"><div class="t">Prolly Tree</div><div class="d">4-index</div></div>
+          <div class="arrow"><i class="pkt"></i></div>
+          <div class="node"><div class="t">CommitDag</div><div class="d">= WAL</div></div>
+          <div class="arrow"><i class="pkt"></i></div>
+          <div class="node"><div class="t">blocks</div><div class="d">DAG-CBOR/CID</div></div>
+        </div>
+        <p class="sub anim d4" style="margin-top:16px">▶ 自動再生中 … 下のバーで一時停止・シーン移動できます</p>
+      </div>
+    </section>
+
+    <!-- ============ SCENE 1 : 全体像 ============ -->
+    <section class="scene" data-dur="13">
+      <span class="chip anim">① 全体像 — 1本の content-addressed チェーン</span>
+      <h2 class="anim">「正本」は Datom ログ。IPFS と B2 は <span style="color:var(--b2)">export tier</span></h2>
+      <p class="sub anim d1">canonical spine: Datom log → ProllyTree → CommitDag → blocks</p>
+
+      <div class="row anim d2" style="margin-top:8px">
+        <div class="box col" style="flex:1.4">
+          <div class="small">正本（system of record） — kotoba プロセス内蔵ストア</div>
+          <div class="pipe" style="justify-content:flex-start">
+            <div class="node" style="min-width:96px"><div class="t">Datom log</div><div class="d">immutable</div></div>
+            <div class="arrow"><i class="pkt"></i></div>
+            <div class="node" style="min-width:96px"><div class="t">ProllyTree</div><div class="d">索引</div></div>
+            <div class="arrow"><i class="pkt"></i></div>
+            <div class="node" style="min-width:96px"><div class="t">CommitDag</div><div class="d">WAL</div></div>
+            <div class="arrow"><i class="pkt"></i></div>
+            <div class="node" style="min-width:96px"><div class="t">blocks</div><div class="d">CID</div></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="row anim d4" style="margin-top:16px">
+        <div class="box" style="flex:1;border-color:#2b3f63">
+          <div class="tag" style="color:var(--ipfs);border-color:#234">EXPORT ①</div>
+          <b style="display:block;margin:6px 0 2px">Kubo IPFS</b>
+          <span class="small">bitswap + DHT で公開・複製。封印した commit を<b>非同期</b>で export</span>
+        </div>
+        <div class="box" style="flex:1;border-color:#5a3a24">
+          <div class="tag" style="color:var(--b2);border-color:#432">EXPORT ②</div>
+          <b style="display:block;margin:6px 0 2px">Backblaze B2 (CAR)</b>
+          <span class="small">off-host の cold pin。DataLad + git-annex で全 block をミラー</span>
+        </div>
+        <div class="box" style="flex:1;border-color:#264">
+          <div class="tag" style="color:var(--ok);border-color:#243">ANCHOR</div>
+          <b style="display:block;margin:6px 0 2px">IPNS / Base L2</b>
+          <span class="small">署名ヘッドで per-graph root を固定、L2 に DAG root を tamper-evidence</span>
+        </div>
+      </div>
+      <p class="sub anim d5" style="margin-top:14px">hot な内蔵ストアが µs–ms で速く、IPFS/B2 は「壊れない・配れる」ための輸出層。</p>
+    </section>
+
+    <!-- ============ SCENE 2 : 書き込み Datom ============ -->
+    <section class="scene" data-dur="13">
+      <span class="chip anim">② 書き込み — Datom を積む</span>
+      <h2 class="anim"><span class="mono" style="color:var(--accent)">kg.ingest / datomic.transact</span> → 5-tuple を pending へ</h2>
+      <p class="sub anim d1">QuadStore::assert_datom（kotoba-graph/src/quad_store.rs）</p>
+
+      <div class="row anim d2" style="margin-top:10px;align-items:center">
+        <div class="box" style="flex:1">
+          <div class="small" style="margin-bottom:6px">Datomic 流の不変 5-tuple（retract は tombstone）</div>
+          <div class="kvs">
+            Datom {<br>
+            &nbsp;&nbsp;<span class="e">e</span>: CID&nbsp;&nbsp;<span class="small">— entity</span><br>
+            &nbsp;&nbsp;<span class="a">a</span>: ":role"&nbsp;<span class="small">— attribute</span><br>
+            &nbsp;&nbsp;<span class="v">v</span>: "admin"&nbsp;<span class="small">— value</span><br>
+            &nbsp;&nbsp;<span class="t">t</span>: tx&nbsp;&nbsp;&nbsp;&nbsp;<span class="small">— 論理時刻(basis-T)</span><br>
+            &nbsp;&nbsp;<span class="add">added</span>: true&nbsp;<span class="small">— 追加/撤回</span><br>
+            }
+          </div>
+        </div>
+        <div class="arrow" style="width:70px"><i class="pkt"></i></div>
+        <div class="box anim d3" style="flex:.9;text-align:center;border-color:#2f456b">
+          <div class="small">pending_datoms</div>
+          <div style="display:flex;gap:6px;justify-content:center;margin-top:10px">
+            <span class="sw" style="width:16px;height:16px;background:var(--eavt)"></span>
+            <span class="sw" style="width:16px;height:16px;background:var(--aevt)"></span>
+            <span class="sw" style="width:16px;height:16px;background:var(--avet)"></span>
+            <span class="sw" style="width:16px;height:16px;background:var(--vaet)"></span>
+            <span class="sw" style="width:16px;height:16px;background:#3a4f7a"></span>
+          </div>
+          <div class="small" style="margin-top:10px">少し溜めてから commit()</div>
+        </div>
+      </div>
+      <p class="sub anim d5" style="margin-top:16px">ここでは <b>正確な 5-tuple をそのまま記録</b>するだけ。索引化は commit で行う。</p>
+    </section>
+
+    <!-- ============ SCENE 3 : Prolly Tree build ============ -->
+    <section class="scene" data-dur="15">
+      <span class="chip anim">③ commit — 4本の Prolly Tree を作る</span>
+      <h2 class="anim">EAVT / AEVT / AVET / VAET を <span style="color:var(--avet)">並列ビルド</span></h2>
+      <p class="sub anim d1">kotoba-query/src/arrangement.rs ＋ kotoba-core/src/prolly.rs</p>
+
+      <div class="grid4 anim d2" style="margin-top:8px">
+        <div class="idx" style="border-color:#1e5673"><div class="n" style="color:var(--eavt)">EAVT</div><div class="u">entity 引き<br>(SPO)</div></div>
+        <div class="idx" style="border-color:#1e6b52"><div class="n" style="color:var(--aevt)">AEVT</div><div class="u">attribute 走査<br>(PSO)</div></div>
+        <div class="idx" style="border-color:#6b5a1e"><div class="n" style="color:var(--avet)">AVET</div><div class="u">値で entity 引き<br>(POS)</div></div>
+        <div class="idx" style="border-color:#6b2d4c"><div class="n" style="color:var(--vaet)">VAET</div><div class="u">逆参照<br>(OSP)</div></div>
+      </div>
+
+      <div class="row anim d4" style="margin-top:16px">
+        <div class="box" style="flex:1.1">
+          <b style="font-size:13px">確率的チャンキング（履歴非依存）</b>
+          <div class="mono" style="font-size:12.5px;margin-top:8px;color:var(--ink)">
+            is_boundary(key):<br>
+            &nbsp;&nbsp;h = <span style="color:var(--avet)">blake3</span>(key)<br>
+            &nbsp;&nbsp;return (h[0..4] &amp; <span class="hl">0x0000_00FF</span>) == 0
+          </div>
+          <p class="small" style="margin:8px 0 0">≈ 1/256 で境界が立つ → 平均 256 entries/chunk。同じデータなら必ず同じ形 = <b>deterministic / hash-consistent</b>。</p>
+        </div>
+        <div class="box" style="flex:1">
+          <b style="font-size:13px">path-copy（差分だけ書く）</b>
+          <div class="tree anim d5" style="height:96px;margin-top:6px">
+            <div class="tnode root" style="left:46%;top:0">root'</div>
+            <div class="tnode" style="left:14%;top:40px">A</div>
+            <div class="tnode" style="left:46%;top:40px;border-color:var(--ok);animation:pulse 1.6s infinite">B'</div>
+            <div class="tnode" style="left:74%;top:40px;opacity:.45">C</div>
+            <div class="tnode leaf" style="left:38%;top:78px;border-color:var(--ok)">leaf'</div>
+            <div class="tline" style="left:50%;top:18px;width:46px;transform:rotate(40deg)"></div>
+            <div class="tline" style="left:50%;top:18px;width:8px;transform:rotate(90deg)"></div>
+            <div class="tline" style="left:50%;top:18px;width:46px;transform:rotate(140deg)"></div>
+          </div>
+          <p class="small" style="margin:2px 0 0">変わった枝だけ新ノード（緑）。残りは旧 CID を共有 → commit ごとに <b>Δ だけ</b>書く。</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ SCENE 4 : DAG-CBOR / CID / CommitDag ============ -->
+    <section class="scene" data-dur="15">
+      <span class="chip anim">④ content-addressing — CID を付ける</span>
+      <h2 class="anim">各ノード → <span style="color:var(--cid)">DAG-CBOR</span> → <span style="color:var(--cid)">sha2-256</span> → CIDv1</h2>
+      <p class="sub anim d1">put_node()（prolly.rs）／ KotobaCid::from_bytes（cid.rs）</p>
+
+      <div class="row anim d2" style="margin-top:8px">
+        <div class="box" style="flex:1.2">
+          <div class="small" style="margin-bottom:6px">ノードを正準 DAG-CBOR で直列化</div>
+          <div class="blk" style="min-width:auto;align-items:flex-start;background:#0e1626">
+            <span class="ty">Internal</span>
+            <span class="mono" style="font-size:11px">children: [(max_key, <span style="color:var(--cid)">child-CID</span>)…]</span>
+            <span class="small">子リンクは IPLD <b>CID tag-42</b></span>
+          </div>
+          <div class="mono" style="font-size:12.5px;margin-top:10px;line-height:1.6">
+            cid[0]=<span class="hl">01</span> <span class="small">CIDv1</span><br>
+            cid[1]=<span class="hl">0x71</span> <span class="small">dag-cbor</span><br>
+            cid[2]=<span class="hl">0x12</span> <span class="small">sha2-256</span><br>
+            cid[3]=<span class="hl">32</span>&nbsp;&nbsp;&nbsp;<span class="small">+ 32B digest</span>
+          </div>
+          <p class="small" style="margin-top:8px">→ <b>IPFS 互換 CIDv1</b>。block の中に自分の CID は持たない（= block の hash そのもの）。</p>
+        </div>
+        <div class="arrow" style="width:50px"><i class="pkt"></i></div>
+        <div class="box" style="flex:1.1">
+          <div class="small" style="margin-bottom:8px">commit を CommitDag に append（= WAL）</div>
+          <div class="blk" style="min-width:auto;align-items:flex-start">
+            <span class="ty">Commit</span>
+            <span class="mono" style="font-size:11px">root / index_roots{eavt,aevt,avet,vaet,tea}</span>
+            <span class="mono" style="font-size:11px">prev → 親 commit ／ seq / tx_cid / sig</span>
+          </div>
+          <div class="pipe anim d4" style="justify-content:flex-start;margin-top:12px">
+            <div class="blk" style="min-width:54px;padding:6px"><span class="cid">c0</span></div>
+            <div class="arrow" style="width:30px"><i class="pkt"></i></div>
+            <div class="blk" style="min-width:54px;padding:6px"><span class="cid">c1</span></div>
+            <div class="arrow" style="width:30px"><i class="pkt"></i></div>
+            <div class="blk" style="min-width:54px;padding:6px;border-color:var(--accent)"><span class="cid">HEAD</span></div>
+          </div>
+          <p class="small" style="margin-top:10px">親リンクで連なる不変チェーン。耐久境界は <b>head-ref の原子的更新</b>（git / Datomic 流）。再起動は head + checkpoint から差分 walk。</p>
+        </div>
+      </div>
+      <p class="sub anim d6" style="margin-top:12px">全 block は <b>CARv1</b> 1束にまとめて単一 PUT（commit を atomic に複製）。</p>
+    </section>
+
+    <!-- ============ SCENE 5 : IPFS / B2 export & pin ============ -->
+    <section class="scene" data-dur="13">
+      <span class="chip anim">⑤ 輸出 & ピン留め — durability</span>
+      <h2 class="anim">kotoba 自身が <span style="color:var(--ipfs)">IPFS block store ＋ pinner</span></h2>
+      <p class="sub anim d1">kotoba-store: Memory / Kubo / Tiered / Distributed・BlockStore trait</p>
+
+      <div class="row anim d2" style="margin-top:10px;align-items:center">
+        <div class="box" style="flex:.9;text-align:center;border-color:var(--accent)">
+          <b>hot tier（内蔵）</b>
+          <div class="small" style="margin-top:6px">直接ディスク µs–ms<br>pin はストア内のフラグ<br>(pin/add RPC 不要 → ~35× 速い)</div>
+        </div>
+        <div class="col" style="flex:1.2">
+          <div class="box" style="border-color:#2b3f63;display:flex;align-items:center;gap:10px">
+            <span class="sw" style="width:14px;height:14px;background:var(--ipfs)"></span>
+            <div><b>Kubo IPFS</b> <span class="small">— bitswap + DHT。block put / get（CIDで取得）</span></div>
+            <div class="arrow" style="width:40px;margin-left:auto"><i class="pkt"></i></div>
+          </div>
+          <div class="box" style="border-color:#5a3a24;display:flex;align-items:center;gap:10px">
+            <span class="sw" style="width:14px;height:14px;background:var(--b2)"></span>
+            <div><b>B2 cold pin (CAR)</b> <span class="small">— 全 block を S3 にミラー、restore で再 import</span></div>
+            <div class="arrow" style="width:40px;margin-left:auto"><i class="pkt"></i></div>
+          </div>
+          <div class="box" style="border-color:#264;display:flex;align-items:center;gap:10px">
+            <span class="sw" style="width:14px;height:14px;background:var(--ok)"></span>
+            <div><b>IPNS 署名ヘッド</b> <span class="small">— per-graph root を可変ポインタで公開</span></div>
+          </div>
+        </div>
+      </div>
+      <p class="sub anim d5" style="margin-top:14px">封印済み commit を <b>ホットパスの外で非同期 export</b>。pin = named commit CID = 恒久・アドレス可能。</p>
+    </section>
+
+    <!-- ============ SCENE 6 : QUERY ============ -->
+    <section class="scene" data-dur="17">
+      <span class="chip anim">⑥ クエリ — datomic.q を実行する（本命）</span>
+      <h2 class="anim"><span class="mono" style="color:var(--accent)">[?e :role "admin"]</span> を AVET で引く</h2>
+      <p class="sub anim d1">q / pull / datoms / asOf / history ｜ keycodec で hot=cold 同順</p>
+
+      <div class="pipe anim d2" style="justify-content:flex-start;margin-top:6px;flex-wrap:wrap;gap:4px">
+        <div class="node" style="min-width:auto;padding:9px 12px"><div class="t" style="font-size:13px">① parse</div><div class="d">EDN → AST</div></div>
+        <div class="arrow"><i class="pkt"></i></div>
+        <div class="node" style="min-width:auto;padding:9px 12px"><div class="t" style="font-size:13px">② 索引選択</div><div class="d">bound a,v → AVET</div></div>
+        <div class="arrow"><i class="pkt"></i></div>
+        <div class="node" style="min-width:auto;padding:9px 12px"><div class="t" style="font-size:13px">③ hot?</div><div class="d">Arrangement</div></div>
+        <div class="arrow"><i class="pkt"></i></div>
+        <div class="node" style="min-width:auto;padding:9px 12px"><div class="t" style="font-size:13px">④ cold scan</div><div class="d">ProllyTree</div></div>
+      </div>
+
+      <div class="row anim d4" style="margin-top:14px">
+        <div class="box" style="flex:1;border-color:var(--accent)">
+          <b style="font-size:13px">HOT — in-memory Arrangement</b>
+          <p class="small" style="margin:6px 0 0">索引がホットなら直引き。<br>EAVT は <b>O(1)</b> hash（≈180ns）、AVET/VAET は <b>O(log N)</b> BTreeMap。これは <b>キャッシュ最適化</b>に過ぎない。</p>
+        </div>
+        <div class="box" style="flex:1.4">
+          <b style="font-size:13px">COLD — ProllyTree を辿る（IPFS基盤の上）</b>
+          <div class="mono" style="font-size:12px;margin-top:6px">
+            root = commit.index_roots["<span style="color:var(--avet)">avet</span>"]<br>
+            prefix = keycodec(":role")+keycodec("admin")<br>
+            ProllyTree::<span class="hl">scan_prefix</span>(root, prefix, store)
+          </div>
+          <div class="tree anim d5" style="height:92px;margin-top:8px">
+            <div class="tnode root" style="left:44%;top:0">root (1 get)</div>
+            <div class="tnode" style="left:8%;top:38px;opacity:.4">child</div>
+            <div class="tnode" style="left:40%;top:38px;border-color:var(--avet);animation:pulse 1.4s infinite">child (1 get)</div>
+            <div class="tnode" style="left:72%;top:38px;opacity:.4">child</div>
+            <div class="tnode leaf" style="left:33%;top:72px;border-color:var(--avet)">leaf → [E…]</div>
+            <div class="tline" style="left:48%;top:16px;width:48px;transform:rotate(38deg)"></div>
+            <div class="tline" style="left:48%;top:16px;width:8px;transform:rotate(90deg)"></div>
+            <div class="tline" style="left:48%;top:16px;width:48px;transform:rotate(142deg)"></div>
+          </div>
+        </div>
+      </div>
+      <p class="sub anim d6" style="margin-top:10px">各レベル = block 1回 get（ceil(log₂₅₆ N) ホップ）。leaf から Datom 復元 → filter/project。<b>asOf/since は TEA</b> で時間遡行。</p>
+    </section>
+
+    <!-- ============ SCENE 7 : provenance emit_cid ============ -->
+    <section class="scene" data-dur="14">
+      <span class="chip anim">⑦ provenance — クエリ結果も content-addressed</span>
+      <h2 class="anim"><span class="mono" style="color:var(--accent)">emit_cid</span> で <span style="color:var(--cid)">result_cid</span> を返す</h2>
+      <p class="sub anim d1">ADR-2606060000 ｜ 3つの DAG-CBOR エンベロープ</p>
+
+      <div class="pipe anim d2" style="margin-top:10px">
+        <div class="blk" style="min-width:160px;border-color:#3a2d63">
+          <span class="ty">kotoba.queryspec.v1</span>
+          <span class="mono" style="font-size:10.5px">lang / query(正準EDN) / inputs</span>
+          <span class="cid">query_spec_cid</span>
+        </div>
+        <div class="arrow"><i class="pkt"></i></div>
+        <div class="blk" style="min-width:170px;border-color:#3a2d63">
+          <span class="ty">kotoba.queryjob.v1</span>
+          <span class="mono" style="font-size:10.5px">spec + basis_t + asOf/since + engine</span>
+          <span class="cid">query_job_cid</span>
+        </div>
+        <div class="arrow"><i class="pkt"></i></div>
+        <div class="blk" style="min-width:160px;border-color:var(--cid)">
+          <span class="ty">kotoba.result.v1</span>
+          <span class="mono" style="font-size:10.5px">job + basis_t + rows_edn(正準)</span>
+          <span class="cid" style="color:#fff;background:#2a1c4d;border-radius:4px;padding:1px 5px">result_cid</span>
+        </div>
+      </div>
+
+      <div class="row anim d4" style="margin-top:16px">
+        <div class="box" style="flex:1;text-align:center"><span class="checkmk">✔</span><b>再現</b><div class="small">同じ query + 同じ basis-T ⇒ 同じ結果</div></div>
+        <div class="box" style="flex:1;text-align:center"><span class="checkmk">✔</span><b>改ざん検知</b><div class="small">1 行変えれば result_cid が動く</div></div>
+        <div class="box" style="flex:1;text-align:center"><span class="checkmk">✔</span><b>キャッシュキー</b><div class="small">query_job_cid が安定キー</div></div>
+        <div class="box" style="flex:1;text-align:center"><span class="checkmk">✔</span><b>provenance DAG</b><div class="small">「なぜこの答え」を辿れる</div></div>
+      </div>
+      <p class="sub anim d6" style="margin-top:12px">result_cid は <b>JSON 応答ではなく</b>正準 DAG-CBOR block の CID。検証は CID で block を再取得して行う。</p>
+    </section>
+
+    <!-- ============ SCENE 8 : SUMMARY ============ -->
+    <section class="scene" data-dur="16">
+      <span class="chip anim">まとめ — end to end</span>
+      <h2 class="anim">クエリは「索引化された Prolly Tree」を辿るだけ</h2>
+      <div class="anim d2 endlist" style="margin-top:10px">
+        <div><span class="checkmk">①</span>書込 <code>QuadStore::assert_datom</code> で 5-tuple <b>(E,A,V,T,Added)</b> を pending に。</div>
+        <div><span class="checkmk">②</span>commit で <b>EAVT/AEVT/AVET/VAET(+TEA)</b> の Prolly Tree を並列ビルド（<code>blake3(key)&amp;0xFF==0</code> 境界・path-copy）。</div>
+        <div><span class="checkmk">③</span>各ノードを <b>DAG-CBOR → sha2-256 → CIDv1(0x71)</b>、子リンクは IPLD tag-42。<code>Commit{index_roots,prev,seq}</code> を CommitDag(=WAL) に append、CARv1 で単一 PUT。</div>
+        <div><span class="checkmk">④</span>封印 commit を <b>Kubo IPFS / B2</b> へ非同期 export・pin、<b>IPNS</b> で head 公開。</div>
+        <div><span class="checkmk">⑤</span>クエリは索引選択 → hot Arrangement か <code>ProllyTree::scan_prefix</code> で cold scan（各レベル=block 1 get）→ Datom 復元。</div>
+        <div><span class="checkmk">⑥</span><code>emit_cid</code> で結果も <b>result_cid</b> として content-address（再現・改ざん検知・キャッシュ）。</div>
+      </div>
+      <p class="sub anim d5" style="margin-top:14px">主要コード: <span class="mono">prolly.rs / arrangement.rs / keycodec.rs / quad_store.rs / commit.rs / cid.rs</span></p>
+      <a class="cred" href="#">net-kotobase/docs/explainer</a>
+    </section>
+
+    <!-- caption -->
+    <div class="caption"><div class="bubble" id="cap">…</div></div>
+
+    <!-- controls -->
+    <div class="controls">
+      <button class="play" id="play">⏸ 一時停止</button>
+      <button id="prev">◀ 前</button>
+      <button id="next">次 ▶</button>
+      <button id="replay">↺</button>
+      <div class="progress" id="bar"><div class="fill" id="fill"></div></div>
+      <span class="spd" id="spd">1.0×</span>
+      <button id="speed">速度</button>
+      <span class="counter" id="counter">0 / 0</span>
+    </div>
+  </div>
+</div>
+
+<script>
+(function(){
+  const scenes = Array.from(document.querySelectorAll('.scene'));
+  const caps = [
+    "今の net-kotoba は、Datomic 流のクエリを IPFS・IPLD・Prolly Tree の上で動かします。要点をシーンごとに見ていきましょう。",
+    "全体は1本の content-addressed チェーン。<b>Datom ログが正本</b>で、IPFS と B2 はあくまで「壊れない・配れる」ための<b>輸出層</b>です。",
+    "書き込みは <span class='k'>assert_datom</span>。Datomic と同じ不変 5-tuple <b>(E,A,V,T,Added)</b> をそのまま pending に積み、索引化は後の commit でまとめて行います。",
+    "commit で <b>EAVT / AEVT / AVET / VAET</b> の4本の Prolly Tree を並列ビルド。<span class='k'>blake3(key)&amp;0xFF==0</span> で境界を決め、変わった枝だけ path-copy で書きます。",
+    "各ノードは <b>DAG-CBOR</b> に直列化し <b>sha2-256</b> で <b>CIDv1(0x71)</b> を付与。子リンクは IPLD tag-42。Commit を CommitDag(=WAL) に繋ぎ、CARv1 で1束にします。",
+    "kotoba 自身が IPFS の block store 兼 pinner。速い内蔵 hot tier が正本で、封印済み commit を <b>Kubo IPFS</b> と <b>B2</b> へ非同期 export・pin します。",
+    "クエリ本番。パターンから索引を選び（ここは AVET）、ホットなら Arrangement を直引き、無ければ <span class='k'>scan_prefix</span> で Prolly Tree を辿る。各レベルが block 1回の get です。",
+    "<span class='k'>emit_cid</span> を付けると結果も content-address されます。queryspec→queryjob→<b>result_cid</b> の3エンベロープで、再現・改ざん検知・キャッシュが効きます。",
+    "まとめ。クエリは結局「索引化された Prolly Tree を辿るだけ」。書込→索引→CommitDag→blocks の1本道に、IPFS/B2 export と CID provenance が乗っています。"
+  ];
+  let i = 0, playing = true, t0 = 0, raf = null, elapsed = 0, speed = 1;
+  const fill = document.getElementById('fill');
+  const counter = document.getElementById('counter');
+  const cap = document.getElementById('cap');
+  const playBtn = document.getElementById('play');
+  const spd = document.getElementById('spd');
+
+  // progress segments
+  const bar = document.getElementById('bar');
+  scenes.forEach((s,k)=>{ if(k>0){const seg=document.createElement('div');seg.className='seg';seg.style.left=(k/scenes.length*100)+'%';bar.appendChild(seg);} });
+
+  function durOf(k){ return (parseFloat(scenes[k].dataset.dur)||10)*1000/speed; }
+
+  function show(k, resetTime){
+    i = (k+scenes.length)%scenes.length;
+    scenes.forEach((s,idx)=>{
+      s.classList.remove('active');
+      // re-trigger reveal animations by reflow
+    });
+    const s = scenes[i];
+    // force restart of CSS animations
+    void s.offsetWidth;
+    s.classList.add('active');
+    cap.innerHTML = caps[i] || '';
+    counter.textContent = (i+1)+' / '+scenes.length;
+    if(resetTime!==false){ elapsed = 0; t0 = performance.now(); }
+  }
+
+  function tick(now){
+    if(!playing){ return; }
+    const dur = durOf(i);
+    const e = elapsed + (now - t0);
+    const p = Math.min(1, e/dur);
+    fill.style.width = ((i + p)/scenes.length*100) + '%';
+    if(p>=1){
+      if(i < scenes.length-1){ show(i+1); }
+      else { playing=false; playBtn.textContent='↺ もう一度'; fill.style.width='100%'; return; }
+    }
+    raf = requestAnimationFrame(tick);
+  }
+  function start(){ playing=true; playBtn.textContent='⏸ 一時停止'; t0=performance.now(); cancelAnimationFrame(raf); raf=requestAnimationFrame(tick); }
+  function pause(){ playing=false; playBtn.textContent='▶ 再生'; elapsed += performance.now()-t0; cancelAnimationFrame(raf); }
+
+  playBtn.onclick = ()=>{
+    if(playBtn.textContent.indexOf('もう一度')>=0){ show(0); start(); return; }
+    playing ? pause() : start();
+  };
+  document.getElementById('next').onclick = ()=>{ show(i+1); start(); };
+  document.getElementById('prev').onclick = ()=>{ show(i-1); start(); };
+  document.getElementById('replay').onclick = ()=>{ show(0); start(); };
+  document.getElementById('speed').onclick = ()=>{
+    speed = speed>=2 ? 0.5 : speed+0.5;
+    spd.textContent = speed.toFixed(1)+'×';
+  };
+  bar.onclick = (ev)=>{
+    const r = bar.getBoundingClientRect();
+    const frac = (ev.clientX-r.left)/r.width;
+    show(Math.floor(frac*scenes.length)); start();
+  };
+  document.addEventListener('keydown',e=>{
+    if(e.key===' '){e.preventDefault();playBtn.onclick();}
+    if(e.key==='ArrowRight'){show(i+1);start();}
+    if(e.key==='ArrowLeft'){show(i-1);start();}
+  });
+
+  show(0); start();
+})();
+</script>
+</body>
+</html>

--- a/docs/explainer/kotoba-query-auth-signal-explainer.html
+++ b/docs/explainer/kotoba-query-auth-signal-explainer.html
@@ -1,0 +1,507 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>net-kotoba ｜ 大規模クエリ・multihop・書込・CACAO・Signal ─ 説明動画 Part 2</title>
+<style>
+  :root{
+    --bg:#0b0f1a; --bg2:#0f1626; --ink:#e8eefc; --dim:#9fb0d0; --line:#26344f;
+    --eavt:#5fd0ff; --aevt:#7af0c0; --avet:#ffd166; --vaet:#ff7eb6;
+    --cid:#b78cff; --ipfs:#65c7ff; --b2:#ff9a62; --ok:#62e08a; --warn:#ff6b6b;
+    --auth:#9d7bff; --sig:#54e0c9; --card:#121b2e; --accent:#7aa2ff;
+    --mono:"SFMono-Regular",ui-monospace,Menlo,Consolas,monospace;
+    --sans:system-ui,-apple-system,"Hiragino Kaku Gothic ProN","Noto Sans JP",sans-serif;
+  }
+  *{box-sizing:border-box}
+  html,body{margin:0;height:100%}
+  body{
+    background:radial-gradient(1200px 800px at 70% -10%,#16213b 0%,var(--bg) 55%) fixed;
+    color:var(--ink); font-family:var(--sans); overflow:hidden; -webkit-font-smoothing:antialiased;
+  }
+  #stage{position:relative; width:100vw; height:100vh; display:flex; align-items:center; justify-content:center;}
+  .frame{
+    position:relative; width:min(1180px,94vw); aspect-ratio:16/9; max-height:84vh;
+    background:linear-gradient(180deg,var(--bg2),#0a1120);
+    border:1px solid var(--line); border-radius:18px; overflow:hidden;
+    box-shadow:0 30px 90px rgba(0,0,0,.55), inset 0 1px 0 rgba(255,255,255,.04);
+  }
+  .topbar{
+    position:absolute; top:0; left:0; right:0; height:46px; z-index:6;
+    display:flex; align-items:center; gap:10px; padding:0 16px;
+    background:linear-gradient(180deg,rgba(10,16,30,.9),rgba(10,16,30,0)); font-size:12px; color:var(--dim);
+  }
+  .dot{width:10px;height:10px;border-radius:50%;background:#2a3a5a}
+  .dot.r{background:#ff5f57}.dot.y{background:#febc2e}.dot.g{background:#28c840}
+  .topbar b{color:var(--ink);font-weight:600;letter-spacing:.02em}
+  .badge{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--dim);
+    border:1px solid var(--line);border-radius:999px;padding:3px 9px}
+
+  .scene{position:absolute; inset:46px 0 96px 0; padding:8px 40px 0; opacity:0; visibility:hidden; transition:opacity .5s ease;}
+  .scene.active{opacity:1; visibility:visible}
+  .scene h2{margin:6px 0 2px; font-size:25px; letter-spacing:.01em}
+  .scene .sub{color:var(--dim); font-size:14px; margin:0 0 10px; font-family:var(--mono)}
+  .chip{display:inline-block;font-family:var(--mono);font-size:11px;color:var(--accent);
+    border:1px solid var(--line);border-radius:6px;padding:2px 7px;margin-bottom:8px}
+
+  .anim{opacity:0; transform:translateY(8px)}
+  .scene.active .anim{animation:rise .6s ease forwards}
+  .scene.active .anim.d1{animation-delay:.15s}.scene.active .anim.d2{animation-delay:.4s}
+  .scene.active .anim.d3{animation-delay:.7s}.scene.active .anim.d4{animation-delay:1.0s}
+  .scene.active .anim.d5{animation-delay:1.35s}.scene.active .anim.d6{animation-delay:1.7s}
+  .scene.active .anim.d7{animation-delay:2.05s}.scene.active .anim.d8{animation-delay:2.4s}
+  @keyframes rise{to{opacity:1;transform:none}}
+  @keyframes pulse{0%,100%{box-shadow:0 0 0 0 rgba(122,162,255,0)}50%{box-shadow:0 0 0 6px rgba(122,162,255,.16)}}
+  @keyframes spin{to{transform:rotate(360deg)}}
+
+  .box{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:12px 14px;font-size:13px}
+  .row{display:flex;gap:14px;align-items:stretch}
+  .col{display:flex;flex-direction:column;gap:12px}
+  .mono{font-family:var(--mono)}
+  .small{font-size:12px;color:var(--dim)}
+  .tag{font-family:var(--mono);font-size:11px;padding:2px 6px;border-radius:5px;border:1px solid var(--line)}
+  .hl{color:#fff;background:rgba(122,162,255,.16);border-radius:4px;padding:0 4px}
+
+  .caption{position:absolute; left:0; right:0; bottom:54px; z-index:6; display:flex; justify-content:center; padding:0 60px; pointer-events:none;}
+  .caption .bubble{max-width:92%; background:rgba(8,12,22,.78); border:1px solid var(--line);
+    backdrop-filter:blur(6px); border-radius:12px; padding:10px 18px; font-size:16px; line-height:1.55;
+    text-align:center; color:#eef3ff; box-shadow:0 10px 30px rgba(0,0,0,.4);}
+  .caption .bubble .k{color:var(--accent);font-family:var(--mono)}
+  .caption b{color:#fff}
+
+  .controls{position:absolute; left:0; right:0; bottom:0; z-index:7; height:54px; display:flex; align-items:center; gap:12px;
+    padding:0 16px; background:linear-gradient(0deg,rgba(8,12,22,.92),rgba(8,12,22,0));}
+  .controls button{background:#16213a;color:var(--ink);border:1px solid var(--line);border-radius:9px;
+    padding:7px 12px;font-size:13px;cursor:pointer;font-family:var(--sans);transition:.15s;}
+  .controls button:hover{background:#1d2c4d;border-color:#3a4f7a}
+  .controls .play{min-width:104px;font-weight:600}
+  .progress{flex:1;height:8px;background:#10182a;border-radius:999px;overflow:hidden;border:1px solid var(--line);position:relative;cursor:pointer}
+  .progress .seg{position:absolute;top:0;bottom:0;width:1px;background:#1d2a44}
+  .progress .fill{position:absolute;left:0;top:0;bottom:0;width:0;background:linear-gradient(90deg,#3a6cff,#65c7ff)}
+  .counter{font-family:var(--mono);font-size:12px;color:var(--dim);min-width:74px;text-align:right}
+  .spd{font-family:var(--mono);font-size:12px;color:var(--dim)}
+
+  .node{position:relative;background:var(--card);border:1px solid var(--line);border-radius:12px;padding:11px 13px;min-width:108px;text-align:center;}
+  .node .t{font-weight:600;font-size:13px}.node .d{font-size:11px;color:var(--dim);font-family:var(--mono);margin-top:3px}
+  .pipe{display:flex;align-items:center;justify-content:center;margin-top:4px;flex-wrap:wrap;gap:4px}
+  .arrow{width:48px;height:2px;background:linear-gradient(90deg,#2c3e63,#3a5a93);position:relative;margin:0 6px}
+  .arrow::after{content:"";position:absolute;right:-1px;top:-4px;border:5px solid transparent;border-left-color:#3a5a93}
+  .arrow .pkt{position:absolute;top:-3px;left:0;width:8px;height:8px;border-radius:50%;background:#65c7ff;box-shadow:0 0 10px #65c7ff}
+  .scene.active .arrow .pkt{animation:flow 1.6s linear infinite}
+  @keyframes flow{0%{left:-4px;opacity:0}10%{opacity:1}90%{opacity:1}100%{left:46px;opacity:0}}
+
+  .grid4{display:grid;grid-template-columns:repeat(4,1fr);gap:10px}
+  .idx{border:1px solid var(--line);border-radius:10px;padding:9px;text-align:center;background:#0e1626}
+  .idx .n{font-family:var(--mono);font-weight:700;font-size:14px}.idx .u{font-size:10.5px;color:var(--dim);margin-top:3px}
+
+  .blk{display:inline-flex;flex-direction:column;gap:2px;align-items:center;border:1px solid var(--line);border-radius:9px;padding:7px 9px;background:#0e1626;min-width:88px}
+  .blk .cid{font-family:var(--mono);font-size:10px;color:var(--cid)}.blk .ty{font-size:11px;color:var(--dim)}
+
+  .checkmk{color:var(--ok);font-weight:700;margin-right:6px}
+  .xmk{color:var(--warn);font-weight:700;margin-right:6px}
+  .endlist{font-size:13px;line-height:1.85}.endlist code{font-family:var(--mono);color:var(--accent);font-size:12px}
+  a.cred{position:absolute;right:14px;bottom:60px;font-size:11px;color:#43597f;text-decoration:none;font-family:var(--mono)}
+
+  /* graph dots for multihop */
+  .gnode{position:absolute;width:30px;height:30px;border-radius:50%;background:#16213a;border:1px solid var(--line);
+    display:flex;align-items:center;justify-content:center;font-size:11px;font-family:var(--mono);color:var(--dim)}
+  .gedge{position:absolute;height:2px;background:#33466e;transform-origin:left center}
+  .gnode.lit{border-color:var(--avet);color:var(--avet);box-shadow:0 0 12px rgba(255,209,102,.4)}
+  .scene.active .gnode.h1{animation:lit .5s .5s forwards}
+  .scene.active .gnode.h2{animation:lit .5s 1.1s forwards}
+  .scene.active .gnode.h3{animation:lit .5s 1.7s forwards}
+  @keyframes lit{to{border-color:var(--avet);color:var(--avet);box-shadow:0 0 12px rgba(255,209,102,.4)}}
+
+  .ladder{display:flex;flex-direction:column;gap:6px}
+  .step{display:flex;align-items:center;gap:8px;font-size:12.5px}
+  .pill{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:999px;padding:2px 9px;color:var(--auth)}
+</style>
+</head>
+<body>
+<div id="stage">
+  <div class="frame">
+    <div class="topbar">
+      <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+      <b>net-kotoba</b> ｜ Part 2 — 大規模クエリ・multihop・書込・CACAO・Signal
+      <span class="badge">CACAO × X3DH/Double-Ratchet × Pregel[BSP] × t-of-N custody</span>
+    </div>
+
+    <!-- 0 TITLE -->
+    <section class="scene" data-dur="9">
+      <div style="height:100%;display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center">
+        <div class="chip anim">EXPLAINER ─ PART 2</div>
+        <h2 class="anim d1" style="font-size:34px;margin:.2em 0">複雑/大規模クエリ・<span style="color:var(--avet)">multihop</span>・書き込み<br>
+          <span style="color:var(--auth)">CACAO 認可</span> ・ <span style="color:var(--sig)">Signal E2E</span> はどう動くか</h2>
+        <p class="sub anim d2">Part 1（Datomic × IPFS × Prolly Tree）の続き</p>
+        <div class="pipe anim d3" style="margin-top:16px">
+          <div class="node"><div class="t">大規模query</div><div class="d">join / MV</div></div>
+          <div class="arrow"><i class="pkt"></i></div>
+          <div class="node"><div class="t">multihop</div><div class="d">path / Pregel</div></div>
+          <div class="arrow"><i class="pkt"></i></div>
+          <div class="node"><div class="t">書込/認可</div><div class="d">CACAO</div></div>
+          <div class="arrow"><i class="pkt"></i></div>
+          <div class="node"><div class="t">E2E秘匿</div><div class="d">Signal</div></div>
+        </div>
+        <p class="sub anim d4" style="margin-top:14px">▶ 自動再生中 … 下のバーで一時停止・シーン移動</p>
+      </div>
+    </section>
+
+    <!-- 1 COMPLEX QUERY -->
+    <section class="scene" data-dur="16">
+      <span class="chip anim">① 複雑/大規模クエリ — join と増分MV</span>
+      <h2 class="anim">BGP は <span style="color:var(--avet)">subject 集合の積</span>で結合する</h2>
+      <p class="sub anim d1">execute_sparql_graph_pattern（quad_store.rs:1673〜）</p>
+
+      <div class="row anim d2" style="margin-top:6px">
+        <div class="box" style="flex:1.3">
+          <div class="mono" style="font-size:12.5px;line-height:1.7">
+            ?s <span style="color:var(--avet)">:role</span> "admin" .<br>
+            ?s <span style="color:var(--aevt)">:score</span> ?n
+          </div>
+          <div class="pipe" style="justify-content:flex-start;margin-top:10px">
+            <div class="blk" style="min-width:auto"><span class="ty">triple1 → AVET</span><span class="cid">{e3,e7,e9…}</span></div>
+            <div style="font-size:20px;color:var(--ok);margin:0 8px">∩</div>
+            <div class="blk" style="min-width:auto"><span class="ty">triple2 → AEVT</span><span class="cid">{e1,e3,e9…}</span></div>
+            <div class="arrow" style="width:40px"><i class="pkt"></i></div>
+            <div class="blk" style="min-width:auto;border-color:var(--ok)"><span class="ty">HashSet 積</span><span class="cid" style="color:var(--ok)">{e3,e9}</span></div>
+          </div>
+          <p class="small" style="margin:8px 0 0">各 triple を最適索引で引いて subject 集合を作り、<b>HashSet で O(1) 交差</b>。線形スキャン無し（JOIN 223→73ms / 10K）。</p>
+        </div>
+        <div class="box" style="flex:1">
+          <b style="font-size:13px">対応する代数（algebra）</b>
+          <div class="small" style="margin-top:8px;line-height:1.9">
+            <span class="tag" style="color:var(--avet)">BGP</span> 三つ組結合<br>
+            <span class="tag">FILTER</span> 数値/文字列述語<br>
+            <span class="tag">UNION</span> 併合 + dedupe<br>
+            <span class="tag">OPTIONAL</span> 左外部結合<br>
+            <span class="tag">GROUP BY</span> COUNT/SUM/AVG…<br>
+            <span class="tag">DISTINCT</span> (s,p,o) で重複除去
+          </div>
+        </div>
+      </div>
+
+      <div class="box anim d5" style="margin-top:14px;border-color:#2b5a4a">
+        <b style="font-size:13px;color:var(--aevt)">繰り返しクエリは MaterializedView で“作り直さない”</b>
+        <div class="pipe" style="justify-content:flex-start;margin-top:8px">
+          <div class="blk" style="min-width:auto"><span class="ty">commit Δ</span><span class="cid">assert/retract</span></div>
+          <div class="arrow" style="width:36px"><i class="pkt"></i></div>
+          <div class="blk" style="min-width:auto"><span class="ty">program.evaluate_delta</span><span class="cid">Datalog rules</span></div>
+          <div class="arrow" style="width:36px"><i class="pkt"></i></div>
+          <div class="blk" style="min-width:auto;border-color:var(--aevt)"><span class="ty">MvRegistry.maintain</span><span class="cid" style="color:var(--aevt)">derived facts ⊕=</span></div>
+        </div>
+        <p class="small" style="margin:8px 0 0">commit ごとの差分だけをルールに流し、結果 Arrangement に畳み込む（mv.rs:7-93）。次回読取は再評価ゼロ。</p>
+      </div>
+    </section>
+
+    <!-- 2 MULTIHOP path/describe -->
+    <section class="scene" data-dur="15">
+      <span class="chip anim">② multihop — property path と N-hop DESCRIBE</span>
+      <h2 class="anim"><span class="mono" style="color:var(--avet)">&lt;pred&gt;+</span> は索引上の <span style="color:var(--avet)">BFS</span>（最大64ホップ）</h2>
+      <p class="sub anim d1">eval_property_path / sparql_describe_n_hop（quad_store.rs:1441〜,2200〜）</p>
+
+      <div class="row anim d2" style="margin-top:6px">
+        <div class="box" style="flex:1.2;position:relative;min-height:150px">
+          <div class="small">?x knows+ ?y を frontier 展開で辿る</div>
+          <div style="position:relative;height:120px;margin-top:6px">
+            <div class="gnode lit" style="left:8px;top:46px">x</div>
+            <div class="gnode h1" style="left:90px;top:14px">a</div>
+            <div class="gnode h1" style="left:90px;top:78px">b</div>
+            <div class="gnode h2" style="left:178px;top:46px">c</div>
+            <div class="gnode h3" style="left:266px;top:14px">d</div>
+            <div class="gnode h3" style="left:266px;top:78px">e</div>
+            <div class="gedge" style="left:38px;top:61px;width:58px;transform:rotate(-24deg)"></div>
+            <div class="gedge" style="left:38px;top:61px;width:58px;transform:rotate(24deg)"></div>
+            <div class="gedge" style="left:120px;top:29px;width:62px;transform:rotate(18deg)"></div>
+            <div class="gedge" style="left:120px;top:93px;width:62px;transform:rotate(-18deg)"></div>
+            <div class="gedge" style="left:208px;top:61px;width:62px;transform:rotate(-24deg)"></div>
+            <div class="gedge" style="left:208px;top:61px;width:62px;transform:rotate(24deg)"></div>
+          </div>
+          <p class="small" style="margin:0">各ラウンド AEVT スキャンで次フロンティアを得て、<span class="hl">(s,p,o)</span> を HashSet で dedupe。</p>
+        </div>
+        <div class="box" style="flex:1">
+          <b style="font-size:13px">path 演算子</b>
+          <div class="small" style="margin-top:8px;line-height:1.95">
+            <span class="mono" style="color:var(--avet)">p+</span> OneOrMore（BFS）<br>
+            <span class="mono" style="color:var(--avet)">p*</span> ZeroOrMore<br>
+            <span class="mono" style="color:var(--vaet)">^p</span> reverse（VAET 逆参照）<br>
+            <span class="mono">p1/p2</span> sequence（連結）
+          </div>
+          <div class="small" style="margin-top:10px;color:var(--ok)">MAX_HOPS = 64<br>N-hop DESCRIBE は層ごとに<br><b>try_join_all で並列 fetch</b>（438→149ms）</div>
+        </div>
+      </div>
+      <p class="sub anim d5" style="margin-top:12px">「友達の友達の…」も「参照を逆に辿る」も、結局 4 索引への BFS に落ちる。</p>
+    </section>
+
+    <!-- 3 PREGEL -->
+    <section class="scene" data-dur="15">
+      <span class="chip anim">③ multihop の重い計算 — Pregel BSP</span>
+      <h2 class="anim">頂点プログラム × <span style="color:var(--ipfs)">superstep</span> × メッセージ伝播</h2>
+      <p class="sub anim d1">kotoba-vm/src/pregel.rs ・ distributed.rs（libp2p gossip）</p>
+
+      <div class="row anim d2" style="margin-top:6px">
+        <div class="box" style="flex:1.1">
+          <div class="ladder">
+            <div class="step"><span class="pill" style="color:var(--ipfs)">superstep k</span> 各頂点が inbox を読む</div>
+            <div class="step"><span class="pill" style="color:var(--ipfs)">compute()</span> state 更新 → 隣へ Message 送信</div>
+            <div class="step"><span class="pill" style="color:var(--ipfs)">barrier</span> 全頂点同期（BSP）</div>
+            <div class="step"><span class="pill" style="color:var(--ok)">halt</span> active 頂点ゼロで終了</div>
+          </div>
+          <p class="small" style="margin:10px 0 0">Vertex{id,state,active} / Message{src,dst,payload=CBOR Delta}（pregel.rs:30-72）。PageRank・最短路・連結成分などをグラフ全体で。</p>
+        </div>
+        <div class="box" style="flex:1">
+          <b style="font-size:13px">分散 Pregel</b>
+          <div class="pipe" style="justify-content:flex-start;margin-top:8px">
+            <div class="blk" style="min-width:auto"><span class="ty">node A</span><span class="cid">頂点 1..n</span></div>
+            <div class="arrow" style="width:36px"><i class="pkt"></i></div>
+            <div class="blk" style="min-width:auto"><span class="ty">gossip</span><span class="cid">msg route</span></div>
+            <div class="arrow" style="width:36px"><i class="pkt"></i></div>
+            <div class="blk" style="min-width:auto"><span class="ty">node B</span><span class="cid">頂点 n+1..</span></div>
+          </div>
+          <p class="small" style="margin:10px 0 0">DistributedPregelRunner が node 跨ぎの Message を async channel + KotobaSwarm gossip でルーティング（QUIC/Noise/GossipSub）。</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- 4 FEDERATION -->
+    <section class="scene" data-dur="14">
+      <span class="chip anim">④ 大きいクエリ — federation で graph を跨ぐ</span>
+      <h2 class="anim"><span class="mono" style="color:var(--accent)">SERVICE &lt;cid:remote&gt;</span> / <span class="mono" style="color:var(--accent)">GRAPH ?g</span></h2>
+      <p class="sub anim d1">GraphPattern::Service / ::Graph（quad_store.rs:2062〜）</p>
+
+      <div class="row anim d2" style="margin-top:8px;align-items:center">
+        <div class="box" style="flex:1;text-align:center">
+          <b>local graph</b><div class="small" style="margin-top:6px">hot Arrangement<br>+ CommitDag head</div>
+        </div>
+        <div class="col" style="flex:1.3">
+          <div class="box" style="display:flex;align-items:center;gap:10px;border-color:#2b3f63">
+            <span class="mono" style="color:var(--accent)">SERVICE &lt;cid:mb&gt;</span>
+            <span class="small">→ multibase 解析 → KotobaCid</span>
+            <div class="arrow" style="width:36px;margin-left:auto"><i class="pkt"></i></div>
+          </div>
+          <div class="box" style="display:flex;align-items:center;gap:10px;border-color:#264">
+            <span class="mono" style="color:var(--ipfs)">DistributedBlockStore</span>
+            <span class="small">→ remote IPFS peer から block 取得</span>
+            <div class="arrow" style="width:36px;margin-left:auto"><i class="pkt"></i></div>
+          </div>
+          <div class="box" style="display:flex;align-items:center;gap:10px">
+            <span class="mono" style="color:var(--accent)">GRAPH ?g</span>
+            <span class="small">→ all_graph_cids() を fan-out 列挙</span>
+          </div>
+        </div>
+      </div>
+      <p class="sub anim d5" style="margin-top:14px">content-address された別グラフを、その CID を service IRI にして横断クエリ。<b>silent=true</b> なら未知サービスは無視。</p>
+    </section>
+
+    <!-- 5 WRITE / TRANSACT -->
+    <section class="scene" data-dur="16">
+      <span class="chip anim">⑤ 書き込み — transact は graph に縛られる</span>
+      <h2 class="anim">CACAO 検証 → <span class="mono" style="color:var(--accent)">assert_datom</span> → commit</h2>
+      <p class="sub anim d1">xrpc transact handler → quad_store.rs commit（:3071〜）</p>
+
+      <div class="pipe anim d2" style="justify-content:flex-start;margin-top:4px">
+        <div class="node" style="min-width:auto;padding:9px 11px"><div class="t" style="font-size:12px">① XRPC</div><div class="d">datomic.transact</div></div>
+        <div class="arrow"><i class="pkt"></i></div>
+        <div class="node" style="min-width:auto;padding:9px 11px;border-color:var(--auth)"><div class="t" style="font-size:12px">② CACAO検証</div><div class="d">datom:transact</div></div>
+        <div class="arrow"><i class="pkt"></i></div>
+        <div class="node" style="min-width:auto;padding:9px 11px"><div class="t" style="font-size:12px">③ graph束縛</div><div class="d">db/&lt;did&gt;/&lt;name&gt;</div></div>
+        <div class="arrow"><i class="pkt"></i></div>
+        <div class="node" style="min-width:auto;padding:9px 11px"><div class="t" style="font-size:12px">④ assert_datom</div><div class="d">pending</div></div>
+        <div class="arrow"><i class="pkt"></i></div>
+        <div class="node" style="min-width:auto;padding:9px 11px"><div class="t" style="font-size:12px">⑤ commit</div><div class="d">CommitDag head</div></div>
+      </div>
+
+      <div class="row anim d4" style="margin-top:16px">
+        <div class="box" style="flex:1;border-color:var(--auth)">
+          <b style="font-size:13px">edge が target graph を強制束縛</b>
+          <p class="small" style="margin:6px 0 0">書込先は呼び手自身の名前空間 <span class="hl mono">kotobase/db/&lt;tenant_did&gt;/&lt;db&gt;</span> に固定。client が <span class="mono">graph</span> を指定しても上書き不可 → <b>自分のDBにしか書けない</b>。</p>
+        </div>
+        <div class="box" style="flex:1.1">
+          <b style="font-size:13px">commit パイプライン</b>
+          <div class="small" style="margin-top:6px;line-height:1.8">
+            pending 収集 → 4索引 ProllyTree 並列ビルド →
+            tx_cid=blake3(datoms) → <span class="mono">DistributedDatomCommit</span>{index_roots, prev, author_sig} →
+            CAR 1束 PUT → CommitDag.add → <b>head-ref 原子更新</b>
+          </div>
+        </div>
+      </div>
+      <p class="sub anim d6" style="margin-top:10px">許可された operator DID だけは任意 graph に書ける。pod は JWT 署名を検証せず（edge が信頼境界）、CACAO は暗号検証する。</p>
+    </section>
+
+    <!-- 6 CACAO AUTH -->
+    <section class="scene" data-dur="17">
+      <span class="chip anim">⑥ CACAO 認証/認可 — 主権鍵のケイパビリティ</span>
+      <h2 class="anim"><span class="mono" style="color:var(--auth)">Cacao{h,p,s}</span> を5段で検証する</h2>
+      <p class="sub anim d1">kotoba-auth: cacao.rs / delegation.rs（verify）</p>
+
+      <div class="row anim d2" style="margin-top:4px">
+        <div class="box" style="flex:1.15">
+          <div class="ladder">
+            <div class="step"><span class="checkmk">1</span>時間: iat/exp（exp無しは <b>最大7日</b>）</div>
+            <div class="step"><span class="checkmk">2</span>能力: <span class="mono" style="color:var(--auth)">datom:read / datom:transact / kotobase:pin</span></div>
+            <div class="step"><span class="checkmk">3</span>graph scope: <span class="mono">kotoba://graph/&lt;cid&gt;</span> に含まれるか（multi-graph 可）</div>
+            <div class="step"><span class="checkmk">4</span>署名: <span class="mono">Ed25519(did:key)</span> または <span class="mono">EIP-191(secp256k1)</span></div>
+            <div class="step"><span class="checkmk">5</span>audience: <span class="mono">aud == node operator DID</span>（使い回し防止）+ nonce</div>
+          </div>
+        </div>
+        <div class="box" style="flex:1">
+          <b style="font-size:13px">depth-2 委譲チェーン</b>
+          <div class="pipe" style="flex-direction:column;align-items:stretch;gap:6px;margin-top:8px">
+            <div class="blk" style="min-width:auto;align-items:flex-start"><span class="ty">root grant</span><span class="cid">delegator → service</span></div>
+            <div style="text-align:center;color:var(--dim);font-size:11px">leaf.iss == root.aud で橋渡し ↓</div>
+            <div class="blk" style="min-width:auto;align-items:flex-start;border-color:var(--auth)"><span class="ty">leaf invocation</span><span class="cid">service → agent</span></div>
+          </div>
+          <p class="small" style="margin:8px 0 0"><b>減衰のみ</b>: leaf 能力 ⊆ root 能力、graph ⊆ root graph。depth-3+ は拒否。</p>
+        </div>
+      </div>
+      <div class="row anim d6" style="margin-top:12px">
+        <div class="box" style="flex:1;text-align:center;border-color:#3a2d63"><b style="color:var(--auth)">Private</b><div class="small">既定。CACAO + graph 一致が必須</div></div>
+        <div class="box" style="flex:1;text-align:center"><b>Authenticated</b><div class="small">Bearer 必要・scope は不問</div></div>
+        <div class="box" style="flex:1;text-align:center;border-color:#264"><b style="color:var(--ok)">Public</b><div class="small">認証不要で誰でも読める</div></div>
+      </div>
+    </section>
+
+    <!-- 7 SIGNAL E2E -->
+    <section class="scene" data-dur="17">
+      <span class="chip anim">⑦ Signal E2E — X3DH → Double Ratchet</span>
+      <h2 class="anim">鍵共有 → <span style="color:var(--sig)">メッセージごとに鍵が前進</span></h2>
+      <p class="sub anim d1">kotoba-signal: x3dh.rs / ratchet.rs ・ kotoba-crypto: AES-256-GCM</p>
+
+      <div class="row anim d2" style="margin-top:4px">
+        <div class="box" style="flex:1">
+          <b style="font-size:13px;color:var(--sig)">X3DH 初期鍵共有</b>
+          <div class="mono small" style="margin-top:8px;line-height:1.8;color:var(--ink)">
+            DH1=ECDH(IK_A, SPK_B)<br>
+            DH2=ECDH(EK_A, IK_B)<br>
+            DH3=ECDH(EK_A, SPK_B)<br>
+            DH4=ECDH(EK_A, OPK_B) <span class="small">任意</span><br>
+            <span class="hl">SS = HKDF(DH1‖DH2‖DH3‖DH4)</span>
+          </div>
+          <p class="small" style="margin:8px 0 0">送受信の双方が同じ shared secret を導出。SPK 署名は IK で検証、OPK は使い捨て。</p>
+        </div>
+        <div class="box" style="flex:1.15">
+          <b style="font-size:13px;color:var(--sig)">Double Ratchet（前方秘匿）</b>
+          <div class="pipe" style="justify-content:flex-start;margin-top:8px">
+            <div class="blk" style="min-width:auto"><span class="ty">root key</span><span class="cid">DH rotation</span></div>
+            <div class="arrow" style="width:30px"><i class="pkt"></i></div>
+            <div class="blk" style="min-width:auto"><span class="ty">chain key</span><span class="cid">KDF 連鎖</span></div>
+            <div class="arrow" style="width:30px"><i class="pkt"></i></div>
+            <div class="blk" style="min-width:auto;border-color:var(--sig)"><span class="ty">message key</span><span class="cid" style="color:var(--sig)">毎回使い捨て</span></div>
+          </div>
+          <p class="small" style="margin:8px 0 0">各メッセージ <span class="mono">mk</span> で <b>AES-256-GCM</b> 暗号化。使用後 mk は zero化、順序ズレは MKSKIPPED にキャッシュ（MAX_SKIP=1000）。鍵漏洩しても過去/未来は守られる。</p>
+        </div>
+      </div>
+      <div class="box anim d6" style="margin-top:12px;border-color:#2b5a52">
+        <b style="font-size:13px;color:var(--sig)">暗号化 datom（Enveloped value）</b>
+        <span class="small" style="margin-left:8px">値を <span class="mono" style="color:var(--sig)">"signal:v1:{base64url}"</span> で包んで格納（keycodec の Encrypted/Enveloped tag）。<b>暗号文のまま複製</b>、復号は subject==self か許可された agent だけ。</span>
+      </div>
+    </section>
+
+    <!-- 8 X-ROAD ACCOUNTABILITY -->
+    <section class="scene" data-dur="16">
+      <span class="chip anim">⑧ X-Road 流アカウンタビリティ — 説明可能な秘匿</span>
+      <h2 class="anim">暗号文複製 ＋ <span style="color:var(--ok)">レシート</span> ＋ <span style="color:var(--auth)">t-of-N 鍵分散</span></h2>
+      <p class="sub anim d1">docs/SECURITY-ARCHITECTURE.md（R0–R3）・kotoba-custody</p>
+
+      <div class="grid4 anim d2" style="margin-top:6px">
+        <div class="idx" style="border-color:#2b5a52"><div class="n" style="color:var(--sig)">R0</div><div class="u">暗号文のみ複製<br>sealed_cid 再計算可</div></div>
+        <div class="idx" style="border-color:#264"><div class="n" style="color:var(--ok)">R1</div><div class="u">全読取で access datom<br>(who/purpose/ts)</div></div>
+        <div class="idx" style="border-color:#3a3a5a"><div class="n">R2</div><div class="u">Base L2 anchor<br>署名 CommitDag</div></div>
+        <div class="idx" style="border-color:#3a2d63"><div class="n" style="color:var(--auth)">R3</div><div class="u">Shamir t-of-N<br>custody</div></div>
+      </div>
+
+      <div class="box anim d4" style="margin-top:14px">
+        <b style="font-size:13px">鍵リリースは「レシートを書いてから」</b>
+        <div class="pipe" style="justify-content:flex-start;margin-top:8px">
+          <div class="blk" style="min-width:auto"><span class="ty">agent</span><span class="cid">key.requestShare</span></div>
+          <div class="arrow" style="width:34px"><i class="pkt"></i></div>
+          <div class="blk" style="min-width:auto;border-color:var(--auth)"><span class="ty">custodian 検証</span><span class="cid">CACAO+purpose+nonce</span></div>
+          <div class="arrow" style="width:34px"><i class="pkt"></i></div>
+          <div class="blk" style="min-width:auto;border-color:var(--ok)"><span class="ty">レシート記帳→</span><span class="cid" style="color:var(--ok)">HPKE share 解放</span></div>
+          <div class="arrow" style="width:34px"><i class="pkt"></i></div>
+          <div class="blk" style="min-width:auto"><span class="ty">client</span><span class="cid">t 個で復元</span></div>
+        </div>
+        <p class="small" style="margin:8px 0 0"><span class="xmk">⚠</span>レシート無しの解放は検知され、custodian は<b>証明可能に有責（slashable）</b>。epoch/deal_id 混在の定足数は拒否。</p>
+      </div>
+    </section>
+
+    <!-- 9 SUMMARY -->
+    <section class="scene" data-dur="16">
+      <span class="chip anim">まとめ — Part 2</span>
+      <h2 class="anim">重いことは全部「索引 / BSP / CID / 鍵」に落ちる</h2>
+      <div class="anim d2 endlist" style="margin-top:8px">
+        <div><span class="checkmk">①</span><b>複雑query</b>: BGP は subject 集合の HashSet 積、FILTER/UNION/OPTIONAL/GROUP。繰返しは <code>MaterializedView</code> が Δ 増分維持。</div>
+        <div><span class="checkmk">②</span><b>multihop</b>: property path <code>p+ / p* / ^p</code> は索引上 BFS（≤64hop）、N-hop DESCRIBE は層ごと並列 fetch。</div>
+        <div><span class="checkmk">③</span><b>重い計算</b>: <code>Pregel BSP</code>（superstep+message+barrier）、分散は libp2p gossip でルーティング。</div>
+        <div><span class="checkmk">④</span><b>federation</b>: <code>SERVICE &lt;cid:remote&gt;</code> / <code>GRAPH ?g</code> で content-address グラフを横断。</div>
+        <div><span class="checkmk">⑤</span><b>書込</b>: edge が <code>db/&lt;did&gt;/&lt;name&gt;</code> に束縛 → 自分のDBのみ。commit→CommitDag head 原子更新。</div>
+        <div><span class="checkmk">⑥</span><b>CACAO</b>: 時間/能力/scope/署名/audience の5段、depth-2 減衰委譲、Private/Authenticated/Public。</div>
+        <div><span class="checkmk">⑦⑧</span><b>Signal</b>: X3DH→Double Ratchet で毎メッセージ鍵前進・AES-256-GCM。暗号文複製＋レシート＋<code>t-of-N</code> custody で“説明可能な秘匿”。</div>
+      </div>
+      <p class="sub anim d6" style="margin-top:12px">主要コード: <span class="mono">quad_store.rs / mv.rs / pregel.rs / delegation.rs / x3dh.rs / ratchet.rs / shares.rs</span></p>
+      <a class="cred" href="#">net-kotobase/docs/explainer</a>
+    </section>
+
+    <div class="caption"><div class="bubble" id="cap">…</div></div>
+
+    <div class="controls">
+      <button class="play" id="play">⏸ 一時停止</button>
+      <button id="prev">◀ 前</button>
+      <button id="next">次 ▶</button>
+      <button id="replay">↺</button>
+      <div class="progress" id="bar"><div class="fill" id="fill"></div></div>
+      <span class="spd" id="spd">1.0×</span>
+      <button id="speed">速度</button>
+      <span class="counter" id="counter">0 / 0</span>
+    </div>
+  </div>
+</div>
+
+<script>
+(function(){
+  const scenes = Array.from(document.querySelectorAll('.scene'));
+  const caps = [
+    "Part 2 です。大規模で複雑なクエリ、multihop の探索、書き込み、CACAO による認可、そして Signal による E2E 秘匿を見ていきます。",
+    "複雑なクエリも核は単純。BGP は各三つ組を最適索引で引いて <b>subject 集合を HashSet で交差</b>するだけ。繰り返すクエリは <span class='k'>MaterializedView</span> が commit の差分だけを増分維持し、作り直しません。",
+    "multihop。<span class='k'>knows+</span> のような property path は索引上の <b>BFS</b>（最大64ホップ）。逆参照は VAET、N-hop DESCRIBE は層ごとに並列 fetch します。",
+    "もっと重いグラフ計算は <b>Pregel の BSP</b>。superstep ごとに各頂点が計算してメッセージを送り、バリアで同期。ノードを跨ぐ時は libp2p の gossip で配送します。",
+    "大きなクエリはグラフを跨ぎます。<span class='k'>SERVICE &lt;cid:remote&gt;</span> や <span class='k'>GRAPH ?g</span> で、CID で指した別グラフを横断し、無ければ remote IPFS peer から block を取ってきます。",
+    "書き込み。transact はまず CACAO を検証し、書込先を <b>呼び手自身の db/&lt;did&gt;/&lt;name&gt;</b> に強制束縛。だから他人のDBには書けません。あとは commit して CommitDag の head を原子的に更新します。",
+    "認可の中心が CACAO。<b>時間・能力・graph scope・署名・audience</b> の5段で検証し、委譲は depth-2 まで・能力は減衰のみ。グラフは Private / Authenticated / Public で見え方が決まります。",
+    "秘匿は Signal。<span class='k'>X3DH</span> で双方が同じ鍵を導出し、<b>Double Ratchet</b> でメッセージごとに鍵が前進。各メッセージは AES-256-GCM で暗号化、値は signal:v1: で包んで暗号文のまま保存します。",
+    "それでも“説明可能”に。暗号文のまま複製し、<b>全読取はレシート</b>として記帳、L2 にアンカー。鍵は <b>t-of-N に分散</b>し、custodian はレシートを書いてから解放。無記帳の解放は検知され有責です。",
+    "まとめ。複雑なクエリも multihop も重い計算も認可も秘匿も、結局は『索引・BSP・CID・鍵』という同じ部品の組み合わせに落ちています。"
+  ];
+  let i=0, playing=true, t0=0, raf=null, elapsed=0, speed=1;
+  const fill=document.getElementById('fill'), counter=document.getElementById('counter'),
+        cap=document.getElementById('cap'), playBtn=document.getElementById('play'), spd=document.getElementById('spd');
+  const bar=document.getElementById('bar');
+  scenes.forEach((s,k)=>{ if(k>0){const seg=document.createElement('div');seg.className='seg';seg.style.left=(k/scenes.length*100)+'%';bar.appendChild(seg);} });
+  function durOf(k){ return (parseFloat(scenes[k].dataset.dur)||10)*1000/speed; }
+  function show(k,resetTime){
+    i=(k+scenes.length)%scenes.length;
+    scenes.forEach(s=>s.classList.remove('active'));
+    const s=scenes[i]; void s.offsetWidth; s.classList.add('active');
+    cap.innerHTML=caps[i]||''; counter.textContent=(i+1)+' / '+scenes.length;
+    if(resetTime!==false){ elapsed=0; t0=performance.now(); }
+  }
+  function tick(now){
+    if(!playing) return;
+    const dur=durOf(i), e=elapsed+(now-t0), p=Math.min(1,e/dur);
+    fill.style.width=((i+p)/scenes.length*100)+'%';
+    if(p>=1){ if(i<scenes.length-1){ show(i+1); } else { playing=false; playBtn.textContent='↺ もう一度'; fill.style.width='100%'; return; } }
+    raf=requestAnimationFrame(tick);
+  }
+  function start(){ playing=true; playBtn.textContent='⏸ 一時停止'; t0=performance.now(); cancelAnimationFrame(raf); raf=requestAnimationFrame(tick); }
+  function pause(){ playing=false; playBtn.textContent='▶ 再生'; elapsed+=performance.now()-t0; cancelAnimationFrame(raf); }
+  playBtn.onclick=()=>{ if(playBtn.textContent.indexOf('もう一度')>=0){ show(0); start(); return; } playing?pause():start(); };
+  document.getElementById('next').onclick=()=>{ show(i+1); start(); };
+  document.getElementById('prev').onclick=()=>{ show(i-1); start(); };
+  document.getElementById('replay').onclick=()=>{ show(0); start(); };
+  document.getElementById('speed').onclick=()=>{ speed=speed>=2?0.5:speed+0.5; spd.textContent=speed.toFixed(1)+'×'; };
+  bar.onclick=(ev)=>{ const r=bar.getBoundingClientRect(); show(Math.floor((ev.clientX-r.left)/r.width*scenes.length)); start(); };
+  document.addEventListener('keydown',e=>{ if(e.key===' '){e.preventDefault();playBtn.onclick();} if(e.key==='ArrowRight'){show(i+1);start();} if(e.key==='ArrowLeft'){show(i-1);start();} });
+  show(0); start();
+})();
+</script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,283 @@
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>kotoba — Content-Addressed Distributed Datalog Database</title>
+<meta name="description" content="kotoba: Datomic-style immutable datoms × Prolly Tree × IPFS/IPLD × CACAO auth × Signal E2E. Interactive explainers and design docs." />
+<style>
+  :root{
+    --bg:#0b0f1a; --bg2:#0f1626; --ink:#e8eefc; --dim:#9fb0d0; --line:#26344f;
+    --eavt:#5fd0ff; --aevt:#7af0c0; --avet:#ffd166; --vaet:#ff7eb6;
+    --cid:#b78cff; --ipfs:#65c7ff; --auth:#9d7bff; --sig:#54e0c9; --ok:#62e08a;
+    --card:#121b2e; --accent:#7aa2ff;
+    --mono:"SFMono-Regular",ui-monospace,Menlo,Consolas,monospace;
+    --sans:system-ui,-apple-system,"Hiragino Kaku Gothic ProN","Noto Sans JP",sans-serif;
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:radial-gradient(1200px 700px at 75% -10%,#16213b 0%,var(--bg) 55%) no-repeat,var(--bg);
+    color:var(--ink);font-family:var(--sans);-webkit-font-smoothing:antialiased;line-height:1.6}
+  a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}
+  .wrap{max-width:1060px;margin:0 auto;padding:0 22px}
+  code,.mono{font-family:var(--mono)}
+
+  /* nav */
+  nav{position:sticky;top:0;z-index:20;backdrop-filter:blur(10px);
+    background:rgba(10,15,28,.72);border-bottom:1px solid var(--line)}
+  nav .wrap{display:flex;align-items:center;gap:18px;height:54px;font-size:14px}
+  nav b{font-weight:700;letter-spacing:.02em}
+  nav .links{display:flex;gap:16px;margin-left:auto;flex-wrap:wrap}
+  nav .links a{color:var(--dim)}nav .links a:hover{color:var(--ink);text-decoration:none}
+
+  /* hero */
+  header{padding:64px 0 34px;text-align:center}
+  header .badge{display:inline-block;font-family:var(--mono);font-size:11px;color:var(--accent);
+    border:1px solid var(--line);border-radius:999px;padding:4px 12px;margin-bottom:18px}
+  header h1{font-size:46px;margin:.1em 0 .15em;letter-spacing:.01em}
+  header .lead{font-size:18px;color:var(--dim);max-width:680px;margin:0 auto}
+  .def{display:inline-block;margin:22px auto 0;font-family:var(--mono);font-size:13px;color:var(--ink);
+    background:#0e1626;border:1px solid var(--line);border-radius:12px;padding:14px 18px;text-align:left;
+    white-space:pre;overflow-x:auto;max-width:100%}
+  .cta{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;margin-top:26px}
+  .btn{display:inline-flex;align-items:center;gap:8px;border:1px solid var(--line);border-radius:11px;
+    padding:11px 18px;font-size:14px;font-weight:600;background:#16213a;color:var(--ink)}
+  .btn:hover{background:#1d2c4d;border-color:#3a4f7a;text-decoration:none}
+  .btn.primary{background:linear-gradient(180deg,#2a52d8,#2142b8);border-color:#3a5cc0}
+
+  section{padding:40px 0;border-top:1px solid var(--line)}
+  h2{font-size:27px;margin:0 0 6px}
+  h2 .num{font-family:var(--mono);font-size:15px;color:var(--accent);margin-right:10px}
+  .sub{color:var(--dim);margin:0 0 22px;font-size:15px}
+
+  /* explainer cards */
+  .vids{display:grid;grid-template-columns:1fr;gap:26px}
+  .vid{background:var(--card);border:1px solid var(--line);border-radius:16px;overflow:hidden}
+  .vid .meta{padding:16px 18px;display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+  .vid .meta .t{font-size:17px;font-weight:700}
+  .vid .meta .d{color:var(--dim);font-size:13.5px;flex:1;min-width:220px}
+  .vid .meta .chip{font-family:var(--mono);font-size:11px;border:1px solid var(--line);border-radius:6px;padding:2px 8px;color:var(--accent)}
+  .vid .frame{position:relative;width:100%;aspect-ratio:16/9;border-top:1px solid var(--line);background:#0a1120}
+  .vid iframe{position:absolute;inset:0;width:100%;height:100%;border:0}
+  .vid .open{padding:10px 18px 16px;font-size:13px}
+
+  /* spine diagram */
+  .spine{display:flex;align-items:center;justify-content:center;gap:0;flex-wrap:wrap;margin:8px 0 20px}
+  .snode{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:12px 16px;text-align:center;min-width:120px}
+  .snode .t{font-weight:700}.snode .d{font-size:11px;color:var(--dim);font-family:var(--mono);margin-top:3px}
+  .sarrow{color:#3a5a93;font-size:22px;margin:0 8px}
+  .note{color:var(--dim);font-size:13px}
+
+  .grid2{display:grid;grid-template-columns:1fr 1fr;gap:18px}
+  .panel{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:18px}
+  .panel h3{margin:0 0 8px;font-size:16px}
+  .panel p{margin:0;color:var(--dim);font-size:14px}
+  .panel ul{margin:8px 0 0;padding-left:18px;color:var(--dim);font-size:14px}
+  .panel li{margin:3px 0}
+
+  table{width:100%;border-collapse:collapse;font-size:13.5px;margin-top:8px;display:block;overflow-x:auto}
+  th,td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line);white-space:nowrap}
+  th{color:var(--dim);font-weight:600}
+  td .mono{color:var(--ink)}
+  td.role{white-space:normal;color:var(--dim)}
+
+  .perf{display:grid;grid-template-columns:repeat(4,1fr);gap:14px}
+  .stat{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:16px;text-align:center}
+  .stat .n{font-size:24px;font-weight:800;color:var(--ipfs)}
+  .stat .l{font-size:12px;color:var(--dim);margin-top:4px}
+
+  .idxgrid{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+  .doclink{display:flex;gap:12px;align-items:flex-start;background:var(--card);border:1px solid var(--line);
+    border-radius:12px;padding:14px 16px}
+  .doclink .k{font-family:var(--mono);font-size:11px;color:var(--accent);border:1px solid var(--line);border-radius:6px;padding:2px 7px;margin-top:2px}
+  .doclink .body{font-size:14px}.doclink .body .d{color:var(--dim);font-size:13px}
+
+  footer{padding:40px 0 64px;color:var(--dim);font-size:13px;border-top:1px solid var(--line)}
+  footer .mono{color:#6f84ad}
+
+  @media(max-width:760px){
+    header h1{font-size:34px}
+    .grid2,.idxgrid{grid-template-columns:1fr}
+    .perf{grid-template-columns:1fr 1fr}
+  }
+</style>
+</head>
+<body>
+<nav><div class="wrap">
+  <b>kotoba</b>
+  <span class="links">
+    <a href="#explainers">Explainers</a>
+    <a href="#architecture">Architecture</a>
+    <a href="#crates">Crates</a>
+    <a href="#security">Security</a>
+    <a href="#performance">Performance</a>
+    <a href="#docs">Docs / ADR</a>
+    <a href="https://github.com/com-junkawasaki/kotoba">GitHub ↗</a>
+  </span>
+</div></nav>
+
+<header><div class="wrap">
+  <div class="badge">CONTENT-ADDRESSED DISTRIBUTED DATALOG DATABASE</div>
+  <h1>kotoba</h1>
+  <p class="lead">Datomic 流の不変 datom を、<b style="color:var(--avet)">Prolly Tree</b> ×
+    <b style="color:var(--ipfs)">IPFS / IPLD</b> 上で索引し、<b style="color:var(--auth)">CACAO</b> 認可と
+    <b style="color:var(--sig)">Signal</b> E2E で守る、分散ナレッジグラフDB。</p>
+  <div class="def">KOTOBA ≝ Datom[CID/T] × EAVT[KSE Topic] × Pregel[BSP] × Datalog[Δ]
+        × CACAO × AT Protocol × LLM/Weight × WASM/WIT</div>
+  <div class="cta">
+    <a class="btn primary" href="#explainers">📺 説明動画を見る</a>
+    <a class="btn" href="explainer/kotoba-datomic-ipfs-explainer.html">Part 1: Datomic × IPFS × Prolly</a>
+    <a class="btn" href="explainer/kotoba-query-auth-signal-explainer.html">Part 2: Query / CACAO / Signal</a>
+  </div>
+</div></header>
+
+<!-- EXPLAINERS -->
+<section id="explainers"><div class="wrap">
+  <h2><span class="num">▶</span>説明動画（インタラクティブ）</h2>
+  <p class="sub">自動再生・日本語ナレーション字幕つき。各カード内で再生でき、全画面リンクからも開けます。コードを <code>file:line</code> まで裏取りした内容です。</p>
+
+  <div class="vids">
+    <div class="vid">
+      <div class="meta">
+        <span class="chip">PART 1</span>
+        <span class="t">Datomic query × IPFS / IPLD / Prolly Tree</span>
+        <span class="d">書込で Datom(E,A,V,T,Added) を積み、commit で 4 索引の Prolly Tree を作り、DAG-CBOR→CID で content-address、IPFS/B2 へ export。クエリは scan_prefix で索引を辿る。</span>
+      </div>
+      <div class="frame"><iframe src="explainer/kotoba-datomic-ipfs-explainer.html" title="kotoba explainer part 1" loading="lazy"></iframe></div>
+      <div class="open">▸ <a href="explainer/kotoba-datomic-ipfs-explainer.html" target="_blank" rel="noopener">全画面で開く</a></div>
+    </div>
+
+    <div class="vid">
+      <div class="meta">
+        <span class="chip">PART 2</span>
+        <span class="t">大規模クエリ・multihop・書込・CACAO・Signal</span>
+        <span class="d">BGP join / MaterializedView、property path BFS と Pregel BSP、SERVICE federation、transact の graph 束縛、CACAO の5段検証と depth-2 委譲、X3DH→Double Ratchet と t-of-N custody。</span>
+      </div>
+      <div class="frame"><iframe src="explainer/kotoba-query-auth-signal-explainer.html" title="kotoba explainer part 2" loading="lazy"></iframe></div>
+      <div class="open">▸ <a href="explainer/kotoba-query-auth-signal-explainer.html" target="_blank" rel="noopener">全画面で開く</a></div>
+    </div>
+  </div>
+</div></section>
+
+<!-- ARCHITECTURE -->
+<section id="architecture"><div class="wrap">
+  <h2><span class="num">①</span>アーキテクチャ — canonical spine</h2>
+  <p class="sub">正本は1本の content-addressed チェーン。IPFS と B2 は system of record ではなく <b>export tier</b>。</p>
+
+  <div class="spine">
+    <div class="snode"><div class="t">Datom log</div><div class="d">(E,A,V,T,Added)</div></div>
+    <span class="sarrow">→</span>
+    <div class="snode"><div class="t">ProllyTree</div><div class="d">EAVT/AEVT/AVET/VAET</div></div>
+    <span class="sarrow">→</span>
+    <div class="snode"><div class="t">CommitDag</div><div class="d">= WAL</div></div>
+    <span class="sarrow">→</span>
+    <div class="snode"><div class="t">blocks</div><div class="d">DAG-CBOR / CIDv1</div></div>
+  </div>
+
+  <div class="grid2">
+    <div class="panel">
+      <h3>① 書込</h3>
+      <p><code>QuadStore::assert_datom</code> が 5-tuple を pending に積み、<code>commit()</code> が 4 索引の Prolly Tree を並列ビルド（<code>blake3(key)&amp;0xFF==0</code> 境界 + path-copy）。CARv1 1束で単一 PUT、<code>Commit{index_roots,prev,seq}</code> を CommitDag に append。</p>
+    </div>
+    <div class="panel">
+      <h3>② クエリ</h3>
+      <p>4 索引が tier-1。BGP は直接索引スキャン（EAVT 点引き ~180ns）、繰返しは <code>MaterializedView</code> が commit Δ を増分維持。SPARQL は同じ projection 上の補助 RDF 面。<code>as-of</code> は TEA で時間遡行。</p>
+    </div>
+    <div class="panel">
+      <h3>③ ブロックストア</h3>
+      <p>kotoba 自身が IPFS block store 兼 pinner（pin/add RPC 不要 → ~35× ingest）。封印 commit を <b>Kubo IPFS</b> と <b>B2 (CAR)</b> へ非同期 export。</p>
+    </div>
+    <div class="panel">
+      <h3>④ アンカー</h3>
+      <p>Datom log が canonical state。<b>IPNS</b> 署名ヘッドが per-graph root を固定、<b>Base L2</b> が CommitDag root を tamper-evidence、AT-Proto MST は ingress/interop。</p>
+    </div>
+  </div>
+
+  <p class="note" style="margin-top:18px">図版: <a href="kotoba-datomic-architecture.svg">kotoba-datomic-architecture.svg</a> ／ <a href="kotoba-canonical-vs-optimization.svg">canonical-vs-optimization.svg</a></p>
+</div></section>
+
+<!-- CRATES -->
+<section id="crates"><div class="wrap">
+  <h2><span class="num">②</span>Crates</h2>
+  <p class="sub">ワークスペース構成（主要クレート）。</p>
+  <table>
+    <tr><th>crate</th><th>役割</th></tr>
+    <tr><td><span class="mono">kotoba-core</span></td><td class="role">CIDv1 dag-cbor sha2-256, KAIS 8-bit frame, Prolly Tree</td></tr>
+    <tr><td><span class="mono">kotoba-query</span></td><td class="role">Datalog engine, Arrangement (EAVT/AEVT/AVET/VAET), Delta, MaterializedView</td></tr>
+    <tr><td><span class="mono">kotoba-graph</span></td><td class="role">Datom projection, SPARQL 1.1 (BGP/Filter/Union/Optional/Path/Service/…), Datalog cold, CID-MV cache, CommitDag, N-hop DESCRIBE</td></tr>
+    <tr><td><span class="mono">kotoba-auth</span></td><td class="role">CACAO chain (depth-2), multi-graph grants, EdDSA / EIP-191, did:key, EVM/BTC read+verify</td></tr>
+    <tr><td><span class="mono">kotoba-signal</span></td><td class="role">Signal Protocol (X3DH + Double Ratchet + MLS)</td></tr>
+    <tr><td><span class="mono">kotoba-crypto</span></td><td class="role">AEAD (AES-256-GCM), HKDF, key wrap</td></tr>
+    <tr><td><span class="mono">kotoba-custody</span></td><td class="role">t-of-N Shamir custody of the block key (HPKE per-custodian wrap)</td></tr>
+    <tr><td><span class="mono">kotoba-vm</span></td><td class="role">KVM — Invoke/Result ChainEntry, CALL_FOREIGN, Pregel BSP hosts</td></tr>
+    <tr><td><span class="mono">kotoba-store</span></td><td class="role">BlockStore: Memory / Kubo HTTP / Budgeted LRU / Tiered / Distributed / Sealed</td></tr>
+    <tr><td><span class="mono">kotoba-net</span></td><td class="role">libp2p QUIC / Noise / GossipSub</td></tr>
+    <tr><td><span class="mono">kotoba-runtime</span></td><td class="role">WASM Component Model host: WasmExecutor + UdfExecutor + WIT bindings</td></tr>
+    <tr><td><span class="mono">kotoba-server</span></td><td class="role">XRPC / MCP endpoints (kg.ingest / kg.query / graph.sparql / datomic.*)</td></tr>
+    <tr><td><span class="mono">kotoba-cli</span></td><td class="role"><code>kotoba</code> binary (init, serve, demo, bench, sparql, …)</td></tr>
+  </table>
+  <p class="note" style="margin-top:10px">全クレートと詳細は <a href="https://github.com/com-junkawasaki/kotoba#crates">README / CLAUDE.md</a> を参照。</p>
+</div></section>
+
+<!-- SECURITY -->
+<section id="security"><div class="wrap">
+  <h2><span class="num">③</span>Security — 説明可能な秘匿</h2>
+  <p class="sub">主権鍵 × ケイパビリティ × E2E 暗号 × X-Road 流アカウンタビリティ。</p>
+  <div class="grid2">
+    <div class="panel">
+      <h3 style="color:var(--auth)">CACAO 認可</h3>
+      <ul>
+        <li>5段検証: 時間 / 能力 / graph scope / 署名 / audience + nonce</li>
+        <li>能力: <code>datom:read</code> / <code>datom:transact</code> / <code>kotobase:pin</code></li>
+        <li>depth-2 委譲（減衰のみ）・multi-graph grant</li>
+        <li>可視性: Private / Authenticated / Public</li>
+      </ul>
+    </div>
+    <div class="panel">
+      <h3 style="color:var(--sig)">Signal E2E + custody</h3>
+      <ul>
+        <li>X3DH 鍵共有 → Double Ratchet（毎メッセージ鍵前進）</li>
+        <li>AES-256-GCM、値は <code>signal:v1:</code> Enveloped datom</li>
+        <li>暗号文のみ複製 + アクセスレシート + Base L2 anchor</li>
+        <li>block key を t-of-N Shamir 分散（無記帳解放は slashable）</li>
+      </ul>
+    </div>
+  </div>
+  <p class="note" style="margin-top:16px">詳細: <a href="SECURITY-ARCHITECTURE.md">SECURITY-ARCHITECTURE.md</a>（R0–R3 脅威モデルと層）／ <a href="ADR-sealed-cold-tier.md">ADR-sealed-cold-tier</a></p>
+</div></section>
+
+<!-- PERFORMANCE -->
+<section id="performance"><div class="wrap">
+  <h2><span class="num">④</span>Performance（抜粋・M4 Mac, release）</h2>
+  <p class="sub">完全な計測マトリクスは README / CLAUDE.md に収録。</p>
+  <div class="perf">
+    <div class="stat"><div class="n">~180 ns</div><div class="l">EAVT 点引き (hot)</div></div>
+    <div class="stat"><div class="n">5222 /s</div><div class="l">kg.ingest_batch 持続</div></div>
+    <div class="stat"><div class="n">12.8K QPS</div><div class="l">CACAO-gated c=32</div></div>
+    <div class="stat"><div class="n">~3.5 ms</div><div class="l">cold Prolly (kubo LAN)</div></div>
+  </div>
+</div></section>
+
+<!-- DOCS / ADR -->
+<section id="docs"><div class="wrap">
+  <h2><span class="num">⑤</span>Docs / ADR 索引</h2>
+  <p class="sub">設計判断はリポジトリの <code>docs/</code> に格納。</p>
+  <div class="idxgrid">
+    <a class="doclink" href="SECURITY-ARCHITECTURE.md"><span class="k">SEC</span><span class="body">SECURITY-ARCHITECTURE<div class="d">X-Road 流アカウンタビリティ・R0–R3 custody</div></span></a>
+    <a class="doclink" href="ADR-001-five-axis-distributed-redesign.md"><span class="k">ADR</span><span class="body">five-axis distributed redesign<div class="d">分散再設計の5軸</div></span></a>
+    <a class="doclink" href="ADR-sealed-cold-tier.md"><span class="k">ADR</span><span class="body">sealed cold tier<div class="d">暗号化 cold tier・t-of-N custody</div></span></a>
+    <a class="doclink" href="ADR-clojure-wasm.md"><span class="k">ADR</span><span class="body">clojure → wasm<div class="d">Clojure/EDN-subset コンパイラ</div></span></a>
+    <a class="doclink" href="ADR-browser-cid-query-vs-p2p.md"><span class="k">ADR</span><span class="body">browser CID query vs p2p<div class="d">ブラウザ実行境界</div></span></a>
+    <a class="doclink" href="ADR-turn-relay.md"><span class="k">ADR</span><span class="body">TURN relay<div class="d">WebRTC 到達性</div></span></a>
+    <a class="doclink" href="ADR-kotoba-word.md"><span class="k">ADR</span><span class="body">kotoba word / root<div class="d">word registry・cap 境界</div></span></a>
+    <a class="doclink" href="WASI-HTTP-EGRESS-XRPC-INGRESS.md"><span class="k">DOC</span><span class="body">WASI HTTP egress / XRPC ingress<div class="d">I/O 境界</div></span></a>
+  </div>
+</div></section>
+
+<footer><div class="wrap">
+  <div><b>kotoba</b> — Content-Addressed Distributed Datalog Database</div>
+  <div class="mono" style="margin-top:6px">Apache-2.0 + etzhayyim Charter Compliance Rider v2.0 ｜ <a href="https://github.com/com-junkawasaki/kotoba">github.com/com-junkawasaki/kotoba</a></div>
+  <div style="margin-top:6px">説明動画は実コード（<span class="mono">prolly.rs / arrangement.rs / cacao.rs / delegation.rs / x3dh.rs / ratchet.rs / shares.rs</span>）を裏取りして作成。</div>
+</div></footer>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds a self-contained **static docs site** under `docs/` and publishes it via **GitHub Pages**.

### Files
- **`docs/index.html`** — docs-site landing hub: overview, architecture (canonical spine), crates, security (CACAO / Signal / custody), performance highlights, and an ADR index. Dark theme matching the explainers.
- **`docs/explainer/kotoba-datomic-ipfs-explainer.html`** — *Part 1* interactive explainer (auto-play, JP narration): how a Datomic query runs over a Prolly-Tree index that is DAG-CBOR/IPLD content-addressed and pinned to IPFS. Write → 4-index build → CID → CommitDag → `scan_prefix` query → result provenance CID.
- **`docs/explainer/kotoba-query-auth-signal-explainer.html`** — *Part 2*: complex/large queries (BGP join, MaterializedView), multihop (property paths, Pregel BSP), `SERVICE` federation, the transact write path, CACAO auth/authz (depth-2 delegation, 5-stage verify), and Signal E2E (X3DH → Double Ratchet) + t-of-N custody.
- **`.github/workflows/pages.yml`** — deploys `docs/` to GitHub Pages (no Jekyll).
- **`README.md`** — adds an "Explainers & Docs site" callout + a Documentation index section.

Once merged → site at **https://com-junkawasaki.github.io/kotoba/**

## Grounding
Every claim in the explainers is grounded in the actual source: `prolly.rs`, `arrangement.rs`, `cacao.rs`, `delegation.rs`, `x3dh.rs`, `ratchet.rs`, `shares.rs`, `quad_store.rs`, `mv.rs`, `pregel.rs`.

## Notes
- Docs-only change — no crate/source code touched. Unrelated local WIP was deliberately excluded from this branch.
- **After merge**, if the first Pages deploy needs it, set **Settings → Pages → Source: GitHub Actions** (the `configure-pages` step enables it automatically on most repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)