### PR TITLE
feat(office): sovereign org-first office layer (gftd-office)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3613,6 +3613,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4876,11 +4882,13 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "base64 0.22.1",
  "bytes",
  "ciborium",
  "ed25519-dalek",
  "getrandom 0.2.17",
  "hex",
+ "kotoba-auth",
  "kotoba-core",
  "kotoba-datomic",
  "kotoba-edn",
@@ -8920,10 +8928,18 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
+ "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ dashmap       = "5"
 # HTTP server
 axum       = "0.7"
 tower      = "0.4"
-tower-http = { version = "0.5", features = ["cors", "trace"] }
+tower-http = { version = "0.5", features = ["cors", "trace", "fs"] }
 base64     = "0.22"
 hex        = "0.4"
 

--- a/crates/kotoba-auth/src/delegation.rs
+++ b/crates/kotoba-auth/src/delegation.rs
@@ -18,6 +18,19 @@ impl DelegationChain {
         Ok(Self { chain: vec![cacao] })
     }
 
+    /// Parse a multi-link chain from a CBOR **array** of CACAOs `[root, leaf]`
+    /// (depth-2 delegation). A single CACAO serializes as a CBOR map, a chain as a
+    /// CBOR array — structurally distinct, so a decoder can try `from_cbor` (map)
+    /// then `from_cbor_chain` (array) without ambiguity. Order is root→leaf.
+    pub fn from_cbor_chain(bytes: &[u8]) -> Result<Self, DelegationError> {
+        let chain: Vec<Cacao> = ciborium::from_reader(bytes)
+            .map_err(|e| DelegationError::Cacao(CacaoError::ParseError(e.to_string())))?;
+        if chain.is_empty() {
+            return Err(DelegationError::EmptyChain);
+        }
+        Ok(Self { chain })
+    }
+
     pub fn new(invocation: Cacao) -> Self {
         Self {
             chain: vec![invocation],
@@ -529,7 +542,9 @@ impl DelegationChain {
         expected_aud: &str,
     ) -> Result<String, DelegationError> {
         // Audience check before signature to fail fast on misrouted tokens.
-        let cacao = self.chain.first().ok_or(DelegationError::EmptyChain)?;
+        // The LEAF (last link) is the invocation presented to this audience; for a
+        // depth-2 chain the root's aud is the delegate, not the server.
+        let cacao = self.chain.last().ok_or(DelegationError::EmptyChain)?;
         // A CACAO with an empty (absent) `aud` field has no audience binding.
         // When the caller explicitly requests audience enforcement, an unbound
         // CACAO is treated as a mismatch — otherwise a bearer token issued without
@@ -551,7 +566,9 @@ impl DelegationChain {
         expected_aud: &str,
         resolver: &dyn DidDocumentResolver,
     ) -> Result<String, DelegationError> {
-        let cacao = self.chain.first().ok_or(DelegationError::EmptyChain)?;
+        // Audience binds to the LEAF (the invocation presented to this server); a
+        // depth-2 root delegates to the member, whose leaf names the server as aud.
+        let cacao = self.chain.last().ok_or(DelegationError::EmptyChain)?;
         if cacao.p.aud.is_empty() || cacao.p.aud != expected_aud {
             return Err(DelegationError::AudienceMismatch {
                 expected: expected_aud.to_string(),

--- a/crates/kotoba-auth/src/lib.rs
+++ b/crates/kotoba-auth/src/lib.rs
@@ -1,5 +1,9 @@
 pub mod btc;
 pub mod cacao;
+// commit_sig imports kotoba_datomic::distributed, which is gated off wasm32
+// (native/server-only commit import-check). The CACAO path (cacao/delegation/
+// did_key) does not use it, so exclude it on wasm32 to keep kotoba-auth wasm-clean.
+#[cfg(not(target_arch = "wasm32"))]
 pub mod commit_sig;
 pub mod delegation;
 pub mod did_document;
@@ -13,6 +17,7 @@ pub use btc::{
     signed_message_hash, verify_message, AddressKind, BtcAddress, BtcError, BtcNetwork,
 };
 pub use cacao::{Cacao, CacaoError, CacaoHeader, CacaoPayload, CacaoSig};
+#[cfg(not(target_arch = "wasm32"))]
 pub use commit_sig::{commit_import_check, verify_commit_author_sig, CommitSigVerdict};
 pub use delegation::{DelegationChain, DelegationError};
 pub use did_document::{

--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -1753,6 +1753,13 @@ pub fn build_router(state: Arc<KotobaState>) -> Router {
     // behaviourally unchanged. Each layer wraps the previous; the rate limiter
     // is applied last so it sheds load before any handler work, and TraceLayer
     // is outermost so even rejected requests are logged.
+    // Same-origin static delivery (docs/gftd-office): when KOTOBA_STATIC_DIR is set,
+    // serve the browser app (editor.html, pkg/, cljs-out/) from the SAME origin as
+    // /xrpc, so the production deployment needs no CORS / --disable-web-security.
+    if let Ok(dir) = std::env::var("KOTOBA_STATIC_DIR") {
+        tracing::info!(dir, "serving static app dir (same-origin)");
+        app = app.fallback_service(tower_http::services::ServeDir::new(dir));
+    }
     if let Some(cors) = cors_from_env() {
         app = app.layer(cors);
     }

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -2161,11 +2161,17 @@ fn verify_datomic_cacao_payload_with_operations(
     let cbor = B64
         .decode(b64)
         .map_err(|e| (StatusCode::BAD_REQUEST, format!("cacao_b64 decode: {e}")))?;
-    let cacao = kotoba_auth::Cacao::from_cbor(&cbor)
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("cacao parse: {e}")))?;
-    let nonce = cacao.p.nonce.clone();
-    let payload = cacao.p.clone();
-    let chain = kotoba_auth::DelegationChain::new(cacao);
+    let chain = decode_cacao_chain(&cbor)?;
+    // The leaf (last link) is the invocation presented now: its nonce gates replay.
+    // The verified issuer is the ULTIMATE authority (root for a depth-2 delegation,
+    // self for depth-1) — owner-binding + auto-registration compare against it, so a
+    // team member can write to the org's graph under a chain rooted at the org owner.
+    let leaf = chain
+        .chain
+        .last()
+        .cloned()
+        .ok_or((StatusCode::BAD_REQUEST, "empty cacao chain".to_string()))?;
+    let nonce = leaf.p.nonce.clone();
     let resolver = local_first_did_resolver(state);
     let mut issuer = None;
     for operation in operations {
@@ -2174,7 +2180,7 @@ fn verify_datomic_cacao_payload_with_operations(
             .map_err(|e| (StatusCode::UNAUTHORIZED, format!("cacao delegation: {e}")))?;
         issuer = Some(verified_issuer);
     }
-    let issuer = issuer.unwrap_or_else(|| payload.iss.clone());
+    let issuer = issuer.unwrap_or_else(|| leaf.p.iss.clone());
     if nonce.is_empty() {
         return Err((
             StatusCode::UNAUTHORIZED,
@@ -2194,7 +2200,23 @@ fn verify_datomic_cacao_payload_with_operations(
         ));
     }
     tracing::debug!(issuer = %issuer, operations = %operations.join(","), graph, "datomic CACAO accepted");
+    // Return the leaf payload but with iss = the verified ultimate authority, so the
+    // caller binds the write/read to the graph owner (the org), not the delegate.
+    let mut payload = leaf.p;
+    payload.iss = issuer;
     Ok(payload)
+}
+
+/// Decode a `cacao_b64`-derived CBOR blob into a delegation chain: a single CACAO
+/// (CBOR map, depth-1) or a `[root, leaf]` array (depth-2 team delegation).
+fn decode_cacao_chain(
+    cbor: &[u8],
+) -> Result<kotoba_auth::DelegationChain, (StatusCode, String)> {
+    match kotoba_auth::Cacao::from_cbor(cbor) {
+        Ok(cacao) => Ok(kotoba_auth::DelegationChain::new(cacao)),
+        Err(_) => kotoba_auth::DelegationChain::from_cbor_chain(cbor)
+            .map_err(|e| (StatusCode::BAD_REQUEST, format!("cacao parse: {e}"))),
+    }
 }
 
 fn verify_datomic_cacao_payload_with_any_operation(
@@ -2222,11 +2244,13 @@ fn verify_datomic_cacao_payload_with_any_operation(
     let cbor = B64
         .decode(b64)
         .map_err(|e| (StatusCode::BAD_REQUEST, format!("cacao_b64 decode: {e}")))?;
-    let cacao = kotoba_auth::Cacao::from_cbor(&cbor)
-        .map_err(|e| (StatusCode::BAD_REQUEST, format!("cacao parse: {e}")))?;
-    let nonce = cacao.p.nonce.clone();
-    let payload = cacao.p.clone();
-    let chain = kotoba_auth::DelegationChain::new(cacao);
+    let chain = decode_cacao_chain(&cbor)?;
+    let leaf = chain
+        .chain
+        .last()
+        .cloned()
+        .ok_or((StatusCode::BAD_REQUEST, "empty cacao chain".to_string()))?;
+    let nonce = leaf.p.nonce.clone();
     let resolver = local_first_did_resolver(state);
     let mut issuer = None;
     let mut last_error = None;
@@ -2275,6 +2299,8 @@ fn verify_datomic_cacao_payload_with_any_operation(
         ));
     }
     tracing::debug!(issuer = %issuer, operations = %operations.join(","), graph, "datomic CACAO accepted");
+    let mut payload = leaf.p;
+    payload.iss = issuer;
     Ok(payload)
 }
 
@@ -4921,6 +4947,26 @@ pub async fn datomic_transact(
                 kotoba_auth::CacaoPayload::OP_TX_CREATE,
             ],
         )?;
+        // Account-owned private graph auto-registration (data sovereignty,
+        // docs/gftd-office). If this graph is not yet registered and its CID is the
+        // deterministic private-graph CID derived from the CACAO issuer's DID
+        // (NamedGraph::private_for → KotobaCid::from_bytes("kotoba://graph/private/{did}")),
+        // register it Private{owner=issuer}. The CID binds to the DID, so only the
+        // issuer whose DID derives THIS exact CID can claim it — it can never grant
+        // ownership of another tenant's graph. Without this, an account could never own
+        // its own graph over the wire (unregistered graphs default to operator-owned),
+        // which would block the org-first sovereignty model.
+        if !state.graph_registry.read().await.contains_key(&graph_cid) {
+            let derived = kotoba_core::named_graph::NamedGraph::private_for(&payload.iss);
+            if derived.cid == graph_cid {
+                tracing::info!(
+                    owner = %payload.iss,
+                    graph = %graph_cid.to_multibase(),
+                    "datomic transact: auto-registered account-owned private graph"
+                );
+                state.register_graph(derived).await;
+            }
+        }
         // ADR-2606131600 P1 owner-binding — write-path mirror (BaaS tenant writes).
         // The CACAO grant above verifies capability + graph scope + aud==operator +
         // signature, but not WHO signed it. A self-signed CACAO scoped to another
@@ -10098,6 +10144,305 @@ mod tests {
             "deny must be the owner-binding gate, got: {}",
             err.1
         );
+    }
+
+    // docs/gftd-office: an account writes office datoms to ITS OWN private graph over
+    // the wire (the CACAO-authed sync path). The graph is unregistered; its CID is the
+    // deterministic NamedGraph::private_for(issuer) CID, so the transact auto-registers
+    // it Private{owner=issuer} and the write succeeds. A write by the same account to a
+    // graph CID that is NOT derived from its DID must be rejected (cannot claim others').
+    #[tokio::test]
+    async fn datomic_transact_auto_registers_account_owned_private_graph() {
+        std::env::set_var("KOTOBA_IPFS", "off");
+        std::env::set_var("KOTOBA_IPNS_REQUIRE_SIGNATURE", "false");
+        let state = Arc::new(KotobaState::new(None).unwrap());
+
+        // signed_cacao_b64 signs with key [42] — the account identity.
+        let account_did = kotoba_auth::ed25519_pubkey_to_did_key(
+            &ed25519_dalek::SigningKey::from_bytes(&[42u8; 32])
+                .verifying_key()
+                .to_bytes(),
+        );
+        let g = kotoba_core::named_graph::NamedGraph::private_for(&account_did).cid;
+        let g_mb = g.to_multibase();
+        assert!(
+            !state.graph_registry.read().await.contains_key(&g),
+            "graph starts unregistered"
+        );
+
+        // Write CACAO: datom:transact + tx:create, scoped to the account's own graph CID.
+        let cacao = signed_cacao_b64(
+            &state,
+            &g_mb,
+            kotoba_auth::CacaoPayload::OP_DATOM_TRANSACT,
+            "auto-reg-nonce-1",
+            [format!(
+                "kotoba://op/{}",
+                kotoba_auth::CacaoPayload::OP_TX_CREATE
+            )],
+        );
+        datomic_transact(
+            axum::extract::State(Arc::clone(&state)),
+            axum::http::HeaderMap::new(),
+            axum::Json(DatomicTransactReq {
+                graph: g_mb.clone(),
+                tx_edn: "[[:db/add \"doc1\" :doc/title \"Hello\"]]".into(),
+                ipns_name: None,
+                cacao_b64: Some(cacao),
+                cacao_proof_cid: None,
+                expected_parent: None,
+                presentation: None,
+            }),
+        )
+        .await
+        .expect("account must be able to write its own DID-derived private graph");
+
+        // The graph is now registered Private{owner = account}.
+        match state.graph_registry.read().await.get(&g) {
+            Some((_, GraphVisibility::Private { owner_did })) => {
+                assert_eq!(owner_did, &account_did, "owner must be the account DID")
+            }
+            other => panic!("graph must be auto-registered private to the account: {other:?}"),
+        }
+
+        // The same account cannot claim a graph CID NOT derived from its DID.
+        let foreign = KotobaCid::from_bytes(b"not-derived-from-account-did");
+        let foreign_mb = foreign.to_multibase();
+        let cacao2 = signed_cacao_b64(
+            &state,
+            &foreign_mb,
+            kotoba_auth::CacaoPayload::OP_DATOM_TRANSACT,
+            "auto-reg-nonce-2",
+            [format!(
+                "kotoba://op/{}",
+                kotoba_auth::CacaoPayload::OP_TX_CREATE
+            )],
+        );
+        let err = datomic_transact(
+            axum::extract::State(Arc::clone(&state)),
+            axum::http::HeaderMap::new(),
+            axum::Json(DatomicTransactReq {
+                graph: foreign_mb,
+                tx_edn: "[[:db/add \"doc1\" :doc/title \"Hello\"]]".into(),
+                ipns_name: None,
+                cacao_b64: Some(cacao2),
+                cacao_proof_cid: None,
+                expected_parent: None,
+                presentation: None,
+            }),
+        )
+        .await
+        .err()
+        .expect("account cannot claim a graph CID not derived from its DID");
+        assert_eq!(err.0, axum::http::StatusCode::UNAUTHORIZED);
+    }
+
+    // docs/gftd-office: read-back. After an account syncs office datoms to its own
+    // private graph, it reads them back over the wire with a READ CACAO (datom:read,
+    // scoped to the graph CID — require_datomic_read uses graph.to_multibase()). No
+    // CACAO → denied; owner CACAO → the written datom is returned (v_edn = EDN form).
+    #[tokio::test]
+    async fn datomic_datoms_reads_back_account_private_graph_with_cacao() {
+        use axum::response::IntoResponse as _;
+        std::env::set_var("KOTOBA_IPFS", "off");
+        std::env::set_var("KOTOBA_IPNS_REQUIRE_SIGNATURE", "false");
+        let state = Arc::new(KotobaState::new(None).unwrap());
+
+        let account_did = kotoba_auth::ed25519_pubkey_to_did_key(
+            &ed25519_dalek::SigningKey::from_bytes(&[42u8; 32])
+                .verifying_key()
+                .to_bytes(),
+        );
+        let g = kotoba_core::named_graph::NamedGraph::private_for(&account_did).cid;
+        let g_mb = g.to_multibase();
+
+        // write (auto-registers the account's private graph)
+        let wcacao = signed_cacao_b64(
+            &state,
+            &g_mb,
+            kotoba_auth::CacaoPayload::OP_DATOM_TRANSACT,
+            "rb-w-1",
+            [format!(
+                "kotoba://op/{}",
+                kotoba_auth::CacaoPayload::OP_TX_CREATE
+            )],
+        );
+        datomic_transact(
+            axum::extract::State(Arc::clone(&state)),
+            axum::http::HeaderMap::new(),
+            axum::Json(DatomicTransactReq {
+                graph: g_mb.clone(),
+                tx_edn: "[[:db/add \"doc1\" :doc/title \"Hello\"]]".into(),
+                ipns_name: None,
+                cacao_b64: Some(wcacao),
+                cacao_proof_cid: None,
+                expected_parent: None,
+                presentation: None,
+            }),
+        )
+        .await
+        .expect("owner write must succeed");
+
+        let datoms_req = |cacao: Option<String>| DatomicDatomsReq {
+            graph: g_mb.clone(),
+            index: "eavt".into(),
+            components_edn: vec![],
+            as_of: None,
+            since: None,
+            remote_peer: None,
+            remote_ipns_name: None,
+            cacao_b64: cacao,
+            presentation: None,
+            limit: None,
+        };
+
+        // no CACAO → denied (the read gate is real)
+        let denied = datomic_datoms(
+            axum::extract::State(Arc::clone(&state)),
+            axum::http::HeaderMap::new(),
+            axum::Json(datoms_req(None)),
+        )
+        .await
+        .err()
+        .expect("private read without cacao must be denied");
+        assert_eq!(denied.0, axum::http::StatusCode::UNAUTHORIZED);
+
+        // owner read CACAO (datom:read, scope = graph CID) → OK + returns the datom
+        let rcacao = signed_cacao_b64(
+            &state,
+            &g_mb,
+            kotoba_auth::CacaoPayload::OP_DATOM_READ,
+            "rb-r-1",
+            Vec::<String>::new(),
+        );
+        let resp = datomic_datoms(
+            axum::extract::State(Arc::clone(&state)),
+            axum::http::HeaderMap::new(),
+            axum::Json(datoms_req(Some(rcacao))),
+        )
+        .await
+        .expect("owner read must be allowed")
+        .into_response();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let datoms = v["datoms"].as_array().expect("datoms array in response");
+        assert!(
+            datoms
+                .iter()
+                .any(|d| d["a"] == ":doc/title" && d["v_edn"] == "\"Hello\""),
+            "read-back must contain the written title datom, got: {v}"
+        );
+    }
+
+    // docs/gftd-office team sharing: a team MEMBER writes to the ORG's private graph
+    // via a depth-2 delegation chain [root(org→member), leaf(member→server)]. The
+    // server binds the write to the ROOT authority (the org owner), so it passes
+    // owner-binding and auto-registers the graph to the org. A member WITHOUT a
+    // delegation (a bare single CACAO) is rejected.
+    #[tokio::test]
+    async fn datomic_transact_accepts_depth2_team_delegation() {
+        use base64::Engine as _;
+        std::env::set_var("KOTOBA_IPFS", "off");
+        std::env::set_var("KOTOBA_IPNS_REQUIRE_SIGNATURE", "false");
+        let state = Arc::new(KotobaState::new(None).unwrap());
+
+        let owner_key = ed25519_dalek::SigningKey::from_bytes(&[7u8; 32]); // org
+        let member_key = ed25519_dalek::SigningKey::from_bytes(&[9u8; 32]); // member
+        let owner_did =
+            kotoba_auth::ed25519_pubkey_to_did_key(&owner_key.verifying_key().to_bytes());
+        let member_did =
+            kotoba_auth::ed25519_pubkey_to_did_key(&member_key.verifying_key().to_bytes());
+        let g = kotoba_core::named_graph::NamedGraph::private_for(&owner_did).cid;
+        let g_mb = g.to_multibase();
+        let aud = state.operator_did.clone();
+
+        let sign = |key: &ed25519_dalek::SigningKey,
+                    iss: &str,
+                    cacao_aud: &str,
+                    nonce: &str,
+                    caps: &[&str]| {
+            use ed25519_dalek::Signer as _;
+            let mut resources: Vec<String> =
+                caps.iter().map(|c| format!("kotoba://op/{c}")).collect();
+            resources.push(format!("kotoba://graph/{g_mb}"));
+            let mut c = kotoba_auth::Cacao {
+                h: kotoba_auth::CacaoHeader {
+                    t: "eip4361".into(),
+                },
+                p: kotoba_auth::CacaoPayload {
+                    iss: iss.into(),
+                    aud: cacao_aud.into(),
+                    issued_at: "2026-05-30T00:00:00Z".into(),
+                    expiry: Some("2099-01-01T00:00:00Z".into()),
+                    nonce: nonce.into(),
+                    domain: "kotoba.test".into(),
+                    statement: None,
+                    version: "1".into(),
+                    resources,
+                },
+                s: kotoba_auth::CacaoSig {
+                    t: "EdDSA".into(),
+                    s: String::new(),
+                },
+            };
+            c.s.s = base64::engine::general_purpose::URL_SAFE_NO_PAD
+                .encode(key.sign(c.siwe_message().as_bytes()).to_bytes());
+            c
+        };
+
+        // root: org → member ; leaf: member → server. Serialize [root, leaf] as a CBOR array.
+        let root = sign(&owner_key, &owner_did, &member_did, "d2-root-1", &["datom:transact", "tx:create"]);
+        let leaf = sign(&member_key, &member_did, &aud, "d2-leaf-1", &["datom:transact", "tx:create"]);
+        let mut cbor = Vec::new();
+        ciborium::into_writer(&vec![root, leaf], &mut cbor).unwrap();
+        let chain_b64 = base64::engine::general_purpose::STANDARD.encode(cbor);
+
+        datomic_transact(
+            axum::extract::State(Arc::clone(&state)),
+            axum::http::HeaderMap::new(),
+            axum::Json(DatomicTransactReq {
+                graph: g_mb.clone(),
+                tx_edn: "[[:db/add \"doc1\" :doc/title \"Team\"]]".into(),
+                ipns_name: None,
+                cacao_b64: Some(chain_b64),
+                cacao_proof_cid: None,
+                expected_parent: None,
+                presentation: None,
+            }),
+        )
+        .await
+        .expect("delegated member write must succeed");
+
+        // bound to the ORG owner, not the member
+        match state.graph_registry.read().await.get(&g) {
+            Some((_, GraphVisibility::Private { owner_did: o })) => assert_eq!(o, &owner_did),
+            other => panic!("graph must be private to the org owner: {other:?}"),
+        }
+
+        // a member WITHOUT delegation (bare single CACAO) cannot write the org graph
+        let solo = sign(&member_key, &member_did, &aud, "d2-solo-1", &["datom:transact", "tx:create"]);
+        let mut sb = Vec::new();
+        ciborium::into_writer(&solo, &mut sb).unwrap();
+        let solo_b64 = base64::engine::general_purpose::STANDARD.encode(sb);
+        let err = datomic_transact(
+            axum::extract::State(Arc::clone(&state)),
+            axum::http::HeaderMap::new(),
+            axum::Json(DatomicTransactReq {
+                graph: g_mb.clone(),
+                tx_edn: "[[:db/add \"x\" :n 1]]".into(),
+                ipns_name: None,
+                cacao_b64: Some(solo_b64),
+                cacao_proof_cid: None,
+                expected_parent: None,
+                presentation: None,
+            }),
+        )
+        .await
+        .err()
+        .expect("non-delegated member must be rejected");
+        assert_eq!(err.0, axum::http::StatusCode::UNAUTHORIZED);
     }
 
     // ADR-2606201700 f/3: per-tier datom write quota. A free-tier tenant (default,

--- a/crates/kotoba-wasm/Cargo.toml
+++ b/crates/kotoba-wasm/Cargo.toml
@@ -16,6 +16,8 @@ kotoba-core = { path = "../kotoba-core" }
 kotoba-datomic = { path = "../kotoba-datomic" }
 kotoba-edn = { path = "../kotoba-edn" }
 kotoba-query = { path = "../kotoba-query" }
+# Exact CACAO type + did:key + siwe_message reuse → server byte-compat (doc b).
+kotoba-auth = { path = "../kotoba-auth" }
 # Wasm-safe canonical IPNS head record (ADR-2606066000) — the browser emits the
 # SAME member-signed record kotoba-ipfs verifies (no parallel format).
 kotoba-ipns-record = { path = "../kotoba-ipns-record" }
@@ -31,6 +33,7 @@ aes-gcm = { workspace = true }
 rand_core = { workspace = true }
 sha2 = { workspace = true }
 hex = { workspace = true }
+base64 = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/crates/kotoba-wasm/src/lib.rs
+++ b/crates/kotoba-wasm/src/lib.rs
@@ -730,6 +730,146 @@ impl WriteCrypto {
         Ok(rec)
     }
 
+    /// Mint a server-verifiable **CACAO** signed by this identity (doc b bridge).
+    /// Returns `base64(dag-cbor(Cacao))` for the `cacao_b64` field of
+    /// `datomic.transact` / read endpoints. Reuses kotoba-auth's exact `Cacao` type,
+    /// `did:key` derivation, and `siwe_message()` so the bytes verify byte-identically
+    /// under `DelegationChain::verify` (no parallel format).
+    ///
+    /// `capabilities` are datomic op tokens granted (each → `kotoba://op/{cap}`).
+    /// A WRITE must grant BOTH `datom:transact` AND `tx:create` (the server verifies
+    /// both, xrpc.rs datomic_transact); a READ grants `datom:read`. `graph_scope` is
+    /// the `kotoba://graph/{scope}` value the server checks: the graph CID for a
+    /// transact, or `private/{owner_did}` for a private read.
+    pub fn mint_cacao(
+        &self,
+        aud: &str,
+        graph_scope: &str,
+        capabilities: &[String],
+        nonce: &str,
+        issued_at: &str,
+        expiry: Option<&str>,
+    ) -> Result<String, String> {
+        use base64::{
+            engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+            Engine,
+        };
+        use ed25519_dalek::Signer;
+        use kotoba_auth::{ed25519_pubkey_to_did_key, Cacao, CacaoHeader, CacaoPayload, CacaoSig};
+        let vk = ed25519_dalek::VerifyingKey::from(&self.signing_key);
+        let iss = ed25519_pubkey_to_did_key(vk.as_bytes());
+        let mut resources: Vec<String> = capabilities
+            .iter()
+            .map(|c| format!("kotoba://op/{c}"))
+            .collect();
+        resources.push(format!("kotoba://graph/{graph_scope}"));
+        let mut cacao = Cacao {
+            h: CacaoHeader {
+                t: "eip4361".to_string(),
+            },
+            p: CacaoPayload {
+                iss,
+                aud: aud.to_string(),
+                issued_at: issued_at.to_string(),
+                expiry: expiry.map(|s| s.to_string()),
+                nonce: nonce.to_string(),
+                domain: "gftd.office".to_string(),
+                statement: None,
+                version: "1".to_string(),
+                resources,
+            },
+            s: CacaoSig {
+                t: "EdDSA".to_string(),
+                s: String::new(),
+            },
+        };
+        let msg = cacao.siwe_message();
+        cacao.s.s = URL_SAFE_NO_PAD.encode(self.signing_key.sign(msg.as_bytes()).to_bytes());
+        let mut cbor = Vec::new();
+        ciborium::into_writer(&cacao, &mut cbor).map_err(|e| e.to_string())?;
+        Ok(STANDARD.encode(cbor))
+    }
+
+    /// Build a depth-2 delegation chain `[root, leaf]` as the delegate (member).
+    /// `root_grant_b64` is a CACAO the OWNER minted with `mint_cacao(aud = this DID, …)`
+    /// (the owner delegating a capability on its graph to this member). This signs a
+    /// leaf (iss = self/member, aud = server) attenuated to `capabilities`/`graph_scope`,
+    /// then serializes `[root, leaf]` as a CBOR array → base64 for `cacao_b64`. The
+    /// server verifies attenuation and binds the write to the ROOT issuer (the owner),
+    /// so a team member can write to the org's graph (docs/gftd-office team sharing).
+    pub fn mint_delegated(
+        &self,
+        root_grant_b64: &str,
+        aud: &str,
+        graph_scope: &str,
+        capabilities: &[String],
+        nonce: &str,
+        issued_at: &str,
+        expiry: Option<&str>,
+    ) -> Result<String, String> {
+        use base64::{
+            engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+            Engine,
+        };
+        use ed25519_dalek::Signer;
+        use kotoba_auth::{ed25519_pubkey_to_did_key, Cacao, CacaoHeader, CacaoPayload, CacaoSig};
+        let root_cbor = STANDARD
+            .decode(root_grant_b64)
+            .map_err(|e| format!("root grant b64: {e}"))?;
+        let root = Cacao::from_cbor(&root_cbor).map_err(|e| format!("root grant parse: {e}"))?;
+        let vk = ed25519_dalek::VerifyingKey::from(&self.signing_key);
+        let iss = ed25519_pubkey_to_did_key(vk.as_bytes());
+        let mut resources: Vec<String> = capabilities
+            .iter()
+            .map(|c| format!("kotoba://op/{c}"))
+            .collect();
+        resources.push(format!("kotoba://graph/{graph_scope}"));
+        let mut leaf = Cacao {
+            h: CacaoHeader {
+                t: "eip4361".to_string(),
+            },
+            p: CacaoPayload {
+                iss,
+                aud: aud.to_string(),
+                issued_at: issued_at.to_string(),
+                expiry: expiry.map(|s| s.to_string()),
+                nonce: nonce.to_string(),
+                domain: "gftd.office".to_string(),
+                statement: None,
+                version: "1".to_string(),
+                resources,
+            },
+            s: CacaoSig {
+                t: "EdDSA".to_string(),
+                s: String::new(),
+            },
+        };
+        leaf.s.s =
+            URL_SAFE_NO_PAD.encode(self.signing_key.sign(leaf.siwe_message().as_bytes()).to_bytes());
+        let chain = vec![root, leaf];
+        let mut cbor = Vec::new();
+        ciborium::into_writer(&chain, &mut cbor).map_err(|e| e.to_string())?;
+        Ok(STANDARD.encode(cbor))
+    }
+
+    /// Canonical W3C `did:key:z6Mk…` for this identity (multibase multicodec ed25519),
+    /// the form CACAO / DID resolution use. NOTE: `did()` returns a simpler hex shim
+    /// used by the IPNS head path; for the office/sovereignty model use this one.
+    pub fn account_did(&self) -> String {
+        let vk = ed25519_dalek::VerifyingKey::from(&self.signing_key);
+        kotoba_auth::ed25519_pubkey_to_did_key(vk.as_bytes())
+    }
+
+    /// Multibase CID of this account's OWN private graph
+    /// (`NamedGraph::private_for(account_did)`). Deterministic from the DID, so the
+    /// server can auto-register it Private{owner=account} on first CACAO write
+    /// (docs/gftd-office). This is the `graph` the browser passes to datomic.transact.
+    pub fn private_graph_id(&self) -> String {
+        kotoba_core::named_graph::NamedGraph::private_for(&self.account_did())
+            .cid
+            .to_multibase()
+    }
+
     /// Encrypt plaintext under the vault key → `signal:v1:<hex(nonce||ct)>`.
     /// The server/IndexedDB only ever sees this ciphertext.
     pub fn encrypt(&self, plaintext: &str) -> Result<String, String> {
@@ -943,6 +1083,18 @@ mod wasm {
                 .map_err(|e| JsValue::from_str(&e))
         }
 
+        /// Encrypt plaintext under the agent's vault key → `signal:v1:<ct>` envelope
+        /// (string value). Lets the office layer encrypt a field ONCE and use the same
+        /// envelope for both the local store and the server sync (docs/gftd-office).
+        #[wasm_bindgen(js_name = encrypt)]
+        pub fn encrypt(&self, plaintext: &str) -> Result<String, JsValue> {
+            let c = self
+                .crypto
+                .as_ref()
+                .ok_or_else(|| JsValue::from_str("no identity — call useIdentity first"))?;
+            c.encrypt(plaintext).map_err(|e| JsValue::from_str(&e))
+        }
+
         /// Decrypt a `signal:v1:` envelope with the agent's vault key.
         pub fn decrypt(&self, envelope: &str) -> Result<String, JsValue> {
             let c = self
@@ -964,6 +1116,87 @@ mod wasm {
                 "root": root.to_multibase(), "did": did, "sig": sig,
             }))
             .map_err(|e| JsValue::from_str(&e.to_string()))
+        }
+
+        /// Canonical W3C did:key:z6Mk… for this identity (the CACAO/sovereignty DID).
+        #[wasm_bindgen(js_name = accountDid)]
+        pub fn account_did(&self) -> Result<String, JsValue> {
+            let c = self
+                .crypto
+                .as_ref()
+                .ok_or_else(|| JsValue::from_str("no identity — call useIdentity first"))?;
+            Ok(c.account_did())
+        }
+
+        /// Multibase CID of this account's own private graph (the `graph` for sync).
+        #[wasm_bindgen(js_name = privateGraphId)]
+        pub fn private_graph_id(&self) -> Result<String, JsValue> {
+            let c = self
+                .crypto
+                .as_ref()
+                .ok_or_else(|| JsValue::from_str("no identity — call useIdentity first"))?;
+            Ok(c.private_graph_id())
+        }
+
+        /// Mint a server-verifiable CACAO signed by the agent identity → base64
+        /// `cacao_b64` (doc b: membership grant → capability). `capabilities` is a
+        /// JS array of op tokens: `["datom:transact","tx:create"]` for a write,
+        /// `["datom:read"]` for a read. `graphScope` = graph CID (write) or
+        /// `private/{ownerDid}` (private read).
+        #[wasm_bindgen(js_name = mintCacao)]
+        pub fn mint_cacao(
+            &self,
+            aud: String,
+            graph_scope: String,
+            capabilities: Vec<String>,
+            nonce: String,
+            issued_at: String,
+            expiry: Option<String>,
+        ) -> Result<String, JsValue> {
+            let c = self
+                .crypto
+                .as_ref()
+                .ok_or_else(|| JsValue::from_str("no identity — call useIdentity first"))?;
+            c.mint_cacao(
+                &aud,
+                &graph_scope,
+                &capabilities,
+                &nonce,
+                &issued_at,
+                expiry.as_deref(),
+            )
+            .map_err(|e| JsValue::from_str(&e))
+        }
+
+        /// Build a depth-2 delegation chain (team sharing): the OWNER first mints a
+        /// root grant via `mintCacao(aud = memberDid, …)`; the MEMBER calls this with
+        /// that `rootGrantB64` to produce the `[root, leaf]` chain base64 for
+        /// `cacao_b64`. `capabilities` must be ⊆ the root's. (doc b / d)
+        #[wasm_bindgen(js_name = mintDelegated)]
+        pub fn mint_delegated(
+            &self,
+            root_grant_b64: String,
+            aud: String,
+            graph_scope: String,
+            capabilities: Vec<String>,
+            nonce: String,
+            issued_at: String,
+            expiry: Option<String>,
+        ) -> Result<String, JsValue> {
+            let c = self
+                .crypto
+                .as_ref()
+                .ok_or_else(|| JsValue::from_str("no identity — call useIdentity first"))?;
+            c.mint_delegated(
+                &root_grant_b64,
+                &aud,
+                &graph_scope,
+                &capabilities,
+                &nonce,
+                &issued_at,
+                expiry.as_deref(),
+            )
+            .map_err(|e| JsValue::from_str(&e))
         }
 
         /// `commit()` + emit a member-signed **kotoba IPNS head record**
@@ -1337,6 +1570,132 @@ mod tests {
         let vk = VerifyingKey::from(&c.signing_key);
         let sig = Signature::from_slice(&hex::decode(sig_hex).unwrap()).unwrap();
         assert!(vk.verify(msg, &sig).is_ok(), "signature must verify");
+    }
+
+    #[test]
+    fn mint_cacao_verifies_through_server_delegation_chain() {
+        // The browser-minted CACAO must verify byte-identically under the SAME
+        // verifier the server runs (kotoba-auth DelegationChain::verify) — proving
+        // the doc-b grant→capability bridge end to end without a browser.
+        let c = WriteCrypto::from_seed(&[7u8; 32]);
+        let graph = "bafy2bzaced-office-graph";
+        // A WRITE CACAO must grant BOTH datom:transact AND tx:create (server checks both).
+        let caps = vec!["datom:transact".to_string(), "tx:create".to_string()];
+        let b64 = c
+            .mint_cacao(
+                "https://kotoba.test",
+                graph,
+                &caps,
+                "office-nonce-1",
+                "2026-01-01T00:00:00Z",
+                Some("2099-01-01T00:00:00Z"),
+            )
+            .unwrap();
+
+        use base64::{engine::general_purpose::STANDARD, Engine};
+        let cbor = STANDARD.decode(b64).unwrap();
+        let cacao = kotoba_auth::Cacao::from_cbor(&cbor).unwrap();
+
+        // Issuer is a real did:key:z6Mk... (not the hex shim) and the sig verifies.
+        let did = cacao.verify_signature().expect("EdDSA sig must verify");
+        assert!(did.starts_with("did:key:z6Mk"), "real did:key, got {did}");
+
+        // The server loops both write ops — BOTH must verify on the same chain.
+        for op in ["datom:transact", "tx:create"] {
+            kotoba_auth::DelegationChain::new(kotoba_auth::Cacao::from_cbor(&cbor).unwrap())
+                .verify(graph, op)
+                .unwrap_or_else(|e| panic!("server verifier must accept op {op}: {e:?}"));
+        }
+
+        // Wrong capability / wrong graph are rejected.
+        assert!(kotoba_auth::DelegationChain::new(
+            kotoba_auth::Cacao::from_cbor(&cbor).unwrap()
+        )
+        .verify(graph, "datom:read")
+        .is_err());
+        assert!(kotoba_auth::DelegationChain::new(
+            kotoba_auth::Cacao::from_cbor(&cbor).unwrap()
+        )
+        .verify("bafy-other-graph", "datom:transact")
+        .is_err());
+    }
+
+    #[test]
+    fn mint_delegated_depth2_binds_to_root_owner_and_attenuates() {
+        // Team sharing: an org owner delegates a capability on its graph to a member,
+        // who presents a depth-2 chain. The server-side verifier returns the ROOT
+        // (owner) as the authority, and rejects any capability the member did not
+        // receive (attenuation).
+        let owner = WriteCrypto::from_seed(&[7u8; 32]); // org
+        let member = WriteCrypto::from_seed(&[9u8; 32]); // team member
+        let graph = "bafy2bzaced-org-graph";
+        let server = "https://kotoba.test";
+        let caps = vec!["datom:transact".to_string(), "tx:create".to_string()];
+
+        // owner → member root grant (aud = member DID)
+        let root = owner
+            .mint_cacao(
+                &member.account_did(),
+                graph,
+                &caps,
+                "root-n-1",
+                "2026-01-01T00:00:00Z",
+                Some("2099-01-01T00:00:00Z"),
+            )
+            .unwrap();
+        // member assembles [root, leaf] (leaf aud = server)
+        let chain_b64 = member
+            .mint_delegated(
+                &root,
+                server,
+                graph,
+                &caps,
+                "leaf-n-1",
+                "2026-01-01T00:00:00Z",
+                Some("2099-01-01T00:00:00Z"),
+            )
+            .unwrap();
+
+        use base64::{engine::general_purpose::STANDARD, Engine};
+        let cbor = STANDARD.decode(chain_b64).unwrap();
+        // a chain is a CBOR array → single-decode fails, chain-decode yields 2 links
+        assert!(kotoba_auth::Cacao::from_cbor(&cbor).is_err());
+        let chain = kotoba_auth::DelegationChain::from_cbor_chain(&cbor).unwrap();
+        assert_eq!(chain.chain.len(), 2);
+        // server verify (leaf aud == server) → authority is the ROOT owner (the org)
+        let authority = kotoba_auth::DelegationChain::from_cbor_chain(&cbor)
+            .unwrap()
+            .verify_with_aud(graph, "datom:transact", server)
+            .expect("depth-2 chain must verify");
+        assert_eq!(authority, owner.account_did(), "authority is the org owner");
+
+        // attenuation: member cannot escalate beyond what the owner granted.
+        let root_read = owner
+            .mint_cacao(
+                &member.account_did(),
+                graph,
+                &["datom:read".to_string()],
+                "root-n-2",
+                "2026-01-01T00:00:00Z",
+                Some("2099-01-01T00:00:00Z"),
+            )
+            .unwrap();
+        let escalated = member
+            .mint_delegated(
+                &root_read,
+                server,
+                graph,
+                &["datom:transact".to_string()],
+                "leaf-n-2",
+                "2026-01-01T00:00:00Z",
+                Some("2099-01-01T00:00:00Z"),
+            )
+            .unwrap();
+        let ebytes = STANDARD.decode(escalated).unwrap();
+        assert!(kotoba_auth::DelegationChain::from_cbor_chain(&ebytes)
+            .unwrap()
+            .verify_with_aud(graph, "datom:transact", server)
+            .is_err());
     }
 
     #[test]

--- a/crates/kotoba-wasm/web/.gitignore
+++ b/crates/kotoba-wasm/web/.gitignore
@@ -1,3 +1,7 @@
-
-# ClojureScript ESM build output (shadow-cljs release web)
-cljs-out/
+# generated browser build artifacts (wasm-pack + shadow-cljs ESM)
+/pkg/
+/pkg-node/
+/cljs-out/
+*.png
+# clojure tool caches for the e2e runner
+browser-e2e/.cpcache/

--- a/crates/kotoba-wasm/web/browser-e2e/deps.edn
+++ b/crates/kotoba-wasm/web/browser-e2e/deps.edn
@@ -1,0 +1,9 @@
+{:paths ["."]
+ :deps  {org.clojure/clojure  {:mvn/version "1.12.0"}
+         ;; the new com-junkawasaki/playwright-clj wrapper (local)
+         com-junkawasaki/playwright-clj
+         {:local/root "../../../../../playwright-clj"}}
+ :aliases
+ {:run       {:main-opts ["-m" "office-browser-test"]}
+  :fullstack {:main-opts ["-m" "office-fullstack-test"]}
+  :editor    {:main-opts ["-m" "office-editor-test"]}}}

--- a/crates/kotoba-wasm/web/browser-e2e/office_browser_test.clj
+++ b/crates/kotoba-wasm/web/browser-e2e/office_browser_test.clj
@@ -1,0 +1,86 @@
+(ns office-browser-test
+  "Runs the kotoba office/CACAO flow in a REAL browser (Chromium) via playwright-clj.
+   Proves the browser (web-target) WASM works end to end: sovereign identity,
+   client-side encryption, CACAO mint, and depth-2 team delegation — in a genuine
+   secure-context page (so crypto.subtle / Service Worker are available).
+
+   Serve the web dir on localhost first; pass its URL via KOTOBA_WEB_URL.
+     (python3 -m http.server in ../  →) KOTOBA_WEB_URL=http://localhost:8123 clojure -M:run"
+  (:require [playwright-clj.core :as pw]))
+
+(def office-flow-js
+  "() => {
+     const N = window.KotobaNode;
+     const acct = new N(); acct.useIdentity('07'.repeat(32));
+     const account = acct.accountDid();
+     const graph = acct.privateGraphId();
+     const env = acct.encrypt('\\u4f1a\\u54e1\\u756a\\u53f7 12345');
+     const back = acct.decrypt(env);
+     const cacao = acct.mintCacao('did:key:zSrv', graph, ['datom:transact','tx:create'], 'n1','2026-01-01T00:00:00Z','2099-01-01T00:00:00Z');
+     const org = new N(); org.useIdentity('b1'.repeat(32));
+     const mem = new N(); mem.useIdentity('c2'.repeat(32));
+     const orgGraph = org.privateGraphId();
+     const root  = org.mintCacao(mem.accountDid(), orgGraph, ['datom:transact','tx:create'],'r1','2026-01-01T00:00:00Z','2099-01-01T00:00:00Z');
+     const chain = mem.mintDelegated(root, 'did:key:zSrv', orgGraph, ['datom:transact','tx:create'],'l1','2026-01-01T00:00:00Z','2099-01-01T00:00:00Z');
+     return {
+       account, graphLen: graph.length,
+       encOk: env.startsWith('signal:v1:'), decryptOk: back === '\\u4f1a\\u54e1\\u756a\\u53f7 12345',
+       leak: env.includes('12345'),
+       cacaoLen: cacao.length, chainLen: chain.length,
+       secure: window.isSecureContext, subtle: !!(crypto && crypto.subtle), sw: ('serviceWorker' in navigator)
+     };
+   }")
+
+(defn -main [& _]
+  (let [url   (or (System/getenv "KOTOBA_WEB_URL") "http://localhost:8123")
+        fails (atom 0)
+        check (fn [n c] (if c (println "  ok  " n)
+                            (do (swap! fails inc) (println "  FAIL" n))))]
+    (pw/with-page [page {:headless true}]
+      (let [logs (pw/capture-console page)]
+        (pw/goto page (str url "/office_harness.html") {:wait-until "load"})
+        (pw/wait-for-fn page "() => window.__kotobaReady === true || window.__kotobaError"
+                        {:timeout 20000})
+        (check "wasm initialised (no init error)"
+               (nil? (pw/eval-js page "() => window.__kotobaError || null")))
+        (let [r (pw/eval-js page office-flow-js)]
+          (check "real-browser secure context" (true? (get r "secure")))
+          (check "crypto.subtle available (secure ctx)" (true? (get r "subtle")))
+          (check "serviceWorker API present" (true? (get r "sw")))
+          (check "accountDid is did:key:z6Mk"
+                 (clojure.string/starts-with? (str (get r "account")) "did:key:z6Mk"))
+          (check "privateGraphId derived" (pos? (long (get r "graphLen"))))
+          (check "body encrypted to signal:v1:" (true? (get r "encOk")))
+          (check "plaintext not in ciphertext" (false? (get r "leak")))
+          (check "decrypt round-trips" (true? (get r "decryptOk")))
+          (check "mintCacao produced a CACAO" (pos? (long (get r "cacaoLen"))))
+          (check "mintDelegated produced a depth-2 chain"
+                 (> (long (get r "chainLen")) (long (get r "cacaoLen")))))
+        ;; kotoba passkey identity unlock (doc b): enroll wraps a fresh Ed25519 seed
+        ;; under the passkey's WebAuthn-PRF secret; unlock on a FRESH node recovers the
+        ;; SAME account. Driven on a CDP virtual authenticator (ctap2 + PRF).
+        (pw/add-virtual-authenticator page)
+        (let [r (pw/eval-js page
+                  "async () => {
+                     const k = window.kotoba;
+                     const n1 = new window.KotobaNode();
+                     const enrolled = await k.enrollPasskey(n1, 'localhost', 'alice');
+                     // a brand-new node (fresh 'device/session') recovers via the passkey
+                     const n2 = new window.KotobaNode();
+                     const recovered = await k.unlockPasskey(n2, 'localhost');
+                     // an unrelated random identity must differ
+                     const n3 = new window.KotobaNode(); n3.generateIdentity();
+                     return { enrolled, recovered, random: n3.accountDid(),
+                              flag: k.passkeyEnrolled() };
+                   }")]
+          (check "passkey PRF unlock recovers the SAME account"
+                 (and (clojure.string/starts-with? (str (get r "enrolled")) "did:key:z6Mk")
+                      (= (get r "enrolled") (get r "recovered"))))
+          (check "recovered identity differs from a random one"
+                 (not= (get r "enrolled") (get r "random")))
+          (check "passkeyEnrolled flag set" (true? (get r "flag"))))
+        (pw/screenshot page "office_harness.png")
+        (check "console shows harness ready"
+               (some #(re-find #"kotoba wasm ready" (:text %)) @logs))))
+    (println (if (zero? @fails) "\nALL OK" (format "\n%d FAILURE(S)" @fails)))
+    (System/exit (if (zero? @fails) 0 1))))

--- a/crates/kotoba-wasm/web/browser-e2e/office_editor_test.clj
+++ b/crates/kotoba-wasm/web/browser-e2e/office_editor_test.clj
@@ -1,0 +1,68 @@
+(ns office-editor-test
+  "Production-shaped E2E: the Hiccup CLJS editor served SAME-ORIGIN by `kotoba serve`
+   (KOTOBA_STATIC_DIR) — no CORS, no --disable-web-security. Drives the real UI via
+   playwright-clj:
+     1. first load → passkey ENROLL → sovereign identity
+     2. edit title/body → 保存+同期 → encrypted, synced same-origin
+     3. RELOAD → passkey UNLOCK → pull → content restored
+     4. OFFLINE edit → queued (Service-Worker-style sync queue) → RECONNECT → auto-flush
+   One server (KOTOBA_API_URL) serves both the app and /xrpc."
+  (:require [playwright-clj.core :as pw]
+            [clojure.string :as str]))
+
+(defn -main [& _]
+  (let [base  (or (System/getenv "KOTOBA_API_URL") "http://localhost:8099")
+        url   (str base "/editor.html")
+        fails (atom 0)
+        check (fn [n c] (if c (println "  ok  " n)
+                            (do (swap! fails inc) (println "  FAIL" n))))]
+    (pw/with-page [page {:headless true}]            ; NO --disable-web-security
+      (pw/add-virtual-authenticator page)            ; passkey (ctap2 + PRF)
+      (pw/capture-console page)
+      ;; 1. first load → passkey enroll
+      (pw/goto page url {:wait-until "load"})
+      (pw/wait-for-fn page "() => window.__editorReady === true || window.__editorError"
+                      {:timeout 25000})
+      (check "editor booted same-origin (no error)"
+             (nil? (pw/eval-js page "() => window.__editorError || null")))
+      (check "passkey enrolled a sovereign account"
+             (str/starts-with? (str (pw/eval-js page "() => document.getElementById('account').textContent"))
+                               "did:key:z6Mk"))
+      ;; 2. edit + save + sync (same-origin)
+      (pw/fill page "#title" "四半期メモ")
+      (pw/fill page "#body" "本文は端末で暗号化される")
+      (pw/click page "#save")
+      (pw/wait-for-fn page "() => document.getElementById('sync').textContent.includes('synced')"
+                      {:timeout 30000 :polling 250})
+      (check "save synced same-origin"
+             (str/includes? (str (pw/eval-js page "() => document.getElementById('sync').textContent")) "synced"))
+      ;; 3. reload → passkey unlock → pull restores content
+      (pw/goto page url {:wait-until "load"})
+      (pw/wait-for-fn page "() => window.__editorReady === true" {:timeout 25000})
+      (pw/wait-for-fn page "() => document.getElementById('title').value === '四半期メモ'" {:timeout 30000 :polling 250})
+      (check "reload → passkey unlock → pull restored title"
+             (= "四半期メモ" (pw/eval-js page "() => document.getElementById('title').value")))
+      (check "pulled body decrypted client-side"
+             (= "本文は端末で暗号化される" (pw/eval-js page "() => document.getElementById('body').value")))
+      ;; 4. offline edit → queued → reconnect → auto-flush
+      (pw/set-offline page true)
+      (pw/fill page "#body" "オフライン編集")
+      (pw/click page "#save")
+      (pw/wait-for-fn page "() => document.getElementById('sync').textContent.includes('pending 1')"
+                      {:timeout 30000 :polling 250})
+      (check "offline edit is queued (pending 1)"
+             (str/includes? (str (pw/eval-js page "() => document.getElementById('sync').textContent")) "pending 1"))
+      (pw/set-offline page false)                    ; fires 'online' → editor auto-flushes
+      (pw/wait-for-fn page "() => document.getElementById('sync').textContent.includes('pending 0')"
+                      {:timeout 30000 :polling 250})
+      (check "reconnect auto-flushed the queue (pending 0)"
+             (str/includes? (str (pw/eval-js page "() => document.getElementById('sync').textContent")) "pending 0"))
+      ;; 5. final reload proves the offline edit reached the server
+      (pw/goto page url {:wait-until "load"})
+      (pw/wait-for-fn page "() => window.__editorReady === true" {:timeout 25000})
+      (pw/wait-for-fn page "() => document.getElementById('body').value === 'オフライン編集'" {:timeout 30000 :polling 250})
+      (check "offline edit persisted to server after reconnect"
+             (= "オフライン編集" (pw/eval-js page "() => document.getElementById('body').value")))
+      (pw/screenshot page "office_editor.png"))
+    (println (if (zero? @fails) "\nALL OK" (format "\n%d FAILURE(S)" @fails)))
+    (System/exit (if (zero? @fails) 0 1))))

--- a/crates/kotoba-wasm/web/browser-e2e/office_fullstack_test.clj
+++ b/crates/kotoba-wasm/web/browser-e2e/office_fullstack_test.clj
@@ -1,0 +1,51 @@
+(ns office-fullstack-test
+  "FULL STACK: real browser → the REAL kotoba office CLJS fns (:advanced ESM) →
+   real `kotoba serve` over HTTP. Exercises encrypt-doc → store-doc! → sync-doc!
+   → pull-doc end to end (sovereign encryption + CACAO sync + read-back + decrypt +
+   :node/lid reconstruction), all in genuine Chromium. This is the definitive check
+   that the office cljs layer survives advanced compilation in a real browser.
+
+   Needs TWO servers:
+     KOTOBA_WEB_URL — static harness (python3 -m http.server, localhost = secure ctx)
+     KOTOBA_API_URL — `kotoba serve` XRPC endpoint
+   The browser runs cross-origin (harness:PORT → api:PORT), so we launch with
+   --disable-web-security (a TEST-ONLY flag; production serves app + API same-origin)."
+  (:require [playwright-clj.core :as pw]
+            [clojure.string :as str]))
+
+(defn -main [& _]
+  (let [web   (or (System/getenv "KOTOBA_WEB_URL") "http://localhost:8128")
+        api   (or (System/getenv "KOTOBA_API_URL") "http://localhost:8099")
+        fails (atom 0)
+        check (fn [n c] (if c (println "  ok  " n)
+                            (do (swap! fails inc) (println "  FAIL" n))))]
+    (pw/with-page [page {:headless true
+                         :args ["--disable-web-security"
+                                "--disable-features=IsolateOrigins,site-per-process"]}]
+      (let [logs (pw/capture-console page)]
+        (pw/goto page (str web "/office_harness.html") {:wait-until "load"})
+        (pw/wait-for-fn page "() => window.__kotobaReady === true || window.__kotobaError"
+                        {:timeout 20000})
+        (check "wasm + cljs ESM loaded"
+               (nil? (pw/eval-js page "() => window.__kotobaError || null")))
+        (let [r (pw/eval-js page
+                  "async (api) => {
+                     const n = new window.KotobaNode();
+                     n.useIdentity('07'.repeat(32));
+                     try { return await window.kotoba.officeRoundtrip(n, api); }
+                     catch (e) { return { error: String(e), stack: (e && e.stack) || '' }; }
+                   }"
+                  api)]
+          (when (get r "error")
+            (println "    roundtrip error:" (get r "error"))
+            (println "    stack:" (get r "stack")))
+          (check "office round-trip synced to server" (true? (get r "synced")))
+          (check "title round-trips (structure)" (= "Q3 戦略メモ" (get r "title")))
+          (check "encrypted body round-trips + decrypts"
+                 (= "原材料費が上昇し…" (get r "text")))
+          (check "full doc reconstructs (encrypt→sync→pull→decrypt→:node/lid)"
+                 (true? (get r "match"))))
+        (check "no browser console errors"
+               (not-any? #(= "error" (:type %)) @logs))))
+    (println (if (zero? @fails) "\nALL OK" (format "\n%d FAILURE(S)" @fails)))
+    (System/exit (if (zero? @fails) 0 1))))

--- a/crates/kotoba-wasm/web/cljs/shadow-cljs.edn
+++ b/crates/kotoba-wasm/web/cljs/shadow-cljs.edn
@@ -27,4 +27,25 @@
                hydrateFromIdbBlocks kotoba.blocks/hydrate-from-idb-blocks
                getSnapshot     kotoba.idb/get-snapshot
                putSnapshot     kotoba.idb/put-snapshot
-               publish         kotoba.write/publish!}}}}}}
+               publish         kotoba.write/publish!
+               ;; org-first office layer (docs/gftd-office)
+               encryptDocument kotoba.office/encrypt-doc
+               officeRoundtrip kotoba.office/office-roundtrip!
+               storeDocument   kotoba.office/store-doc!
+               loadDocument    kotoba.office/load-doc
+               syncDocument    kotoba.office/sync-doc!
+               syncDocumentDelegated kotoba.office/sync-doc-delegated!
+               pullDocument    kotoba.office/pull-doc
+               discoverOperatorDid kotoba.office/discover-operator-did
+               storeOrg        kotoba.office/store-org!
+               storeGrant      kotoba.office/store-grant!
+               ;; membership grant -> CACAO bridge (doc b/d)
+               mintCacaoViaNode kotoba.cacao/mint-cacao!
+               mintDelegated    kotoba.cacao/mint-delegated!
+               grantToCacaoB64  kotoba.cacao/sign-cacao->b64
+               ;; passkey (WebAuthn PRF) identity unlock (doc b)
+               enrollPasskey    kotoba.passkey/enroll!
+               unlockPasskey    kotoba.passkey/unlock!
+               passkeyEnrolled  kotoba.passkey/enrolled?
+               ;; editor UI entry (syncq is used in-CLJS, no ESM export needed)
+               initEditor       kotoba.editor/init!}}}}}}

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/cacao.cljc
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/cacao.cljc
@@ -1,0 +1,158 @@
+(ns kotoba.cacao
+  "Bridge a membership grant (access-DAG datom, kotoba.office) into a CACAO that
+   kotoba's server already verifies (kotoba-auth DelegationChain::verify /
+   datomic_transact). See docs/gftd-office/b-webauthn-cacao-adapter.md and
+   d-did-identity-layer.md.
+
+   PURE (.cljc, bb-testable): grant -> CacaoPayload map, capability/resource mapping,
+   and a byte-exact reproduction of kotoba-auth cacao.rs `siwe_message()` (the string
+   that gets Ed25519-signed).
+
+   CLJS: the wasm node now exposes native CACAO minting — `KotobaNode.mintCacao`
+   (kotoba-wasm WriteCrypto::mint_cacao) reuses kotoba-auth's exact Cacao type +
+   did:key + siwe_message, so the bytes verify byte-identically under the server's
+   DelegationChain::verify (proven by cargo test -p kotoba-wasm). Prefer `mint-cacao!`.
+   `sign-cacao->b64` (INJECTED Ed25519 + dag-cbor, e.g. @noble/ed25519 + cbor-x)
+   remains as a portable fallback that doesn't require the wasm identity.
+
+   Capability tokens are the DATOMIC ones (kotoba-auth CacaoPayload::OP_*):
+   datom:read / datom:transact / tx:create — NOT the kotoba-graph quad:* tokens."
+  (:require [clojure.string :as str]))
+
+;; ===========================================================================
+;; grant capability -> CACAO operation token + resources
+;; ===========================================================================
+
+(def cap->op
+  {:cap/read     "datom:read"
+   :cap/transact "datom:transact"
+   :cap/admin    "tx:create"})
+
+(defn grant->resources
+  "[:kotoba://op/{op} :kotoba://graph/{scope}] for a grant {:cap :scope}."
+  [{:keys [cap scope]}]
+  [(str "kotoba://op/" (cap->op cap))
+   (str "kotoba://graph/" scope)])
+
+;; ===========================================================================
+;; CacaoPayload (clojure-side keys; wire renames iat/exp applied at CBOR time)
+;; ===========================================================================
+
+(defn grant->payload
+  "Build a CacaoPayload map from a grant + opts.
+   opts: :iss  (REQUIRED — signing DID = the authority; for an account writing its
+                own graph this is the account/owner DID; for member→server use a
+                depth-2 chain, a follow-up)
+         :aud  (REQUIRED — server/operator DID or URI)
+         :nonce :issued-at :expiry  (REQUIRED for replay-safety / temporal scope)
+         :domain (default \"gftd.office\") :version (default \"1\") :statement."
+  [grant {:keys [iss aud nonce issued-at expiry domain version statement]
+          :or {domain "gftd.office" version "1"}}]
+  {:iss        iss
+   :aud        aud
+   :issued-at  issued-at
+   :expiry     expiry
+   :nonce      nonce
+   :domain     domain
+   :statement  statement
+   :version    version
+   :resources  (grant->resources grant)})
+
+;; ===========================================================================
+;; siwe_message — byte-exact mirror of kotoba-auth cacao.rs::siwe_message()
+;; ===========================================================================
+
+(defn- iss-address [iss] (last (str/split iss #":")))
+
+(defn- iss-chain-id [iss]
+  (if (str/starts-with? iss "did:key:")
+    "1"
+    (let [segs (str/split iss #":")]
+      (if (>= (count segs) 2) (nth segs (- (count segs) 2)) "1"))))
+
+(defn siwe-message
+  "Reproduce the exact plaintext kotoba-auth signs. Lines joined with '\\n'."
+  [{:keys [iss aud issued-at expiry nonce domain statement version resources]}]
+  (->> (concat
+        [(str domain " wants you to sign in with your Ethereum account:")
+         (iss-address iss)
+         ""]
+        (when statement [statement ""])
+        [(str "URI: " aud)
+         (str "Version: " version)
+         (str "Chain ID: " (iss-chain-id iss))
+         (str "Nonce: " nonce)
+         (str "Issued At: " issued-at)]
+        (when expiry [(str "Expiration Time: " expiry)])
+        (when (seq resources)
+          (cons "Resources:" (map #(str "- " %) resources))))
+       (str/join "\n")))
+
+;; ===========================================================================
+;; wire object (CBOR-ready): clojure payload -> {h,p,s} with iat/exp renames
+;; ===========================================================================
+
+(defn ->wire
+  "Assemble the {h,p,s} object kotoba-auth deserializes (ciborium). `sig-b64` is the
+   base64url-no-pad Ed25519 signature over (siwe-message payload); pass nil to stage."
+  [payload sig-b64]
+  {:h {:t "eip4361"}
+   :p (cond-> {:iss       (:iss payload)
+               :aud       (:aud payload)
+               :iat       (:issued-at payload)
+               :nonce     (:nonce payload)
+               :domain    (:domain payload)
+               :version   (:version payload)
+               :resources (:resources payload)}
+        (:expiry payload)    (assoc :exp (:expiry payload))
+        (:statement payload) (assoc :statement (:statement payload)))
+   :s {:t "EdDSA" :s (or sig-b64 "")}})
+
+;; ===========================================================================
+;; CLJS-only: sign + CBOR-encode -> cacao_b64
+;; ===========================================================================
+
+#?(:cljs
+   (do
+     (def write-caps ["datom:transact" "tx:create"])  ; server verifies BOTH for a write
+     (def read-caps  ["datom:read"])
+
+     (defn mint-cacao!
+       "Mint a server-verifiable CACAO via the wasm node (KotobaNode.mintCacao).
+        Requires the node identity (useIdentity/generateIdentity).
+          caps:  op tokens, e.g. write-caps / read-caps
+          scope: graph CID (write) or \"private/{account-did}\" (private read)
+          opts:  {:aud :nonce :issued-at :expiry}.
+        Returns the base64 cacao_b64."
+       [^js node scope caps {:keys [aud nonce issued-at expiry]}]
+       (.mintCacao node aud scope (clj->js caps) nonce issued-at expiry))
+
+     (defn mint-delegated!
+       "Build a depth-2 chain as the delegate (member) for team sharing.
+        root-grant-b64: a CACAO the OWNER minted via
+          (mint-cacao! owner-node org-graph write-caps {:aud member-did …}).
+        scope: the OWNER's graph CID; caps ⊆ root's. opts {:aud(server) :nonce …}.
+        Returns the base64 [root,leaf] chain for cacao_b64."
+       [^js node root-grant-b64 scope caps {:keys [aud nonce issued-at expiry]}]
+       (.mintDelegated node root-grant-b64 aud scope (clj->js caps) nonce issued-at expiry))
+
+     (defn sign-cacao->b64
+       "grant + opts -> base64(dag-cbor(Cacao)) for the datomic.transact cacao_b64 field.
+        Injected fns (kotoba-auth has no wasm CACAO export yet):
+          :sign-fn  (Uint8Array msg) -> Uint8Array(64)   Ed25519 over UTF-8 siwe bytes
+          :sig->b64url (Uint8Array)  -> string           base64url-no-pad
+          :cbor-encode (js-obj)      -> Uint8Array        dag-cbor
+          :b64-encode  (Uint8Array)  -> string           base64-standard
+        (e.g. @noble/ed25519 + cbor-x + js btoa-helpers, or a future wasm-bindgen API)."
+       [grant {:keys [sign-fn sig->b64url cbor-encode b64-encode] :as opts}]
+       (let [payload (grant->payload grant opts)
+             msg     (siwe-message payload)
+             bytes   (.encode (js/TextEncoder.) msg)
+             sig     (sign-fn bytes)
+             sig-b64 (sig->b64url sig)
+             wire    (clj->js (->wire payload sig-b64))]
+         (b64-encode (cbor-encode wire))))
+
+     (def ^:export mintCacao      mint-cacao!)
+     (def ^:export mintDelegated  mint-delegated!)
+     (def ^:export grantToCacaoB64 sign-cacao->b64)))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/editor.cljs
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/editor.cljs
@@ -1,0 +1,91 @@
+(ns kotoba.editor
+  "Minimal sovereign office editor (docs/gftd-office), UI written in **Hiccup** data
+   (kotoba.hiccup, no React). Wires the DOM to the office layer: passkey unlock →
+   pull latest (or local) → edit → save (encrypt-doc + store-doc! local-first, then
+   enqueue + flush to the server). Re-syncs the offline queue when connectivity
+   returns. Same-origin (remote = \"\")."
+  (:require [kotoba.office :as office]
+            [kotoba.passkey :as passkey]
+            [kotoba.syncq :as syncq]
+            [kotoba.hiccup :as h]))
+
+(defn- el [id] (js/document.getElementById id))
+(defn- getv [id] (let [e (el id)] (if e (.-value e) "")))
+(defn- setv! [id v] (when-let [e (el id)] (set! (.-value e) (or v ""))))
+(defn- sett! [id v] (when-let [e (el id)] (set! (.-textContent e) v)))
+
+(defn- read-model []
+  {:id "doc1" :kind :doc/document :title (getv "title") :owner-org "self"
+   :created-at (js/Date.now)
+   :blocks [{:id "b0" :kind :block/paragraph :text (getv "body") :order "a0"}]})
+
+(defn- render! [model]
+  (setv! "title" (:title model))
+  (setv! "body" (get-in model [:blocks 0 :text])))
+
+(defn- save! [^js node remote]
+  ;; local-first + sovereign: encrypt, store locally, build the SIGNED request now
+  ;; (passkey is unlocked here), enqueue it to IndexedDB, then let the Service Worker
+  ;; deliver it (immediately if online, on Background Sync if offline/closed).
+  (let [enc (office/encrypt-doc node (read-model))]
+    (-> (office/store-doc! node enc)
+        (.then (fn [_] (office/prepare-sync-request node enc {:remote remote})))
+        (.then (fn [req] (syncq/enqueue! req)))
+        (.then (fn [_]
+                 (syncq/register-bg-sync!)
+                 (syncq/nudge-sw!)
+                 (-> (syncq/pending) (.then (fn [p] (sett! "sync" (str "queued · pending " p))))))))))
+
+(defn- load! [^js node remote]
+  (-> (office/pull-doc node {:remote remote})
+      (.then (fn [m] (render! (if (:title m) m {})) "server"))
+      (.catch (fn [_]
+                (render! (try (office/load-doc node "doc1") (catch :default _ {})))
+                "local"))))
+
+(defn- view
+  "The editor UI as Hiccup data."
+  [^js node remote]
+  [:div
+   [:h1 "gftd office — sovereign editor "
+    [:span.meta "passkey-unlocked · client-encrypted · same-origin sync"]]
+   [:div.meta "account: " [:span#account "—"]]
+   [:input#title {:placeholder "タイトル"}]
+   [:textarea#body {:placeholder "本文（端末で暗号化され、サーバには暗号文のみ同期）"}]
+   [:div.bar
+    [:button#save {:onclick (fn [_] (save! node remote))} "保存 + 同期"]
+    [:span#status "booting…"]
+    [:span#sync "—"]]])
+
+(defn- register-sw! []
+  ;; Register the Background-Sync SW + reflect its drain reports in the UI.
+  (when-let [swc (.-serviceWorker js/navigator)]
+    (.addEventListener swc "message"
+      (fn [^js e]
+        (let [d (.-data e)]
+          (when (= "office-synced" (.-type d))
+            (sett! "sync" (str "synced " (.-synced d) " · pending " (.-remaining d)))))))
+    (.register swc "/office-sw.js")))
+
+(defn init!
+  "Boot the editor on `node`: render the Hiccup UI into #app, register the
+   Background-Sync SW, passkey unlock/enroll → load → drain the queue. The SW owns
+   draining (works tab-closed); the page enqueues + nudges. Returns Promise<true>."
+  [^js node]
+  (let [remote "" rp (.-hostname js/location)]
+    (h/mount! "app" (view node remote))
+    (register-sw!)
+    (sett! "status" "unlocking…")
+    (-> (if (passkey/enrolled?)
+          (passkey/unlock! node rp)
+          (passkey/enroll! node rp "owner"))
+        (.then (fn [did]
+                 (sett! "account" did)
+                 (.addEventListener js/window "online" (fn [_] (syncq/nudge-sw!)))
+                 (load! node remote)))
+        (.then (fn [_]
+                 (when (.-onLine js/navigator) (syncq/nudge-sw!))
+                 (sett! "status" "ready")
+                 true)))))
+
+(def ^:export initEditor init!)

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/hiccup.cljs
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/hiccup.cljs
@@ -1,0 +1,61 @@
+(ns kotoba.hiccup
+  "Tiny dependency-free hiccup → DOM renderer (no React/Reagent). Enough for the
+   sovereign editor UI to be written as Clojure data:
+
+     [:input#title.big {:placeholder \"…\" :value v :oninput f} children…]
+
+   - tag shorthand: :tag#id.class1.class2
+   - attrs map (optional 2nd element): :value sets the property; :onX adds an event
+     listener for event X (e.g. :onclick → \"click\"); others → setAttribute
+   - children: strings/numbers, nested vectors, seqs, nils (skipped)."
+  (:require [clojure.string :as str]))
+
+(defn- parse-tag [t]
+  (let [s (name t)
+        dot (str/split s #"\.")
+        tag+id (first dot)
+        classes (rest dot)
+        hash (str/split tag+id #"#")]
+    [(first hash) (second hash) (vec classes)]))
+
+(declare ->dom)
+
+(defn- append-child! [^js node child]
+  (cond
+    (nil? child) nil
+    (seq? child) (doseq [c child] (append-child! node c))
+    :else (.appendChild node (->dom child))))
+
+(defn ->dom
+  "Render a hiccup form to a DOM Node."
+  [form]
+  (cond
+    (string? form) (js/document.createTextNode form)
+    (number? form) (js/document.createTextNode (str form))
+    (nil? form)    (js/document.createTextNode "")
+    (vector? form)
+    (let [[t & more] form
+          [tag id classes] (parse-tag t)
+          [attrs children] (if (map? (first more)) [(first more) (rest more)] [nil more])
+          node (js/document.createElement tag)]
+      (when id (set! (.-id node) id))
+      (when (seq classes) (set! (.-className node) (str/join " " classes)))
+      (doseq [[k v] attrs]
+        (let [kn (name k)]
+          (cond
+            (nil? v) nil
+            (and (fn? v) (str/starts-with? kn "on"))
+            (.addEventListener node (subs kn 2) v)
+            (= :value k) (set! (.-value node) (or v ""))
+            :else (.setAttribute node kn (str v)))))
+      (doseq [c children] (append-child! node c))
+      node)
+    :else (js/document.createTextNode (str form))))
+
+(defn mount!
+  "Replace the contents of `target` (id string or Node) with the rendered hiccup."
+  [target form]
+  (let [t (if (string? target) (js/document.getElementById target) target)]
+    (set! (.-innerHTML t) "")
+    (.appendChild t (->dom form))
+    t))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/office.cljc
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/office.cljc
@@ -1,0 +1,499 @@
+(ns kotoba.office
+  "Organization-first office documents on the browser kotoba node.
+
+   Two layers:
+   - PURE (.cljc, runs under babashka + cljs): model <-> kotoba transact batch
+     ([{e,a,v_edn}]), with v_edn encoded exactly as kotoba's parse_edn_scalar expects
+     (kotoba-wasm/src/lib.rs). Org-first + W3C-DID + access-DAG schema (see
+     docs/gftd-office/d-did-identity-layer.md).
+   - CLJS-only (#?(:cljs)): drives the wasm KotobaNode (assert/transact/commit/datomicQ)
+     + IndexedDB snapshot persistence. Wired into shadow-cljs.edn :exports.
+
+   Entity ids here are caller-supplied LOGICAL ids; kotoba content-hashes `e` to a CID.
+   :block/text is encrypted at write time via assertEncrypted (signal:v1:) in real use;
+   this layer passes it as a plain value (encryption is a separate increment)."
+  (:require [clojure.string :as str]
+            #?(:clj [cheshire.core :as json])))
+
+;; ===========================================================================
+;; schema registry (value types drive v_edn encode/decode)
+;; ===========================================================================
+
+(def schema
+  {;; org / account (account = org node)
+   :org/did          {:db/valueType :did     :db/cardinality :one :db/unique :identity}
+   :org/kind         {:db/valueType :keyword :db/cardinality :one}
+   :org/display-name {:db/valueType :string  :db/cardinality :one}
+   :org/parent       {:db/valueType :ref     :db/cardinality :one}  ; ownership tree = DID controller
+   :org/data-graph   {:db/valueType :string  :db/cardinality :one}  ; DID service endpoint
+   :org/created-at   {:db/valueType :long    :db/cardinality :one}
+   ;; W3C DID verification method
+   :vm/of                   {:db/valueType :ref     :db/cardinality :one}
+   :vm/vid                  {:db/valueType :string  :db/cardinality :one :db/unique :identity}
+   :vm/type                 {:db/valueType :keyword :db/cardinality :one}
+   :vm/public-key-multibase {:db/valueType :string  :db/cardinality :one}
+   :vm/rel                  {:db/valueType :keyword :db/cardinality :many}
+   ;; membership grant (access DAG ~ CACAO)
+   :grant/org        {:db/valueType :ref     :db/cardinality :one}
+   :grant/subject    {:db/valueType :did     :db/cardinality :one}
+   :grant/cap        {:db/valueType :keyword :db/cardinality :one}
+   :grant/scope      {:db/valueType :string  :db/cardinality :one}
+   :grant/role       {:db/valueType :keyword :db/cardinality :one}
+   :grant/issued-at  {:db/valueType :long    :db/cardinality :one}
+   :grant/expires-at {:db/valueType :long    :db/cardinality :one}
+   ;; logical id (survives the server's content-addressing: the entity `e` becomes a
+   ;; CID server-side, but :node/lid keeps the caller's stable id as a value, so
+   ;; tree reconstruction (:block/parent references a parent's lid) works on read-back)
+   :node/lid         {:db/valueType :string  :db/cardinality :one}
+   ;; document
+   :doc/kind         {:db/valueType :keyword :db/cardinality :one}
+   :doc/title        {:db/valueType :string  :db/cardinality :one}
+   :doc/owner-org    {:db/valueType :ref     :db/cardinality :one}
+   :doc/created-at   {:db/valueType :long    :db/cardinality :one}
+   ;; block (tree under doc)
+   :block/kind    {:db/valueType :keyword :db/cardinality :one}
+   :block/text    {:db/valueType :string  :db/cardinality :one :db/encrypted true}
+   :block/order   {:db/valueType :string  :db/cardinality :one}
+   :block/parent  {:db/valueType :ref     :db/cardinality :one}
+   :block/deleted {:db/valueType :boolean :db/cardinality :one}})
+
+(defn value-type [a] (get-in schema [a :db/valueType] :string))
+
+;; ===========================================================================
+;; v_edn codec — matches kotoba-wasm parse_edn_scalar exactly
+;;   "\"s\""  -> JSON string  (string/ref/did)
+;;   :kw      -> keyword (colon stripped on decode)
+;;   123      -> bare literal (long)
+;;   true     -> bare literal (boolean)
+;; ===========================================================================
+
+(defn- json-str [s]
+  #?(:clj  (json/generate-string s)
+     :cljs (js/JSON.stringify s)))
+
+(defn- json-parse [s]
+  #?(:clj  (json/parse-string s)
+     :cljs (js/JSON.parse s)))
+
+(defn encode-value
+  "v -> v_edn string for a kotoba transact datom, per attribute value type."
+  [a v]
+  (case (value-type a)
+    (:string :ref :did) (json-str (str v))
+    :keyword            (str v)            ; keyword prints with leading ':'
+    :long               (str v)
+    :boolean            (str v)
+    (json-str (str v))))
+
+(defn parse-edn-scalar
+  "Mirror of kotoba-wasm parse_edn_scalar: v_edn string -> decoded scalar string.
+   (Real datomicQ already returns this decoded form; used here for round-trip tests.)"
+  [s]
+  (let [s (str/trim s)]
+    (cond
+      (str/starts-with? s "\"") (json-parse s)
+      (str/starts-with? s ":")  (subs s 1)
+      :else s)))
+
+(defn decode-value
+  "decoded-scalar-string (from kotoba) -> typed value, per attribute value type."
+  [a s]
+  (case (value-type a)
+    (:string :ref :did) s
+    :keyword            (keyword s)
+    :long               #?(:clj (Long/parseLong s) :cljs (js/parseInt s 10))
+    :boolean            (= "true" s)
+    s))
+
+;; ===========================================================================
+;; model -> transact batch  ([{:e :a :v_edn}] as Clojure data)
+;; ===========================================================================
+
+(defn- d [e a v] {:e e :a (str a) :v_edn (encode-value a v)})
+
+(defn- block->tx [parent-id {:keys [id kind text order children deleted]}]
+  (into (cond-> [(d id :node/lid id)
+                 (d id :block/kind kind)
+                 (d id :block/parent parent-id)
+                 (d id :block/order order)]
+          (some? text)    (conj (d id :block/text text))
+          (some? deleted) (conj (d id :block/deleted deleted)))
+        (mapcat #(block->tx id %) children)))
+
+(defn doc->tx [{:keys [id kind title owner-org created-at blocks]}]
+  (into [(d id :node/lid id)
+         (d id :doc/kind kind)
+         (d id :doc/title title)
+         (d id :doc/owner-org owner-org)
+         (d id :doc/created-at created-at)]
+        (mapcat #(block->tx id %) blocks)))
+
+(defn org->tx [{:keys [id did kind display-name parent data-graph created-at vms]}]
+  (into (cond-> [(d id :org/did did)
+                 (d id :org/kind kind)
+                 (d id :org/display-name display-name)
+                 (d id :org/data-graph data-graph)
+                 (d id :org/created-at created-at)]
+          (some? parent) (conj (d id :org/parent parent)))
+        (mapcat (fn [{:keys [vid type pk rels]}]
+                  (into [(d vid :vm/of id)
+                         (d vid :vm/vid vid)
+                         (d vid :vm/type type)
+                         (d vid :vm/public-key-multibase pk)]
+                        (map #(d vid :vm/rel %) rels)))
+                vms)))
+
+(defn grant->tx [{:keys [id org subject cap scope role issued-at expires-at]}]
+  (cond-> [(d id :grant/org org)
+           (d id :grant/subject subject)
+           (d id :grant/cap cap)
+           (d id :grant/scope scope)
+           (d id :grant/role role)
+           (d id :grant/issued-at issued-at)]
+    (some? expires-at) (conj (d id :grant/expires-at expires-at))))
+
+(defn tx->json
+  "Serialize a transact batch for KotobaNode.transact / loadDatoms (LOCAL write)."
+  [tx]
+  #?(:clj  (json/generate-string tx)
+     :cljs (js/JSON.stringify (clj->js tx))))
+
+;; ---- server sync form: tx_edn = [[:db/add e a v] ...] (datomic.transact) ----
+;; The v_edn scalar already matches kotoba EDN exactly (string "x" / keyword :kw /
+;; long 123 / bool true), so we reuse it verbatim as the [:db/add] value.
+
+(defn- datom->add [{:keys [e a v_edn]}]
+  (str "[:db/add " (json-str (str e)) " " a " " v_edn "]"))
+
+(defn tx->edn
+  "Render a transact batch ([{:e :a :v_edn}]) as kotoba `tx_edn`: a vector of
+   [:db/add e a v] ops for the server datomic.transact endpoint."
+  [tx]
+  (str "[" (apply str (map datom->add tx)) "]"))
+
+(defn- block-ids [{:keys [id children]}] (into [id] (mapcat block-ids children)))
+(defn- doc-entity-ids [{:keys [id blocks]}] (into [id] (mapcat block-ids blocks)))
+
+(defn doc->tx-edn
+  "Datomic tx_edn for a doc. Prepends `[:db.fn/retractEntity id]` for the doc + every
+   block so a RE-EDIT cleanly REPLACES prior values (office attrs are plain :db/add,
+   so without this a re-saved :block/text would accumulate multiple values and a read
+   could return a stale one). retractEntity on a not-yet-existing entity is a no-op."
+  [model]
+  (str "["
+       (apply str (map (fn [eid] (str "[:db.fn/retractEntity " (json-str eid) "]"))
+                       (doc-entity-ids model)))
+       (apply str (map datom->add (doc->tx model)))
+       "]"))
+
+(defn org->tx-edn   [model] (tx->edn (org->tx model)))
+(defn grant->tx-edn [model] (tx->edn (grant->tx model)))
+
+;; ---- sovereign body encryption (pure tree transform; the actual crypto fn is
+;;      injected so this stays platform-neutral / bb-testable) ----
+(defn- map-block-text [f {:keys [text children] :as block}]
+  (cond-> block
+    (some? text)     (assoc :text (f text))
+    (seq children)   (update :children #(mapv (partial map-block-text f) %))))
+
+(defn map-doc-text
+  "Return the doc with every block :text replaced by (f text). Used to encrypt
+   (f = node.encrypt → signal:v1:) or decrypt (f = node.decrypt) bodies uniformly."
+  [f {:keys [blocks] :as model}]
+  (cond-> model
+    (seq blocks) (assoc :blocks (mapv (partial map-block-text f) blocks))))
+
+;; ===========================================================================
+;; rows -> model   (rows = decoded [e a-str scalar-str] triples from datomicQ)
+;; ===========================================================================
+
+(defn- a->kw [a] (keyword (cond-> a (str/starts-with? a ":") (subs 1))))
+
+(defn- v1 [rows e a]
+  (some (fn [[re ra rv]] (when (and (= re e) (= (a->kw ra) a)) (decode-value a rv))) rows))
+
+(defn- vN [rows e a]
+  (set (keep (fn [[re ra rv]] (when (and (= re e) (= (a->kw ra) a)) (decode-value a rv))) rows)))
+
+(defn rows->doc
+  "Reconstruct the nested doc model from EAV rows. Identity is the logical id
+   (:node/lid), NOT the entity `e` — so this works whether `e` is the caller's
+   string id (local node) or a content-addressed CID (server read-back); parent
+   links (:block/parent → a parent's lid) resolve in lid-space either way."
+  [rows]
+  (let [lid-of (fn [e] (v1 rows e :node/lid))
+        doc-e  (some (fn [[e a]] (when (= (a->kw a) :doc/kind) e)) rows)
+        children-of (fn children-of [parent-lid]
+                      (->> rows
+                           (keep (fn [[e a v]]
+                                   (when (and (= (a->kw a) :block/parent)
+                                              (= (decode-value :block/parent v) parent-lid)) e)))
+                           distinct
+                           (sort-by #(v1 rows % :block/order))
+                           (mapv (fn [e]
+                                   (let [lid  (lid-of e)
+                                         kids (children-of lid)
+                                         txt  (v1 rows e :block/text)
+                                         del  (v1 rows e :block/deleted)]
+                                     (cond-> {:id lid
+                                              :kind  (v1 rows e :block/kind)
+                                              :order (v1 rows e :block/order)}
+                                       (some? txt) (assoc :text txt)
+                                       (some? del) (assoc :deleted del)
+                                       (seq kids)  (assoc :children kids)))))))]
+    {:id         (lid-of doc-e)
+     :kind       (v1 rows doc-e :doc/kind)
+     :title      (v1 rows doc-e :doc/title)
+     :owner-org  (v1 rows doc-e :doc/owner-org)
+     :created-at (v1 rows doc-e :doc/created-at)
+     :blocks     (children-of (lid-of doc-e))}))
+
+(defn rows->org [rows org-id]
+  (let [vm-ids (->> rows
+                    (keep (fn [[e a v]]
+                            (when (and (= (a->kw a) :vm/of)
+                                       (= (decode-value :vm/of v) org-id)) e)))
+                    distinct)
+        vms (mapv (fn [vid] {:vid  vid
+                             :type (v1 rows vid :vm/type)
+                             :pk   (v1 rows vid :vm/public-key-multibase)
+                             :rels (vN rows vid :vm/rel)})
+                  vm-ids)]
+    (cond-> {:id           org-id
+             :did          (v1 rows org-id :org/did)
+             :kind         (v1 rows org-id :org/kind)
+             :display-name (v1 rows org-id :org/display-name)
+             :data-graph   (v1 rows org-id :org/data-graph)
+             :created-at   (v1 rows org-id :org/created-at)
+             :vms          vms}
+      (v1 rows org-id :org/parent) (assoc :parent (v1 rows org-id :org/parent)))))
+
+(defn rows->grant [rows grant-id]
+  (cond-> {:id        grant-id
+           :org       (v1 rows grant-id :grant/org)
+           :subject   (v1 rows grant-id :grant/subject)
+           :cap       (v1 rows grant-id :grant/cap)
+           :scope     (v1 rows grant-id :grant/scope)
+           :role      (v1 rows grant-id :grant/role)
+           :issued-at (v1 rows grant-id :grant/issued-at)}
+    (v1 rows grant-id :grant/expires-at) (assoc :expires-at (v1 rows grant-id :grant/expires-at))))
+
+;; ===========================================================================
+;; CLJS-only: drive the wasm KotobaNode + IndexedDB persistence
+;; ===========================================================================
+
+#?(:cljs
+   (do
+     (defn- transact! [^js node tx]
+       (.transact node (tx->json tx)))
+
+     (defn- persist! [^js node]
+       ;; mirror kotoba.write/kotoba-sw: snapshot -> IndexedDB (durable, offline)
+       (js/Promise.resolve (.snapshot node)))
+
+     ;; wasm-bindgen Option<String> wants `undefined`, not JS `null` (nil). And the
+     ;; server requires a 20-char UTC `…SSZ` issued_at (no millis) + a fresh nonce.
+     (defn- opt-str [v] (if (nil? v) js/undefined v))
+     (defn- now-iso [] (str (.slice (.toISOString (js/Date.)) 0 19) "Z"))
+     (defn- fresh-nonce []
+       (let [a (js/Uint8Array. 16)]
+         (js/crypto.getRandomValues a)
+         (.join (js/Array.from a (fn [b] (str b "-"))) "")))
+
+     (defn encrypt-doc
+       "Return the doc with every block :text replaced by a signal:v1: envelope
+        (node.encrypt) ONCE — so the same ciphertext is used for both the local store
+        and the server sync. Structure (kind/order/parent/title) stays plaintext.
+        Sovereign flow: (let [m (encrypt-doc node model)] (store-doc! node m)
+        (sync-doc! node m {...}))."
+       [^js node model]
+       (map-doc-text (fn [t] (.encrypt node t)) model))
+
+     (defn store-doc!
+       "Write an office document into the node (LOCAL, sovereign) + commit + persist.
+        Pass an encrypt-doc'd model to keep bodies as ciphertext.
+        Returns Promise<#js{root snapshot}>. No network: pure local-first."
+       [^js node model]
+       (transact! node (doc->tx model))
+       (let [root (.commit node)]
+         (-> (persist! node)
+             (.then (fn [snap] #js {:root root :snapshot snap})))))
+
+     ;; ── aud (operator DID) discovery — public key.custodianInfo returns {did} ──
+     (defn discover-operator-did
+       "Fetch the node's operator DID (= CACAO aud) from the public key.custodianInfo
+        endpoint, CACHED in localStorage so offline saves can still mint a CACAO.
+        opts {:remote :fetch-fn}. Returns Promise<did>."
+       [{:keys [remote fetch-fn]}]
+       (let [cached (js/localStorage.getItem "kotoba.operator-did")]
+         (if cached
+           (js/Promise.resolve cached)
+           (let [fetch-fn (or fetch-fn js/fetch)]
+             (-> (fetch-fn (str remote "/xrpc/com.etzhayyim.apps.kotoba.key.custodianInfo"))
+                 (.then (fn [^js r] (.json r)))
+                 (.then (fn [^js j]
+                          (let [d (.-did j)]
+                            (js/localStorage.setItem "kotoba.operator-did" d)
+                            d))))))))
+
+     (defn- resolve-aud [{:keys [operator-did] :as opts}]
+       (if operator-did (js/Promise.resolve operator-did) (discover-operator-did opts)))
+
+     (defn prepare-sync-request
+       "Build the SIGNED transact request for an (encrypted) doc → Promise<#js{url body}>,
+        WITHOUT POSTing — so a Service Worker can deliver it later (offline/background)
+        without re-signing (the SW cannot run WebAuthn). aud auto-discovered (cached)."
+       [^js node enc {:keys [remote nonce issued-at expiry] :as opts}]
+       (-> (resolve-aud opts)
+           (.then (fn [aud]
+                    (let [graph (.privateGraphId node)
+                          cacao (.mintCacao node aud graph
+                                            #js ["datom:transact" "tx:create"]
+                                            (or nonce (fresh-nonce)) (or issued-at (now-iso))
+                                            (opt-str expiry))]
+                      #js {:url  (str remote "/xrpc/com.etzhayyim.apps.kotoba.datomic.transact")
+                           :body (js/JSON.stringify
+                                  #js {:graph graph :tx_edn (doc->tx-edn enc) :cacao_b64 cacao})})))))
+
+
+     (defn- decrypt-row
+       "Decrypt a signal:v1: value with the node identity; pass others through."
+       [^js node v]
+       (if (and (string? v) (str/starts-with? v "signal:v1:")) (.decrypt node v) v))
+
+     (defn pull-doc
+       "Read this account's office document back from the server's PRIVATE graph with
+        a read CACAO (datom:read, scoped to the graph CID — require_datomic_read uses
+        graph.to_multibase()). Reconstructs via :node/lid (server entity ids are CIDs)
+        and decrypts signal:v1: bodies. aud is :operator-did or auto-discovered.
+        opts: :remote (REQUIRED) :operator-did :nonce :issued-at :expiry :fetch-fn.
+        Returns Promise<doc-model>."
+       [^js node {:keys [remote nonce issued-at expiry fetch-fn] :as opts}]
+       (-> (resolve-aud opts)
+           (.then (fn [aud]
+                    (let [fetch-fn (or fetch-fn js/fetch)
+                          graph    (.privateGraphId node)
+                          cacao    (.mintCacao node aud graph #js ["datom:read"]
+                                               (or nonce (fresh-nonce)) (or issued-at (now-iso))
+                                               (opt-str expiry))
+                          body     (js/JSON.stringify
+                                    #js {:graph graph :index "eavt"
+                                         :components_edn #js [] :cacao_b64 cacao})]
+                      (-> (fetch-fn (str remote "/xrpc/com.etzhayyim.apps.kotoba.datomic.datoms")
+                                    #js {:method "POST"
+                                         :headers #js {"content-type" "application/json"}
+                                         :body body})
+                          (.then (fn [^js r]
+                                   (if (.-ok r)
+                                     (.json r)
+                                     (throw (js/Error. (str "datomic.datoms → HTTP " (.-status r)))))))
+                          (.then (fn [^js resp]
+                                   (rows->doc
+                                    (mapv (fn [^js dt]
+                                            [(.-e dt) (.-a dt)
+                                             (decrypt-row node (parse-edn-scalar (.-v_edn dt)))])
+                                          (.-datoms resp)))))))))))
+
+     (defn store-org!  [^js node model] (transact! node (org->tx model))  (.commit node))
+     (defn store-grant! [^js node model] (transact! node (grant->tx model)) (.commit node))
+
+     (defn- all-rows
+       "Fetch e/a/v triples from the local node. NOTE: P0 uses a broad scan;
+        a scoped query (per doc subtree) is a follow-up optimisation."
+       [^js node]
+       (let [res (js/JSON.parse (.datomicQ node "[:find ?e ?a ?v :where [?e ?a ?v]]" "[]"))]
+         (mapv (fn [^js row] [(aget row 0) (aget row 1) (aget row 2)]) res)))
+
+     (defn load-doc
+       "Read back an office document model from the LOCAL node, decrypting signal:v1:
+        bodies."
+       [^js node _doc-id]
+       (rows->doc (mapv (fn [[e a v]] [e a (decrypt-row node v)]) (all-rows node))))
+
+     (defn sync-doc!
+       "Push an office document to the server's PRIVATE graph owned by this account,
+        authenticated with a freshly-minted transact CACAO (doc b). Local-first: call
+        after store-doc! (which already encrypted bodies — the signal:v1: envelopes
+        sync as opaque values). The graph is the account's deterministic private-graph
+        CID; the server auto-registers it Private{owner=account} on first write.
+        aud is :operator-did or auto-discovered. opts: :remote (REQUIRED) :operator-did
+        :nonce :issued-at :expiry :fetch-fn. Returns Promise<response-json>."
+       [^js node model {:keys [remote nonce issued-at expiry fetch-fn] :as opts}]
+       (-> (resolve-aud opts)
+           (.then (fn [aud]
+                    (let [fetch-fn (or fetch-fn js/fetch)
+                          graph    (.privateGraphId node)
+                          cacao    (.mintCacao node aud graph
+                                               #js ["datom:transact" "tx:create"]
+                                               (or nonce (fresh-nonce)) (or issued-at (now-iso))
+                                               (opt-str expiry))
+                          body     (js/JSON.stringify
+                                    #js {:graph graph :tx_edn (doc->tx-edn model) :cacao_b64 cacao})]
+                      (-> (fetch-fn (str remote "/xrpc/com.etzhayyim.apps.kotoba.datomic.transact")
+                                    #js {:method "POST"
+                                         :headers #js {"content-type" "application/json"}
+                                         :body body})
+                          (.then (fn [^js r]
+                                   (if (.-ok r)
+                                     (.json r)
+                                     (throw (js/Error. (str "datomic.transact → HTTP " (.-status r)))))))))))))
+
+     (defn sync-doc-delegated!
+       "Team sharing: a MEMBER pushes a doc to an ORG's private graph via a depth-2
+        delegation chain. The owner first mints a root grant
+          (.mintCacao owner-node member-did org-graph #js[\"datom:transact\" \"tx:create\"] …)
+        and hands `:root-grant` to the member. aud auto-resolved.
+        opts: :remote (REQUIRED) :org-graph (REQUIRED) :root-grant (REQUIRED)
+        :operator-did :nonce :issued-at :expiry :fetch-fn."
+       [^js node model {:keys [remote org-graph root-grant nonce issued-at expiry fetch-fn] :as opts}]
+       (-> (resolve-aud opts)
+           (.then (fn [aud]
+                    (let [fetch-fn (or fetch-fn js/fetch)
+                          cacao    (.mintDelegated node root-grant aud org-graph
+                                                   #js ["datom:transact" "tx:create"]
+                                                   (or nonce (fresh-nonce)) (or issued-at (now-iso))
+                                                   (opt-str expiry))
+                          body     (js/JSON.stringify
+                                    #js {:graph org-graph :tx_edn (doc->tx-edn model) :cacao_b64 cacao})]
+                      (-> (fetch-fn (str remote "/xrpc/com.etzhayyim.apps.kotoba.datomic.transact")
+                                    #js {:method "POST"
+                                         :headers #js {"content-type" "application/json"}
+                                         :body body})
+                          (.then (fn [^js r]
+                                   (if (.-ok r)
+                                     (.json r)
+                                     (throw (js/Error. (str "datomic.transact → HTTP " (.-status r)))))))))))))
+
+     (defn office-roundtrip!
+       "Full browser↔server round-trip exercising the REAL office cljs fns under
+        :advanced: build a doc, encrypt bodies, store locally, sync to the account's
+        private graph, pull it back, reconstruct + decrypt. JS-friendly (string in,
+        JS object out) so a playwright-clj E2E can drive it. Returns
+        Promise<#js{synced, title, text, match}>."
+       [^js node remote]
+       (let [model {:id "doc1" :kind :doc/document :title "Q3 戦略メモ"
+                    :owner-org "self" :created-at 1719000005000
+                    :blocks [{:id "b0" :kind :block/heading :text "概要" :order "a0"}
+                             {:id "b1" :kind :block/paragraph :text "原材料費が上昇し…" :order "a1"
+                              :children [{:id "b1a" :kind :block/paragraph :text "詳細" :order "a0"}]}]}
+             enc (encrypt-doc node model)]
+         (-> (store-doc! node enc)
+             (.then (fn [_] (sync-doc! node enc {:remote remote})))
+             (.then (fn [_] (pull-doc node {:remote remote})))
+             (.then (fn [recovered]
+                      (clj->js {:synced true
+                                :title  (:title recovered)
+                                :text   (get-in recovered [:blocks 1 :text])
+                                :match  (= recovered model)}))))))
+
+     ;; exports referenced from shadow-cljs.edn
+     (def ^:export encryptDocument encrypt-doc)
+     (def ^:export officeRoundtrip office-roundtrip!)
+     (def ^:export storeDocument store-doc!)
+     (def ^:export loadDocument  load-doc)
+     (def ^:export syncDocument  sync-doc!)
+     (def ^:export syncDocumentDelegated sync-doc-delegated!)
+     (def ^:export pullDocument  pull-doc)
+     (def ^:export discoverOperatorDid discover-operator-did)
+     (def ^:export storeOrg      store-org!)
+     (def ^:export storeGrant    store-grant!)))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/office_test.clj
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/office_test.clj
@@ -1,0 +1,141 @@
+(ns kotoba.office-test
+  "Pure (.cljc) verification of the office datom wire format + CACAO bridge.
+   Runs under babashka WITHOUT building wasm:
+     bb --classpath src -e \"(require 'kotoba.office-test)(kotoba.office-test/-main)\"
+   Verifies the kotoba wire contract (v_edn encode/decode mirrors parse_edn_scalar)
+   and the byte-exact siwe_message reproduction."
+  (:require [kotoba.office :as o]
+            [kotoba.cacao :as c]
+            [clojure.test :refer [deftest is run-tests]]))
+
+;; ---- simulate kotoba store+read: tx [{:e :a :v_edn}] -> decoded [e a v] rows ----
+(defn- tx->rows [tx]
+  (mapv (fn [{:keys [e a v_edn]}] [e a (o/parse-edn-scalar v_edn)]) tx))
+
+;; ---- samples (org-first + DID + access-DAG) ----
+(def sample-orgs
+  [{:id "org-root" :did "did:key:zRoot" :kind :org.kind/root
+    :display-name "gftd.ai" :data-graph "g-root" :created-at 1719000000000
+    :vms [{:vid "did:key:zRoot#k1" :type :Ed25519 :pk "zRoot"
+           :rels #{:authentication :capabilityDelegation}}]}
+   {:id "org-alice" :did "did:key:zAlice" :kind :org.kind/account
+    :display-name "Alice" :parent "org-acme" :data-graph "g-alice" :created-at 1719000002000
+    :vms [{:vid "did:key:zAlice#k1" :type :Ed25519 :pk "zAlice"
+           :rels #{:authentication :capabilityInvocation :keyAgreement}}]}])
+
+(def sample-grants
+  [{:id "grant-alice-acme" :org "org-acme" :subject "did:key:zAlice"
+    :cap :cap/transact :scope "g-acme" :role :role/member :issued-at 1719000003000}
+   {:id "grant-alice-beta" :org "org-beta" :subject "did:key:zAlice"
+    :cap :cap/read :scope "g-beta" :role :role/guest
+    :issued-at 1719000004000 :expires-at 1726000000000}])
+
+(def sample-doc
+  {:id "doc1" :kind :doc/document :title "Q3 戦略メモ"
+   :owner-org "org-alice" :created-at 1719000005000
+   :blocks [{:id "b0" :kind :block/heading :text "概要" :order "a0"}
+            {:id "b1" :kind :block/paragraph :text "原材料費が上昇し…" :order "a1"
+             :children [{:id "b1a" :kind :block/paragraph :text "詳細" :order "a0"}]}]})
+
+;; ---- v_edn wire-format contract ----
+(deftest v-edn-encoding-matches-kotoba
+  (is (= "\"hello\""        (o/encode-value :doc/title "hello")))   ; string -> JSON string
+  (is (= ":org.kind/account" (o/encode-value :org/kind :org.kind/account))) ; keyword -> bare ':'
+  (is (= "1719000000000"    (o/encode-value :org/created-at 1719000000000))) ; long -> bare
+  (is (= "true"             (o/encode-value :block/deleted true)))  ; boolean -> bare
+  ;; decode mirrors kotoba parse_edn_scalar
+  (is (= "hello"            (o/decode-value :doc/title (o/parse-edn-scalar (o/encode-value :doc/title "hello")))))
+  (is (= :org.kind/account  (o/decode-value :org/kind (o/parse-edn-scalar (o/encode-value :org/kind :org.kind/account)))))
+  (is (= 1719000000000      (o/decode-value :org/created-at (o/parse-edn-scalar (o/encode-value :org/created-at 1719000000000)))))
+  (is (= true               (o/decode-value :block/deleted (o/parse-edn-scalar (o/encode-value :block/deleted true))))))
+
+(deftest doc-round-trip-through-wire
+  (is (= sample-doc (o/rows->doc (tx->rows (o/doc->tx sample-doc))))))
+
+(deftest server-read-back-reconstructs-via-lid
+  ;; The server content-addresses the entity (e -> CID), losing the caller's logical
+  ;; id. :node/lid + lid-keyed rows->doc must still rebuild the original nested doc.
+  (let [cid  (fn [e] (str "bafy-" e))           ; simulate server CID-ifying the entity
+        rows (mapv (fn [{:keys [e a v_edn]}] [(cid e) a (o/parse-edn-scalar v_edn)])
+                   (o/doc->tx sample-doc))]
+    (is (= sample-doc (o/rows->doc rows)))))
+
+(deftest org-round-trip-through-wire
+  (doseq [org sample-orgs]
+    (is (= org (o/rows->org (tx->rows (o/org->tx org)) (:id org)))
+        (str "org: " (:id org)))))
+
+(deftest grant-round-trip-through-wire
+  (doseq [g sample-grants]
+    (is (= g (o/rows->grant (tx->rows (o/grant->tx g)) (:id g)))
+        (str "grant: " (:id g)))))
+
+;; ---- server sync form (tx_edn for datomic.transact) ----
+(deftest tx-edn-is-datomic-add-ops
+  (let [edn (o/doc->tx-edn sample-doc)]
+    ;; re-edit safety: retractEntity for the doc + every block precedes the adds
+    (is (clojure.string/starts-with? edn "[[:db.fn/retractEntity \"doc1\"]"))
+    (is (clojure.string/includes? edn "[:db.fn/retractEntity \"b0\"]"))
+    (is (clojure.string/includes? edn "[:db.fn/retractEntity \"b1a\"]"))
+    (is (clojure.string/ends-with? edn "]]"))
+    ;; [:db/add e a v]; entity + string values quoted, keywords bare, longs bare
+    (is (clojure.string/includes? edn "[:db/add \"doc1\" :doc/kind :doc/document]"))
+    (is (clojure.string/includes? edn "[:db/add \"doc1\" :doc/title \"Q3 戦略メモ\"]"))
+    (is (clojure.string/includes? edn "[:db/add \"doc1\" :doc/created-at 1719000005000]"))
+    (is (clojure.string/includes? edn "[:db/add \"b0\" :block/parent \"doc1\"]"))))
+
+;; ---- sovereign body transform (encrypt/decrypt are inverse over :text) ----
+(deftest map-doc-text-transforms-only-block-text
+  (let [enc (o/map-doc-text #(str "E(" % ")") sample-doc)]
+    ;; structure untouched; every :text wrapped (incl nested)
+    (is (= "E(概要)" (get-in enc [:blocks 0 :text])))
+    (is (= "E(原材料費が上昇し…)" (get-in enc [:blocks 1 :text])))
+    (is (= "E(詳細)" (get-in enc [:blocks 1 :children 0 :text])))
+    (is (= (:title enc) (:title sample-doc)))            ; non-text untouched
+    ;; inverse transform restores the original (encrypt then decrypt)
+    (is (= sample-doc (o/map-doc-text #(subs % 2 (dec (count %))) enc)))))
+
+;; ---- CACAO bridge ----
+(deftest grant-maps-to-cacao-resources
+  (is (= ["kotoba://op/datom:transact" "kotoba://graph/g-acme"]
+         (c/grant->resources (first sample-grants))))
+  (is (= ["kotoba://op/datom:read" "kotoba://graph/g-beta"]
+         (c/grant->resources (second sample-grants)))))
+
+(deftest siwe-message-is-byte-exact
+  ;; matches kotoba-auth cacao.rs::siwe_message() exactly (see CACAO surface report)
+  (let [payload (c/grant->payload
+                 {:cap :cap/read :scope "graph-cid"}
+                 {:iss "did:key:z6MkABC" :aud "https://kotoba.test"
+                  :nonce "test-nonce" :issued-at "2026-01-01T00:00:00Z"
+                  :expiry "2099-01-01T00:00:00Z" :domain "kotoba.test"})
+        expected (clojure.string/join
+                  "\n"
+                  ["kotoba.test wants you to sign in with your Ethereum account:"
+                   "z6MkABC"
+                   ""
+                   "URI: https://kotoba.test"
+                   "Version: 1"
+                   "Chain ID: 1"
+                   "Nonce: test-nonce"
+                   "Issued At: 2026-01-01T00:00:00Z"
+                   "Expiration Time: 2099-01-01T00:00:00Z"
+                   "Resources:"
+                   "- kotoba://op/datom:read"
+                   "- kotoba://graph/graph-cid"])]
+    (is (= expected (c/siwe-message payload)))))
+
+(deftest cacao-wire-has-renamed-fields
+  (let [payload (c/grant->payload (first sample-grants)
+                                  {:iss "did:key:zAlice" :aud "https://srv"
+                                   :nonce "n" :issued-at "2026-01-01T00:00:00Z"})
+        wire (c/->wire payload "sigb64")]
+    (is (= "eip4361" (get-in wire [:h :t])))
+    (is (= "EdDSA"   (get-in wire [:s :t])))
+    (is (= "did:key:zAlice" (get-in wire [:p :iss])))
+    (is (= "2026-01-01T00:00:00Z" (get-in wire [:p :iat])))  ; renamed issued-at->iat
+    (is (contains? (set (get-in wire [:p :resources])) "kotoba://op/datom:transact"))))
+
+(defn -main [& _]
+  (let [{:keys [fail error]} (run-tests 'kotoba.office-test)]
+    (System/exit (if (zero? (+ fail error)) 0 1))))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/passkey.cljs
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/passkey.cljs
@@ -1,0 +1,126 @@
+(ns kotoba.passkey
+  "Passkey (WebAuthn PRF) unlock of the sovereign identity (docs/gftd-office doc b).
+
+   The account's 32-byte Ed25519 seed is wrapped with an AES-GCM key DERIVED from the
+   WebAuthn **PRF** extension output of a passkey. Only the passkey (held in the device
+   authenticator / Secure Enclave) can produce that PRF secret, so only it can unwrap
+   the seed. Only ciphertext is persisted (localStorage) — the seed never rests in the
+   clear. `enroll!` registers a passkey + wraps a fresh identity; `unlock!` recovers the
+   SAME identity on any device that has the passkey. Browser-only.
+
+   NOTE on :advanced compilation: native browser APIs (navigator.credentials,
+   SubtleCrypto, WebAuthn extension results) must be reached with `^js` hints and
+   goog.object/get so the Closure compiler does not munge their method/property names."
+  (:require [goog.object :as gobj]))
+
+(def ^:private storage-key "kotoba.passkey.seed")
+
+;; fixed app salt for the PRF eval (deterministic secret per passkey): "kotoba:prf:v1"
+(def ^:private prf-salt
+  (js/Uint8Array.from #js [107 111 116 111 98 97 58 112 114 102 58 118 49]))
+
+(defn- rand-bytes [n]
+  (let [a (js/Uint8Array. n)] (js/crypto.getRandomValues a) a))
+
+(defn- byte->hex [b]
+  (let [h (.toString b 16)] (if (== 1 (.-length h)) (str "0" h) h)))
+
+(defn- buf->hex [buf]
+  (let [a (js/Uint8Array. buf)]
+    (areduce a i acc "" (str acc (byte->hex (aget a i))))))
+
+(defn- buf->b64 [buf]
+  (js/btoa (.apply js/String.fromCharCode nil (js/Uint8Array. buf))))
+
+(defn- b64->u8 [s]
+  (let [bin (js/atob s) n (.-length bin) a (js/Uint8Array. n)]
+    (dotimes [i n] (aset a i (.charCodeAt bin i)))
+    a))
+
+(defn- credentials [] ^js (gobj/get js/navigator "credentials"))
+(defn- subtle [] ^js (gobj/get js/crypto "subtle"))
+
+(defn- prf-secret
+  "Run a passkey assertion with a PRF eval and return Promise<Uint8Array(32)>."
+  [rp-id]
+  (-> (.get (credentials)
+            #js {:publicKey #js {:challenge (rand-bytes 32)
+                                 :rpId rp-id
+                                 :userVerification "required"
+                                 :extensions #js {:prf #js {:eval #js {:first prf-salt}}}
+                                 :timeout 15000}})
+      (.then (fn [assertion]
+               (let [res   (.getClientExtensionResults ^js assertion)
+                     first (some-> (gobj/get res "prf")
+                                   (gobj/get "results")
+                                   (gobj/get "first"))]
+                 (if first
+                   (js/Uint8Array. first)
+                   (throw (js/Error. "passkey PRF extension not available"))))))))
+
+(defn- import-aes [prf-bytes]
+  (.importKey (subtle) "raw" prf-bytes #js {:name "AES-GCM"} false
+              #js ["encrypt" "decrypt"]))
+
+(defn- wrap-seed [prf-bytes seed-u8]
+  (-> (import-aes prf-bytes)
+      (.then (fn [key]
+               (let [iv (rand-bytes 12)]
+                 (-> (.encrypt (subtle) #js {:name "AES-GCM" :iv iv} key seed-u8)
+                     (.then (fn [ct] (str (buf->b64 iv) ":" (buf->b64 ct))))))))))
+
+(defn- unwrap-seed [prf-bytes blob]
+  (let [parts (.split blob ":")
+        iv (b64->u8 (aget parts 0))
+        ct (b64->u8 (aget parts 1))]
+    (-> (import-aes prf-bytes)
+        (.then (fn [key]
+                 (-> (.decrypt (subtle) #js {:name "AES-GCM" :iv iv} key ct)
+                     (.then (fn [pt] (js/Uint8Array. pt)))))))))
+
+(defn enroll!
+  "Register a passkey and wrap a FRESH sovereign identity under its PRF secret.
+   Activates the identity on `node` and persists only ciphertext. Returns
+   Promise<account-did (z6Mk)>. `rp-id` is the site (e.g. \"localhost\"/\"docs.gftd.ai\")."
+  [^js node rp-id user-name]
+  (-> (.create (credentials)
+               #js {:publicKey #js {:challenge (rand-bytes 32)
+                                    :rp #js {:name "kotoba" :id rp-id}
+                                    :user #js {:id (rand-bytes 16)
+                                               :name user-name
+                                               :displayName user-name}
+                                    :pubKeyCredParams #js [#js {:type "public-key" :alg -7}
+                                                           #js {:type "public-key" :alg -257}]
+                                    :authenticatorSelection #js {:residentKey "required"
+                                                                 :userVerification "required"}
+                                    :extensions #js {:prf #js {}}
+                                    :timeout 15000}})
+      (.then (fn [_cred] (prf-secret rp-id)))
+      (.then (fn [prf]
+               (let [seed (rand-bytes 32)]
+                 (.useIdentity node (buf->hex seed))
+                 (-> (wrap-seed prf seed)
+                     (.then (fn [blob]
+                              (js/localStorage.setItem storage-key blob)
+                              (.accountDid node)))))))))
+
+(defn unlock!
+  "Recover the wrapped identity via the passkey PRF and activate it on `node`.
+   Returns Promise<account-did (z6Mk)> — equal to the enrolled account on any device
+   holding the passkey."
+  [^js node rp-id]
+  (let [blob (js/localStorage.getItem storage-key)]
+    (if-not blob
+      (js/Promise.reject (js/Error. "no enrolled passkey on this device"))
+      (-> (prf-secret rp-id)
+          (.then (fn [prf] (unwrap-seed prf blob)))
+          (.then (fn [seed]
+                   (.useIdentity node (buf->hex seed))
+                   (.accountDid node)))))))
+
+(defn enrolled? [] (some? (js/localStorage.getItem storage-key)))
+
+;; exports
+(def ^:export enrollPasskey enroll!)
+(def ^:export unlockPasskey unlock!)
+(def ^:export passkeyEnrolled enrolled?)

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/syncq.cljs
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/syncq.cljs
@@ -1,0 +1,62 @@
+(ns kotoba.syncq
+  "Offline sync queue in **IndexedDB** (docs/gftd-office), shared with `office-sw.js`
+   for **Background Sync**. The page (passkey-unlocked) ENQUEUES *pre-signed* transact
+   requests (#js{url body}); the Service Worker DRAINS them on reconnect / background
+   sync / page nudge — so edits sync even when the tab is closed (the SW cannot run
+   WebAuthn, so signing must happen in the page; only the POST is deferred).
+
+   localStorage is invisible to a SW, so the queue lives in IndexedDB (DB
+   \"kotoba-office\", store \"syncq\"), the exact schema office-sw.js reads.")
+
+(def ^:private db-name "kotoba-office")
+(def ^:private store "syncq")
+
+(defn- open-db []
+  (js/Promise.
+    (fn [res rej]
+      (let [r (js/indexedDB.open db-name 1)]
+        (set! (.-onupgradeneeded r)
+              (fn [_]
+                (let [db (.-result r)]
+                  (when-not (.contains (.-objectStoreNames db) store)
+                    (.createObjectStore db store #js {:keyPath "id" :autoIncrement true})))))
+        (set! (.-onsuccess r) (fn [_] (res (.-result r))))
+        (set! (.-onerror r) (fn [_] (rej (.-error r))))))))
+
+(defn enqueue!
+  "Persist a pre-signed request #js{url body}. Returns Promise<true>."
+  [req]
+  (-> (open-db)
+      (.then (fn [db]
+               (js/Promise.
+                 (fn [res rej]
+                   (let [t (.transaction db store "readwrite")]
+                     (.add (.objectStore t store) req)
+                     (set! (.-oncomplete t) (fn [_] (res true)))
+                     (set! (.-onerror t) (fn [_] (rej (.-error t)))))))))))
+
+(defn pending
+  "Promise<number of queued requests>."
+  []
+  (-> (open-db)
+      (.then (fn [db]
+               (js/Promise.
+                 (fn [res rej]
+                   (let [rq (.count (.objectStore (.transaction db store "readonly") store))]
+                     (set! (.-onsuccess rq) (fn [_] (res (.-result rq))))
+                     (set! (.-onerror rq) (fn [_] (rej (.-error rq)))))))))))
+
+(defn register-bg-sync!
+  "Register a Background Sync so the SW drains the queue even with the page closed
+   (best-effort; the browser schedules the 'sync' event on connectivity)."
+  []
+  (-> (.-ready js/navigator.serviceWorker)
+      (.then (fn [reg] (when-let [s (.-sync reg)] (.register s "office-sync"))))
+      (.catch (fn [_] nil))))
+
+(defn nudge-sw!
+  "Ask the active SW to drain the queue now (page-open reconnect path)."
+  []
+  (-> (.-ready js/navigator.serviceWorker)
+      (.then (fn [reg] (some-> (.-active reg) (.postMessage #js {:type "office-flush"}))))
+      (.catch (fn [_] nil))))

--- a/crates/kotoba-wasm/web/editor.html
+++ b/crates/kotoba-wasm/web/editor.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>gftd office — sovereign editor</title>
+    <style>
+      body { font: 15px/1.5 system-ui, sans-serif; max-width: 720px; margin: 2rem auto; padding: 0 1rem; }
+      h1 { font-size: 1.1rem; color: #444; }
+      .meta { color: #888; font-size: 12px; word-break: break-all; }
+      #title { font-size: 1.3rem; font-weight: 600; width: 100%; padding: .4rem; margin: .5rem 0; }
+      #body { width: 100%; min-height: 14rem; padding: .6rem; font: inherit; }
+      .bar { display: flex; gap: 1rem; align-items: center; margin: .6rem 0; }
+      button { padding: .5rem 1rem; }
+      #status, #sync { font-size: 13px; color: #555; }
+    </style>
+  </head>
+  <body>
+    <!-- The whole UI is rendered from Hiccup data by kotoba.editor; this shell only
+         provides a mount point. Same-origin: pkg + cljs-out are served by `kotoba
+         serve` (KOTOBA_STATIC_DIR) alongside /xrpc — no CORS. -->
+    <div id="app">booting…</div>
+    <script type="module">
+      import init, { KotobaNode } from "./pkg/kotoba_wasm.js";
+      import { initEditor } from "./cljs-out/kotoba-node.js";
+      (async () => {
+        await init();
+        const node = new KotobaNode();
+        window.__node = node;
+        await initEditor(node);
+        window.__editorReady = true;
+      })().catch((e) => {
+        document.getElementById("app").textContent = "error: " + e;
+        window.__editorError = String(e);
+        console.error(e);
+      });
+    </script>
+  </body>
+</html>

--- a/crates/kotoba-wasm/web/office-sw.js
+++ b/crates/kotoba-wasm/web/office-sw.js
@@ -1,0 +1,69 @@
+// office-sw.js — Background-Sync drain of the office sync queue (docs/gftd-office).
+//
+// The page enqueues PRE-SIGNED transact requests into IndexedDB (kotoba.syncq); this
+// Service Worker POSTs them when connectivity returns — on a Background Sync 'sync'
+// event (fires even with the tab CLOSED) or when the page nudges it via postMessage.
+// The SW never signs (no WebAuthn in a worker) — it only delivers what the page signed.
+
+const DB = "kotoba-office";
+const STORE = "syncq";
+const TAG = "office-sync";
+
+function openDb() {
+  return new Promise((res, rej) => {
+    const r = indexedDB.open(DB, 1);
+    r.onupgradeneeded = () => {
+      const db = r.result;
+      if (!db.objectStoreNames.contains(STORE))
+        db.createObjectStore(STORE, { keyPath: "id", autoIncrement: true });
+    };
+    r.onsuccess = () => res(r.result);
+    r.onerror = () => rej(r.error);
+  });
+}
+function getAll(db) {
+  return new Promise((res, rej) => {
+    const rq = db.transaction(STORE, "readonly").objectStore(STORE).getAll();
+    rq.onsuccess = () => res(rq.result);
+    rq.onerror = () => rej(rq.error);
+  });
+}
+function del(db, id) {
+  return new Promise((res, rej) => {
+    const t = db.transaction(STORE, "readwrite");
+    t.objectStore(STORE).delete(id);
+    t.oncomplete = () => res();
+    t.onerror = () => rej(t.error);
+  });
+}
+
+async function drain() {
+  const db = await openDb();
+  const jobs = await getAll(db);
+  let synced = 0;
+  for (const j of jobs) {
+    try {
+      const r = await fetch(j.url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: j.body,
+      });
+      if (r.ok) { await del(db, j.id); synced++; }
+      // non-ok (e.g. nonce/auth) → drop so it can't wedge the queue forever
+      else if (r.status >= 400 && r.status < 500) { await del(db, j.id); }
+    } catch (e) { /* offline → keep for the next drain */ }
+  }
+  const remaining = (await getAll(db)).length;
+  const clients = await self.clients.matchAll({ includeUncontrolled: true });
+  clients.forEach((c) => c.postMessage({ type: "office-synced", synced, remaining }));
+  return remaining;
+}
+
+self.addEventListener("install", () => self.skipWaiting());
+self.addEventListener("activate", (e) =>
+  // claim first; a drain failure must never block activation.
+  e.waitUntil(self.clients.claim().then(() => drain()).catch(() => {})));
+self.addEventListener("sync", (e) => { if (e.tag === TAG) e.waitUntil(drain()); });
+self.addEventListener("message", (e) => {
+  if (e.data && e.data.type === "office-flush") e.waitUntil(drain());
+});

--- a/crates/kotoba-wasm/web/office.test.mjs
+++ b/crates/kotoba-wasm/web/office.test.mjs
@@ -1,0 +1,97 @@
+// office.test.mjs — JS↔wasm E2E for the org-first office layer + CACAO bridge.
+//
+//   node web/office.test.mjs
+//
+// Drives the real `KotobaNode` wasm bindings (pkg-node) through:
+//   1. office document write in the kotoba.office wire format ([{e,a,v_edn}])
+//      -> commit -> datomicQ read-back (proves the v_edn contract end to end)
+//   2. assertEncrypted/decrypt (sovereign field encryption, signal:v1:)
+//   3. mintCacao (doc-b grant -> server-verifiable CACAO) at the wasm boundary
+// The native test (cargo test -p kotoba-wasm) proves the minted CACAO verifies
+// byte-identically under kotoba-auth DelegationChain::verify; this proves the
+// same surface runs across the JS boundary.
+
+import { KotobaNode } from "./pkg-node/kotoba_wasm.js";
+
+let failures = 0;
+function check(name, cond) {
+  if (cond) console.log(`  ok   ${name}`);
+  else { failures++; console.error(`  FAIL ${name}`); }
+}
+
+// ---- 1. office document write/read in the kotoba.office wire format ----
+const node = new KotobaNode();
+const did = node.useIdentity("07".repeat(32)); // 32-byte seed hex
+check("useIdentity returns a did:key", typeof did === "string" && did.startsWith("did:key:"));
+
+// mirrors kotoba.office/doc->tx output (v_edn: strings JSON-quoted, keywords bare,
+// longs bare). doc "doc1" owned by org-alice, one heading block.
+const tx = [
+  { e: "doc1", a: ":doc/kind",      v_edn: ":doc/document" },
+  { e: "doc1", a: ":doc/title",     v_edn: '"Q3 戦略メモ"' },
+  { e: "doc1", a: ":doc/owner-org", v_edn: '"org-alice"' },
+  { e: "doc1", a: ":doc/created-at",v_edn: "1719000005000" },
+  { e: "b0",   a: ":block/kind",    v_edn: ":block/heading" },
+  { e: "b0",   a: ":block/parent",  v_edn: '"doc1"' },
+  { e: "b0",   a: ":block/order",   v_edn: '"a0"' },
+  { e: "b0",   a: ":block/text",    v_edn: '"概要"' },
+];
+const n = node.transact(JSON.stringify(tx));
+check("transact applied all office datoms", n === tx.length);
+const root = node.commit();
+check("commit yields a content-addressed root CID", typeof root === "string" && root.length > 0);
+
+const titleRes = JSON.parse(
+  node.datomicQ('[:find ?t :where [?e :doc/title ?t]]', "[]"),
+);
+check("datomicQ reads the doc title back", JSON.stringify(titleRes).includes("Q3 戦略メモ"));
+
+const blockRes = JSON.parse(
+  node.datomicQ('[:find ?txt :where [?b :block/parent "doc1"] [?b :block/text ?txt]]', "[]"),
+);
+check("datomicQ reads a block under the doc", JSON.stringify(blockRes).includes("概要"));
+
+// ---- 2. sovereign field encryption ----
+node.assertEncrypted("b1", ":block/text", "会員番号 12345");
+const env = JSON.parse(node.datomicQ('[:find ?v :where [?e :block/text ?v]]', "[]"));
+const envStr = JSON.stringify(env);
+check("encrypted block stored as signal:v1: ciphertext", envStr.includes("signal:v1:"));
+check("plaintext never appears in the store", !envStr.includes("12345"));
+// recover one envelope and decrypt it
+const envValue = (envStr.match(/signal:v1:[0-9a-f]+/) || [])[0];
+check("decrypt round-trips the ciphertext", node.decrypt(envValue) === "会員番号 12345");
+
+// ---- 3. sovereign identity: canonical did:key + deterministic private graph CID ----
+const accountDid = node.accountDid();
+check("accountDid is a canonical did:key:z6Mk", accountDid.startsWith("did:key:z6Mk"));
+const graphId = node.privateGraphId();
+check("privateGraphId returns a graph CID", typeof graphId === "string" && graphId.length > 0);
+// same identity -> same graph CID (the server auto-registers Private{owner=account} on it)
+const node2 = new KotobaNode();
+node2.useIdentity("07".repeat(32));
+check("privateGraphId is deterministic for an identity", node2.privateGraphId() === graphId);
+const node3 = new KotobaNode();
+node3.useIdentity("09".repeat(32));
+check("different identity -> different private graph CID", node3.privateGraphId() !== graphId);
+
+// ---- 4. CACAO mint at the wasm boundary (doc-b grant -> capability) ----
+// A WRITE grants BOTH datom:transact AND tx:create, scoped to the account's graph CID.
+const W = ["datom:transact", "tx:create"];
+const OP = "did:key:zOperatorNodeDid"; // aud = server operator DID
+const cacaoB64 = node.mintCacao(OP, graphId, W, "office-nonce-1", "2026-01-01T00:00:00Z", "2099-01-01T00:00:00Z");
+check("mintCacao returns a non-empty base64 cacao_b64", typeof cacaoB64 === "string" && cacaoB64.length > 0);
+const cacaoBytes = Buffer.from(cacaoB64, "base64");
+check("cacao_b64 decodes to a non-empty CBOR blob", cacaoBytes.length > 0);
+// deterministic: same identity + same args -> identical signed CACAO (Ed25519 det.)
+const cacaoB64b = node.mintCacao(OP, graphId, W, "office-nonce-1", "2026-01-01T00:00:00Z", "2099-01-01T00:00:00Z");
+check("mintCacao is deterministic for identical inputs", cacaoB64 === cacaoB64b);
+// different nonce -> different signed bytes
+const cacaoB64c = node.mintCacao(OP, graphId, W, "office-nonce-2", "2026-01-01T00:00:00Z", "2099-01-01T00:00:00Z");
+check("different nonce yields a different CACAO", cacaoB64 !== cacaoB64c);
+// read CACAO: single datom:read cap, scoped to the graph CID (datomic.datoms uses
+// require_datomic_read → graph.to_multibase(), same scope as the write).
+const readCacao = node.mintCacao(OP, graphId, ["datom:read"], "office-read-1", "2026-01-01T00:00:00Z", "2099-01-01T00:00:00Z");
+check("read CACAO mints distinctly from write CACAO", typeof readCacao === "string" && readCacao !== cacaoB64);
+
+console.log(failures === 0 ? "\nALL OK" : `\n${failures} FAILURE(S)`);
+process.exit(failures === 0 ? 0 : 1);

--- a/crates/kotoba-wasm/web/office_harness.html
+++ b/crates/kotoba-wasm/web/office_harness.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+  <head><meta charset="utf-8"><title>kotoba office harness</title></head>
+  <body>
+    <h1 id="status">loading…</h1>
+    <!-- Loads the browser (web-target) kotoba WASM and exposes KotobaNode so a
+         playwright-clj driver can run the office/CACAO flow in a REAL browser. -->
+    <script type="module">
+      import init, { KotobaNode } from "./pkg/kotoba_wasm.js";
+      import { enrollPasskey, unlockPasskey, passkeyEnrolled, officeRoundtrip }
+        from "./cljs-out/kotoba-node.js";
+      (async () => {
+        await init();
+        window.KotobaNode = KotobaNode;
+        window.kotoba = { enrollPasskey, unlockPasskey, passkeyEnrolled, officeRoundtrip };
+        window.__kotobaReady = true;
+        document.getElementById("status").textContent = "ready";
+        console.log("[harness] kotoba wasm ready");
+      })().catch((e) => {
+        window.__kotobaError = String(e);
+        document.getElementById("status").textContent = "error: " + e;
+        console.error("[harness] init failed", e);
+      });
+    </script>
+  </body>
+</html>

--- a/crates/kotoba-wasm/web/office_http_e2e.mjs
+++ b/crates/kotoba-wasm/web/office_http_e2e.mjs
@@ -1,0 +1,110 @@
+// office_http_e2e.mjs — LIVE end-to-end against a running `kotoba serve`.
+//
+//   KOTOBA_URL=http://localhost:8099 node web/office_http_e2e.mjs
+//
+// Proves the full sovereign office round-trip over real HTTP with the browser
+// (pkg-node) WASM doing all the crypto:
+//   1. discover the node operator DID (CACAO aud) from public key.custodianInfo
+//   2. encrypt a block body client-side (signal:v1:) — server never sees plaintext
+//   3. sync to the account's OWN private graph with a transact CACAO (auto-registered)
+//   4. read it back with a read CACAO; reconstruct + decrypt client-side
+// Mirrors kotoba.office sync-doc!/pull-doc + encrypt-doc, but inlined so it needs no
+// shadow-cljs build.
+
+import { KotobaNode } from "./pkg-node/kotoba_wasm.js";
+
+const REMOTE = process.env.KOTOBA_URL || "http://localhost:8099";
+let failures = 0;
+const check = (n, c) => { if (c) console.log(`  ok   ${n}`); else { failures++; console.error(`  FAIL ${n}`); } };
+const IAT = "2026-01-01T00:00:00Z", EXP = "2099-01-01T00:00:00Z";
+let nonceN = 0;
+const nonce = () => `e2e-${Date.now()}-${nonceN++}`;
+
+async function post(path, body) {
+  const r = await fetch(`${REMOTE}/xrpc/${path}`, {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
+  });
+  return { ok: r.ok, status: r.status, json: r.ok ? await r.json() : await r.text() };
+}
+
+const node = new KotobaNode();
+node.useIdentity("07".repeat(32));            // the account identity
+const account = node.accountDid();
+const graph = node.privateGraphId();
+check("account is did:key:z6Mk", account.startsWith("did:key:z6Mk"));
+
+// 1. discover operator DID (CACAO aud)
+const ci = await fetch(`${REMOTE}/xrpc/com.etzhayyim.apps.kotoba.key.custodianInfo`).then((r) => r.json());
+const operatorDid = ci.did;
+check("discovered operator DID (aud)", typeof operatorDid === "string" && operatorDid.startsWith("did:key:"));
+
+// 2. encrypt the body client-side (server must never see this plaintext)
+const SECRET = "会員番号 12345 機密本文";
+const envelope = node.encrypt(SECRET);
+check("body encrypted to signal:v1: envelope", envelope.startsWith("signal:v1:"));
+
+// 3. sync to the account's own private graph with a transact CACAO
+const txEdn =
+  `[[:db/add "doc1" :node/lid "doc1"]` +
+  `[:db/add "doc1" :doc/kind :doc/document]` +
+  `[:db/add "doc1" :doc/title "Q3 戦略メモ"]` +
+  `[:db/add "b0" :node/lid "b0"]` +
+  `[:db/add "b0" :block/kind :block/paragraph]` +
+  `[:db/add "b0" :block/parent "doc1"]` +
+  `[:db/add "b0" :block/order "a0"]` +
+  `[:db/add "b0" :block/text ${JSON.stringify(envelope)}]]`;
+const wcacao = node.mintCacao(operatorDid, graph, ["datom:transact", "tx:create"], nonce(), IAT, EXP);
+const w = await post("com.etzhayyim.apps.kotoba.datomic.transact", { graph, tx_edn: txEdn, cacao_b64: wcacao });
+check("transact accepted (account owns its auto-registered private graph)", w.ok);
+check("transact wrote datoms", w.ok && w.json.datom_count >= 5);
+
+// a non-owner write must be rejected (different identity, same target graph CID)
+const intruder = new KotobaNode();
+intruder.useIdentity("aa".repeat(32));
+const icacao = intruder.mintCacao(operatorDid, graph, ["datom:transact", "tx:create"], nonce(), IAT, EXP);
+const bad = await post("com.etzhayyim.apps.kotoba.datomic.transact", { graph, tx_edn: "[[:db/add \"x\" :n 1]]", cacao_b64: icacao });
+check("non-owner write to the account's graph is rejected", !bad.ok && bad.status === 401);
+
+// 4. read back with a read CACAO; the server holds only ciphertext
+const rcacao = node.mintCacao(operatorDid, graph, ["datom:read"], nonce(), IAT, EXP);
+const rd = await post("com.etzhayyim.apps.kotoba.datomic.datoms", {
+  graph, index: "eavt", components_edn: [], cacao_b64: rcacao,
+});
+check("read accepted with read CACAO", rd.ok);
+const datoms = rd.ok ? rd.json.datoms : [];
+const raw = JSON.stringify(datoms);
+check("plaintext body never present on the server", !raw.includes("12345"));
+check("title plaintext is readable structure", raw.includes("Q3 戦略メモ"));
+const textDatom = datoms.find((d) => d.a === ":block/text");
+check("body stored as signal:v1: ciphertext", textDatom && textDatom.v_edn.includes("signal:v1:"));
+// decrypt client-side
+const back = textDatom ? node.decrypt(JSON.parse(textDatom.v_edn)) : null;
+check("client decrypts the synced body back to plaintext", back === SECRET);
+
+// no-CACAO read is denied
+const denied = await post("com.etzhayyim.apps.kotoba.datomic.datoms", { graph, index: "eavt", components_edn: [] });
+check("private read without a CACAO is denied", !denied.ok && denied.status === 401);
+
+// ---- 5. team sharing: a MEMBER writes to the ORG's graph via depth-2 delegation ----
+const org = new KotobaNode(); org.useIdentity("b1".repeat(32));   // the org/owner identity
+const member = new KotobaNode(); member.useIdentity("c2".repeat(32)); // a team member
+const orgGraph = org.privateGraphId();
+const W2 = ["datom:transact", "tx:create"];
+// org delegates to member: a root grant (aud = the member's DID)
+const rootGrant = org.mintCacao(member.accountDid(), orgGraph, W2, nonce(), IAT, EXP);
+// member assembles the [root, leaf] chain (leaf aud = server)
+const chain = member.mintDelegated(rootGrant, operatorDid, orgGraph, W2, nonce(), IAT, EXP);
+const tw = await post("com.etzhayyim.apps.kotoba.datomic.transact", {
+  graph: orgGraph, tx_edn: `[[:db/add "t1" :doc/title "Team doc"]]`, cacao_b64: chain,
+});
+if (!tw.ok) console.error("    depth-2 transact error:", tw.status, tw.json);
+check("delegated member writes to the org graph (depth-2)", tw.ok);
+// the org graph is bound to the ORG owner, not the member: a bare member CACAO is rejected
+const solo = member.mintCacao(operatorDid, orgGraph, W2, nonce(), IAT, EXP);
+const sw = await post("com.etzhayyim.apps.kotoba.datomic.transact", {
+  graph: orgGraph, tx_edn: `[[:db/add "x" :n 1]]`, cacao_b64: solo,
+});
+check("non-delegated member write to the org graph is rejected", !sw.ok && sw.status === 401);
+
+console.log(failures === 0 ? "\nALL OK" : `\n${failures} FAILURE(S)`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
Browser, local-first, login-optional, install-free **office document layer with data
sovereignty**, built on the kotoba datom node + CACAO authz. (docs/gftd-office in the
superproject.)

## What's in it
- **CLJS office layer** (`kotoba.office`): org-first datom schema (org/account = DID;
  ownership tree + access DAG), doc/block model, `v_edn` codec matching the wasm
  `parse_edn_scalar`, client-side encryption (`signal:v1:`), local store + CACAO-authed
  **same-origin sync** + read-back with `:node/lid` reconstruction (CID-entity safe;
  `:db.fn/retractEntity` prefix so re-edits replace, not accumulate).
- **CACAO bridge** (`kotoba.cacao`) + **wasm exposure** (`kotoba-wasm`: `mint_cacao` /
  `mint_delegated` / `account_did` / `private_graph_id` / `encrypt`) — reuses
  kotoba-auth's exact `Cacao` + `did:key` + `siwe_message`, so browser-minted CACAOs
  verify server-side byte-for-byte.
- **Server** (`kotoba-server`): account-owned **private graph auto-registration** on
  first CACAO write (CID binds to DID), **depth-2 team delegation** (decode
  single-or-chain, bind to root authority), and **same-origin static delivery** via
  `KOTOBA_STATIC_DIR`.
- **kotoba-auth**: `from_cbor_chain` + leaf-aud verification for depth-2 chains;
  `commit_sig` excluded on `wasm32` so kotoba-auth is wasm-clean.
- **passkey** (`kotoba.passkey`): WebAuthn-**PRF**-wrapped Ed25519 seed → multi-device
  sovereign identity recovery.
- **Hiccup editor UI** (`kotoba.editor` + `kotoba.hiccup`, no React) + **Service-Worker
  offline sync queue** (`kotoba.syncq` + `office-sw.js`, IndexedDB + Background Sync).

## Verification
- `bb` pure round-trip tests (schema/codec/siwe/tx_edn): 10 tests / 35 assertions.
- native: `cargo test -p kotoba-wasm` (mint/delegated), `-p kotoba-server`
  (auto-register, depth-2, read-back) — all green; `cargo test -p kotoba-auth` 286 pass.
- **real-browser E2E** via `com-junkawasaki/playwright-clj`: office / fullstack /
  editor (passkey enroll+unlock, offline queue→reconnect flush) / passkey-PRF — ALL OK.
- `cargo check -p kotoba-wasm -p kotoba-server -p kotoba-auth` clean on the rebased tree.

## Notes
- Generated build artifacts (pkg/, pkg-node/, cljs-out/, .cpcache, *.png) are gitignored.
- Unrelated in-progress mesh on-kse WIP (codegen.rs/component.rs/world.wit) was left
  out (preserved in local stashes for its owner to reconcile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)