### PR TITLE
test(mesh): capstone e2e — compile→deploy→route→execute + refresh example

### DIFF
--- a/crates/kotoba-clj/Cargo.toml
+++ b/crates/kotoba-clj/Cargo.toml
@@ -55,6 +55,9 @@ kotoba-runtime = { path = "../kotoba-runtime" }
 # Stage E: drive a compiled component through the Pregel BSP engine
 # (WasmPregelRunner — superstep loop, halt voting, quad accumulation).
 kotoba-vm = { path = "../kotoba-vm" }
+# Capstone e2e: drive the full mesh pipeline (compile → manifest → deploy plan →
+# routing → execution). kotoba-lattice is pure (no cycle: it does not dep kotoba-clj).
+kotoba-lattice = { path = "../kotoba-lattice" }
 # Stage C-5 Datomic loop: agent-asserted quads -> kqe Datom -> Datomic Db query.
 kotoba-core = { path = "../kotoba-core" }
 kotoba-query = { path = "../kotoba-query" }

--- a/crates/kotoba-clj/tests/mesh_e2e.rs
+++ b/crates/kotoba-clj/tests/mesh_e2e.rs
@@ -1,0 +1,102 @@
+//! Capstone end-to-end: the whole KOTOBA Mesh pipeline in one test —
+//!
+//!   Clojure source  --kotoba-clj-->  kotoba-mesh WASM component  (M7–M10)
+//!        manifest    --kotoba-lattice deploy_messages-->  PutTriggers/PutRoutes (M16)
+//!        routing     --TriggerRoutes--> which component fires for which event   (M13–M15)
+//!        execution   --WasmExecutor.execute_on_*--> the matching guest export   (M11)
+//!
+//! Only the live net_actor gossip/inject hop (needs a running swarm) is out of
+//! scope here; that path is covered by kotoba-server's net_actor unit tests.
+
+use kotoba_clj::component::compile_kais_mesh_component_str;
+use kotoba_lattice::routes::parse_schedule_ms;
+use kotoba_lattice::{deploy_messages, AppManifest, LatticeMessage, TriggerRoutes};
+use kotoba_runtime::host::WitQuad;
+use kotoba_runtime::WasmExecutor;
+use std::collections::{BTreeMap, HashMap};
+
+const WIT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/../kotoba-runtime/wit");
+const GAS: u64 = 10_000_000;
+
+// One component handling all four trigger kinds; each export returns a distinct
+// constant so we can prove the routed export actually ran.
+const SRC: &str = "(ns bot) \
+    (defn run [c] \"RUN\") \
+    (defn on-http [r] \"HTTP\") \
+    (defn on-tick [e] \"TICK\") \
+    (defn on-kse [t p] \"KSE\")";
+
+#[test]
+fn full_pipeline_compile_deploy_route_execute() {
+    // ── 1. compile Clojure → kotoba-mesh component ────────────────────────
+    let component = compile_kais_mesh_component_str(SRC, WIT).expect("compile mesh component");
+    assert_eq!(&component[0..4], b"\0asm");
+    let cid = kotoba_core::cid::KotobaCid::from_bytes(&component).to_multibase();
+
+    // ── 2. manifest binding the component to all trigger kinds ────────────
+    let manifest = format!(
+        "{{:kotoba.app/name \"bot\" \
+           :kotoba.app/components \
+           [{{:name \"bot\" :cid \"{cid}\" \
+              :triggers [{{:type :http :route \"/reply\"}} \
+                         {{:type :kse :topic \"kotoba/mail/in\"}} \
+                         {{:type :cron :schedule \"every 5m\"}} \
+                         {{:type :datom-delta :predicate \"mail/received\"}}]}}]}}"
+    );
+    let app = AppManifest::from_edn(&manifest).expect("parse manifest");
+
+    // ── 3. deploy plan: PutTriggers (datom-Δ) + PutRoutes (kse/cron/http) ──
+    let msgs = deploy_messages(&app, &BTreeMap::new());
+    assert!(
+        msgs.iter().any(|(_, m)| matches!(m, LatticeMessage::PutTriggers { triggers, .. } if !triggers.is_empty())),
+        "deploy must emit PutTriggers for the datom-Δ trigger"
+    );
+    assert!(
+        msgs.iter().any(|(_, m)| matches!(m, LatticeMessage::PutRoutes { .. })),
+        "deploy must emit PutRoutes for kse/cron/http"
+    );
+
+    // ── 4. routing: each event source resolves to our component cid ───────
+    let routes = TriggerRoutes::from_app(&app, &BTreeMap::new());
+    assert_eq!(routes.http_target("/reply"), Some(cid.as_str()));
+    assert!(routes.kse_targets("kotoba/mail/in").contains(&cid));
+    assert_eq!(routes.cron, vec![(cid.clone(), "every 5m".to_string())]);
+    assert_eq!(parse_schedule_ms(&routes.cron[0].1), Some(300_000));
+
+    // ── 5. execution: the routed cid runs the matching export ─────────────
+    let exec = WasmExecutor::new(GAS).expect("executor");
+    let did = "did:key:zMeshE2E";
+    let q = Vec::<WitQuad>::new;
+    let h = HashMap::<String, String>::new;
+
+    // HTTP route → on-http
+    let http_cid = routes.http_target("/reply").unwrap();
+    let out = exec
+        .execute_on_http(http_cid, &component, did, b"req".to_vec(), q(), h())
+        .expect("on-http")
+        .output_cbor;
+    assert_eq!(out, b"HTTP");
+
+    // KSE topic → on-kse
+    let kse_cid = &routes.kse_targets("kotoba/mail/in")[0];
+    let out = exec
+        .execute_on_kse(kse_cid, &component, did, "kotoba/mail/in".into(), b"payload".to_vec(), q(), h())
+        .expect("on-kse")
+        .output_cbor;
+    assert_eq!(out, b"KSE");
+
+    // cron → on-tick
+    let (cron_cid, _sched) = &routes.cron[0];
+    let out = exec
+        .execute_on_tick(cron_cid, &component, did, 1_700_000_000_000, q(), h())
+        .expect("on-tick")
+        .output_cbor;
+    assert_eq!(out, b"TICK");
+
+    // generic placement → run
+    let out = exec
+        .execute(&cid, &component, did, b"ctx".to_vec(), q(), h())
+        .expect("run")
+        .output_cbor;
+    assert_eq!(out, b"RUN");
+}

