### PR TITLE
feat(kotoba-cli): mesh component build → on-http world + prelude prepend

### DIFF
--- a/crates/kotoba-cli/src/mesh.rs
+++ b/crates/kotoba-cli/src/mesh.rs
@@ -70,8 +70,19 @@ fn compile_source(file: &Path, wit_dir: &str) -> Result<(Vec<u8>, Lang)> {
         std::fs::read_to_string(file).with_context(|| format!("read component source {}", path))?;
 
     let wasm = match lang {
-        Lang::Clojure => kotoba_clj::component::compile_kais_component_str(&src, wit_dir)
-            .map_err(|e| anyhow!("kotoba-clj compile {}: {e:?}", path))?,
+        // Mesh build path (M7): exports `run`, plus `on-http` when the guest
+        // defines `(defn on-http [req] …)` — targeting the `kotoba-component`
+        // world. Run-only guests fall back to the `kotoba-node` world, so
+        // existing components are unaffected. The kotoba-clj prelude (dynamic
+        // vector/map containers + CBOR encode/decode + kqe accessors) is
+        // prepended so guests can use those helpers — mirrors `kotoba-clj`'s
+        // own build CLI; direct host-import builtins (kqe-assert!/kqe-query)
+        // work with or without it.
+        Lang::Clojure => {
+            let with_prelude = format!("{}\n{}", kotoba_clj::prelude(), src);
+            kotoba_clj::component::compile_kais_mesh_component_str(&with_prelude, wit_dir)
+                .map_err(|e| anyhow!("kotoba-clj compile {}: {e:?}", path))?
+        }
         other => bail!(
             "language {:?} not wired into `kotoba component build` yet — \
              Clojure (.clj) is the default; build {:?} components with their \


### PR DESCRIPTION
## What

`kotoba component build` (the KOTOBA Mesh CLI) now compiles Clojure components via the **mesh** path:

1. **on-http world** — switched `compile_source` from `compile_kais_component_str` to `compile_kais_mesh_component_str`. Guests that define `(defn on-http [req] …)` now export `on-http` alongside `run` (the `kotoba-component` world); run-only guests still fall back to the `kotoba-node` world, so existing components are unaffected.
2. **prelude prepend** — the kotoba-clj prelude (dynamic vector/map containers + CBOR encode/decode + kqe accessors) is prepended before compiling, mirroring kotoba-clj's own build CLI (`cli.rs`). Without it, Pregel/BSP cells using `cbor-enc-text!` / `bytes-alloc` / `map-assoc!` failed to compile.

## Why

These two gaps blocked migrating real actors onto the mesh. Proven end-to-end by the **kabuto** mesh pilot (etzhayyim/20-actors/kabuto, separate PR):
- `methods/mesh.clj` → run + on-http component → `kotoba app deploy` resolves to control-graph datoms.
- `cells/pregel.clj` → compiles to the `run(ctx)` BSP contract that `kotoba-vm::WasmPregelRunner` drives (`tests/pregel.rs`).

## Tests

- `cargo test -p kotoba-clj --test mesh_component` → 9/9 (incl. run-only fallback, on-http loads under wasmtime)
- `cargo test -p kotoba-clj --test pregel` → 3/3

🤖 Generated with [Claude Code](https://claude.com/claude-code)