--- a/examples/kotoba-mesh-app/ingest.clj
+++ b/examples/kotoba-mesh-app/ingest.clj
@@ -1,10 +1,21 @@
 ;; ingest.clj — KOTOBA Mesh default-language component (Clojure / kotoba-clj).
 ;;
-;; KSE-topic-triggered: records an inbound mail event as a Datom. Like reply.clj,
-;; all triggers currently dispatch to `run(ctx)` (multi-export codegen — on-kse —
-;; is a kotoba-clj increment; ADR §14.3).
+;; KSE-topic-triggered. The manifest binds this component to the KSE topic
+;; "kotoba/mail/in"; when a message is gossiped on that topic the host invokes
+;; the `on-kse` export with (topic, payload). Multi-trigger codegen (M9/M13):
+;; `compile_kais_mesh_component_str` emits the `kotoba-kse`/`kotoba-mesh` world
+;; for whichever trigger handlers the component defines.
+;;
+;; host-imports used:  kqe-assert! / kqe-query  → kotoba:kais/kqe
 (ns ingest)
 
+;; generic invoke / placement
 (defn run [ctx]
   (kqe-assert! "g" "ingest" "status" "received")
   (kqe-query "status(?s) :- ingest(?s)."))
+
+;; KSE-topic trigger: (topic, payload) → response bytes. Record the inbound
+;; mail event as a Datom, then echo the payload back.
+(defn on-kse [topic payload]
+  (kqe-assert! "g" "ingest" "status" "received")
+  payload)

--- a/examples/kotoba-mesh-app/kotoba.app.edn
+++ b/examples/kotoba-mesh-app/kotoba.app.edn
@@ -3,7 +3,12 @@
 ;; The manifest, the components, and the queries are all one language family:
 ;;   manifest = EDN · component = Clojure (kotoba-clj) · data = Datomic/Datalog.
 ;;
-;; Deploy:  kotoba app deploy kotoba.app.edn
+;; Deploy (dry-run):  kotoba app deploy kotoba.app.edn
+;; Deploy (live)   :  kotoba app deploy kotoba.app.edn --publish --url http://node:8080
+;;   --publish compiles each :src to a CID, builds the PutTriggers/PutRoutes
+;;   lattice messages, and announces them to a running node (M16/R0): peers and
+;;   the node itself install the triggers/routes and fire the bound component's
+;;   run / on-http / on-tick / on-kse export on a matching event.
 ;; (`:lang` omitted ⇒ Clojure default; `.clj` src is compiled to a CID at deploy)
 {:kotoba.app/name    "kotodama-bot"
  :kotoba.app/version "0.3.0"

--- a/examples/kotoba-mesh-app/reply.clj
+++ b/examples/kotoba-mesh-app/reply.clj
@@ -1,16 +1,23 @@
 ;; reply.clj — KOTOBA Mesh default-language component (Clojure / kotoba-clj).
 ;;
-;; Compiled by `kotoba-clj::component::compile_kais_component_str` into a real
-;; `kotoba:kais/kotoba-node` WASM component and driven by kotoba-runtime's
-;; WasmExecutor. This is the *default* way to write a mesh component — same
-;; language family as the manifest (EDN) and the data (Datomic/Datalog).
+;; HTTP-triggered. The manifest binds this component to the route "/reply"; an
+;; HTTP POST to `/mesh/http/reply` on a hosting node invokes the `on-http`
+;; export with the request bytes, and the export's output becomes the HTTP
+;; response (M15). Compiled by `compile_kais_mesh_component_str` into a real
+;; `kotoba:kais` WASM component, driven by kotoba-runtime's WasmExecutor — the
+;; same language family as the manifest (EDN) and the data (Datomic/Datalog).
 ;;
 ;; host-imports used:  kqe-assert! / kqe-query  → kotoba:kais/kqe
 ;;                     llm-infer               → kotoba:kais/llm  (needs cap/llm link)
 (ns reply)
 
+;; generic invoke / placement
 (defn run [ctx]
-  ;; record that we handled a request (a Datom assertion into graph "g")
   (kqe-assert! "g" "reply" "status" "ok")
-  ;; read it back via Datalog — the query language is Datalog over the same datoms
   (kqe-query "status(?s) :- reply(?s)."))
+
+;; HTTP trigger: (request-bytes) → response bytes. Record that we handled a
+;; request, then echo the request back as the response.
+(defn on-http [req]
+  (kqe-assert! "g" "reply" "status" "ok")
+  req)


### PR DESCRIPTION
KOTOBA Mesh **capstone**: 全層を 1 テストで検証する end-to-end + stale な example の刷新。これまで各層は個別 unit test だったが、**パイプライン全体が合成して動く**ことの証明が無かった。

> base = main(M1–M16 + R0 マージ済み)。

## `tests/mesh_e2e.rs`
```
Clojure source  ─kotoba-clj→        kotoba-mesh WASM component   (M7–M10)
   manifest     ─deploy_messages→    PutTriggers / PutRoutes      (M16)
   routing      ─TriggerRoutes→      どの component がどの event で発火  (M13–M15)
   execution    ─WasmExecutor→       一致する guest export を実行   (M11)
```
1 component(run + on-http + on-tick + on-kse, 各 export が distinct な戻り値)を compile → manifest で 4 trigger に bind → `deploy_messages` が PutTriggers(datom-Δ)+ PutRoutes(kse/cron/http)を生成 → `TriggerRoutes` が各 event source を component cid に解決 → **routed cid の正しい export を `WasmExecutor` が実行**(RUN/HTTP/TICK/KSE)。`parse_schedule_ms` も検証。
- 範囲外: live net_actor gossip/inject hop(swarm 必要 — net_actor unit test で被覆)。
- kotoba-clj dev-dep に `kotoba-lattice` 追加(純粋, cycle なし)。

## example 刷新(`examples/kotoba-mesh-app`)
- `ingest.clj` に `on-kse`、`reply.clj` に `on-http` を追加し、「全 trigger は run に dispatch(multi-export は今後)」という**実装前の旧コメント**を実態(M9/M13/M15)に修正。
- `kotoba.app.edn` に `--publish` の live deploy 手順を追記。

## テスト
- `cargo test -p kotoba-clj` → **28 test binary green**(mesh_e2e 含む)
- `clippy` → 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)