### PR TITLE
chore: realign workspace to rustfmt/clippy 0.1.96 (green the Rust gates)

### DIFF
--- a/crates/kotoba-cli/src/mesh.rs
+++ b/crates/kotoba-cli/src/mesh.rs
@@ -218,7 +218,9 @@ pub async fn run_app(cmd: AppCmd) -> Result<()> {
                 // with their real artifact CID (R0).
                 let mut wire: Vec<(String, Vec<u8>)> = Vec::with_capacity(msgs.len());
                 for (topic, m) in &msgs {
-                    let cbor = m.to_cbor().map_err(|e| anyhow!("encode lattice msg: {e}"))?;
+                    let cbor = m
+                        .to_cbor()
+                        .map_err(|e| anyhow!("encode lattice msg: {e}"))?;
                     wire.push((topic.to_string(), cbor));
                 }
                 let mut body = Vec::new();

--- a/crates/kotoba-clj/src/codegen.rs
+++ b/crates/kotoba-clj/src/codegen.rs
@@ -84,9 +84,7 @@ impl EntryAbi {
     fn wrapper_params(self) -> &'static [ValType] {
         match self {
             // (in_ptr, in_len)
-            EntryAbi::BytesToBytes | EntryAbi::BytesToResultBytes => {
-                &[ValType::I32, ValType::I32]
-            }
+            EntryAbi::BytesToBytes | EntryAbi::BytesToResultBytes => &[ValType::I32, ValType::I32],
             // (epoch: u64)
             EntryAbi::I64ToResultBytes => &[ValType::I64],
             // (topic_ptr, topic_len, payload_ptr, payload_len)
@@ -101,9 +99,7 @@ impl EntryAbi {
         match self {
             EntryAbi::StringBytesToResultBytes => 2, // (topic, payload)
             // list<u8>/u64 inputs are a single guest value
-            EntryAbi::BytesToBytes
-            | EntryAbi::BytesToResultBytes
-            | EntryAbi::I64ToResultBytes => 1,
+            EntryAbi::BytesToBytes | EntryAbi::BytesToResultBytes | EntryAbi::I64ToResultBytes => 1,
         }
     }
 }
@@ -262,7 +258,9 @@ pub fn compile_core(program: &Program, entries: &[Entry]) -> Result<Vec<u8>, Clj
     // (the return-area pointer).
     for (i, (user_idx, abi, export_name)) in entry_targets.iter().enumerate() {
         let wrapper_type = types.len();
-        types.ty().function(abi.wrapper_params().iter().copied(), [ValType::I32]);
+        types
+            .ty()
+            .function(abi.wrapper_params().iter().copied(), [ValType::I32]);
         funcs.function(wrapper_type);
         let wrapper_index = realloc_fn_index + 1 + i as u32;
         exports.export(export_name, ExportKind::Func, wrapper_index);
@@ -750,8 +748,16 @@ fn entry_wrapper_fn(user_fn_index: u32, realloc_index: u32, abi: EntryAbi) -> Fu
 fn tick_wrapper_fn(user_fn_index: u32, realloc_index: u32) -> Function {
     // param 0 = epoch(i64) ; locals: 1=ret_handle(i64) 2=area(i32)
     let mut f = Function::new([(1, ValType::I64), (1, ValType::I32)]);
-    let store32 = |offset: u64| MemArg { offset, align: 2, memory_index: 0 };
-    let store8 = |offset: u64| MemArg { offset, align: 0, memory_index: 0 };
+    let store32 = |offset: u64| MemArg {
+        offset,
+        align: 2,
+        memory_index: 0,
+    };
+    let store8 = |offset: u64| MemArg {
+        offset,
+        align: 0,
+        memory_index: 0,
+    };
 
     // ret_handle = user_fn(epoch)   — epoch is the guest fn's i64 value arg
     f.instruction(&Instruction::LocalGet(0));
@@ -800,8 +806,16 @@ fn kse_wrapper_fn(user_fn_index: u32, realloc_index: u32) -> Function {
     // params: 0=topic_ptr 1=topic_len 2=payload_ptr 3=payload_len
     // locals:  4=ret_handle(i64) 5=area(i32)
     let mut f = Function::new([(1, ValType::I64), (1, ValType::I32)]);
-    let store32 = |offset: u64| MemArg { offset, align: 2, memory_index: 0 };
-    let store8 = |offset: u64| MemArg { offset, align: 0, memory_index: 0 };
+    let store32 = |offset: u64| MemArg {
+        offset,
+        align: 2,
+        memory_index: 0,
+    };
+    let store8 = |offset: u64| MemArg {
+        offset,
+        align: 0,
+        memory_index: 0,
+    };
 
     // topic handle = (topic_ptr << 32) | topic_len
     f.instruction(&Instruction::LocalGet(0));

--- a/crates/kotoba-clj/src/component.rs
+++ b/crates/kotoba-clj/src/component.rs
@@ -234,7 +234,11 @@ pub fn compile_kais_mesh_component_str(src: &str, wit_dir: &str) -> Result<Vec<u
         // exactly one → its dedicated world (M7/M8/M9), no stubs
         1 => {
             let (n, _, abi) = defined[0];
-            entries.push(Entry { name: n, abi: *abi, export_name: n });
+            entries.push(Entry {
+                name: n,
+                abi: *abi,
+                export_name: n,
+            });
             match *n {
                 "on-http" => "kotoba-component",
                 "on-tick" => "kotoba-cron",
@@ -250,9 +254,15 @@ pub fn compile_kais_mesh_component_str(src: &str, wit_dir: &str) -> Result<Vec<u
                     let params: Vec<String> = (0..arity).map(|i| format!("a{i}")).collect();
                     let stub = format!("(defn {n} [{}] \"\")", params.join(" "));
                     let p = crate::ast::parse_program(&stub)?;
-                    program.functions.extend(p.functions.into_iter().filter(|f| f.name == n));
+                    program
+                        .functions
+                        .extend(p.functions.into_iter().filter(|f| f.name == n));
                 }
-                entries.push(Entry { name: n, abi, export_name: n });
+                entries.push(Entry {
+                    name: n,
+                    abi,
+                    export_name: n,
+                });
             }
             "kotoba-mesh"
         }

--- a/crates/kotoba-clj/tests/mesh_dispatch.rs
+++ b/crates/kotoba-clj/tests/mesh_dispatch.rs
@@ -27,22 +27,34 @@ fn host_dispatches_each_trigger_to_its_own_export() {
 
     let run = exec
         .execute(cid, &comp, did, b"x".to_vec(), q(), h())
-        .expect("run").output_cbor;
+        .expect("run")
+        .output_cbor;
     assert_eq!(run, b"RUN", "run export");
 
     let http = exec
         .execute_on_http(cid, &comp, did, b"req".to_vec(), q(), h())
-        .expect("on-http").output_cbor;
+        .expect("on-http")
+        .output_cbor;
     assert_eq!(http, b"HTTP", "on-http export");
 
     let tick = exec
         .execute_on_tick(cid, &comp, did, 1_700_000_000_000, q(), h())
-        .expect("on-tick").output_cbor;
+        .expect("on-tick")
+        .output_cbor;
     assert_eq!(tick, b"TICK", "on-tick export");
 
     let kse = exec
-        .execute_on_kse(cid, &comp, did, "kotoba/mail/in".into(), b"payload".to_vec(), q(), h())
-        .expect("on-kse").output_cbor;
+        .execute_on_kse(
+            cid,
+            &comp,
+            did,
+            "kotoba/mail/in".into(),
+            b"payload".to_vec(),
+            q(),
+            h(),
+        )
+        .expect("on-kse")
+        .output_cbor;
     assert_eq!(kse, b"KSE", "on-kse export");
 }
 
@@ -52,8 +64,12 @@ fn missing_trigger_export_errors_cleanly() {
     let comp = compile_kais_mesh_component_str("(ns m) (defn run [c] c)", WIT).expect("compile");
     let exec = WasmExecutor::new(GAS).expect("executor");
     let r = exec.execute_on_http(
-        "clj-runonly", &comp, "did:key:z", b"req".to_vec(),
-        Vec::<WitQuad>::new(), HashMap::<String, String>::new(),
+        "clj-runonly",
+        &comp,
+        "did:key:z",
+        b"req".to_vec(),
+        Vec::<WitQuad>::new(),
+        HashMap::<String, String>::new(),
     );
     assert!(r.is_err(), "missing on-http export must error");
 }

--- a/crates/kotoba-clj/tests/mesh_e2e.rs
+++ b/crates/kotoba-clj/tests/mesh_e2e.rs
@@ -52,7 +52,8 @@ fn full_pipeline_compile_deploy_route_execute() {
         "deploy must emit PutTriggers for the datom-Δ trigger"
     );
     assert!(
-        msgs.iter().any(|(_, m)| matches!(m, LatticeMessage::PutRoutes { .. })),
+        msgs.iter()
+            .any(|(_, m)| matches!(m, LatticeMessage::PutRoutes { .. })),
         "deploy must emit PutRoutes for kse/cron/http"
     );
 
@@ -80,7 +81,15 @@ fn full_pipeline_compile_deploy_route_execute() {
     // KSE topic → on-kse
     let kse_cid = &routes.kse_targets("kotoba/mail/in")[0];
     let out = exec
-        .execute_on_kse(kse_cid, &component, did, "kotoba/mail/in".into(), b"payload".to_vec(), q(), h())
+        .execute_on_kse(
+            kse_cid,
+            &component,
+            did,
+            "kotoba/mail/in".into(),
+            b"payload".to_vec(),
+            q(),
+            h(),
+        )
         .expect("on-kse")
         .output_cbor;
     assert_eq!(out, b"KSE");

--- a/crates/kotoba-core/src/cid.rs
+++ b/crates/kotoba-core/src/cid.rs
@@ -179,7 +179,10 @@ mod tests {
         for i in 0..payload.len() {
             let mut bad = payload.clone();
             bad[i] ^= 0x01;
-            assert!(!cid.verifies(&bad), "byte {i} tamper slipped past verification");
+            assert!(
+                !cid.verifies(&bad),
+                "byte {i} tamper slipped past verification"
+            );
         }
         // truncation and extension also fail (length is part of the content).
         assert!(!cid.verifies(&payload[..payload.len() - 1]));
@@ -190,8 +193,8 @@ mod tests {
         let mut tampered = payload.clone();
         tampered[0] ^= 0x01;
         let bad = unverified_blocks(&[
-            (cid.clone(), payload.clone()),  // authentic
-            (cid.clone(), tampered),         // tampered
+            (cid.clone(), payload.clone()), // authentic
+            (cid.clone(), tampered),        // tampered
         ]);
         assert_eq!(bad, vec![cid], "exactly the tampered response is flagged");
     }
@@ -202,9 +205,9 @@ mod tests {
         let b = KotobaCid::from_bytes(b"beta");
         let c = KotobaCid::from_bytes(b"gamma");
         let responses = vec![
-            (a.clone(), b"alpha".to_vec()),       // authentic
-            (b.clone(), b"WRONG".to_vec()),       // gateway lied
-            (c.clone(), b"gamma".to_vec()),       // authentic
+            (a.clone(), b"alpha".to_vec()), // authentic
+            (b.clone(), b"WRONG".to_vec()), // gateway lied
+            (c.clone(), b"gamma".to_vec()), // authentic
         ];
         let bad = unverified_blocks(&responses);
         assert_eq!(bad, vec![b], "only the tampered block is flagged");

--- a/crates/kotoba-core/src/hlc.rs
+++ b/crates/kotoba-core/src/hlc.rs
@@ -102,11 +102,7 @@ where
 /// deduping events that appear in more than one stream by their `tiebreak` key
 /// (overlapping subscriptions must not emit an event twice). Result is the same
 /// total causal order as [`causal_sort_by`]. Deterministic across stream order.
-pub fn causal_merge_dedup<T, K, FH, FK>(
-    streams: Vec<Vec<T>>,
-    hlc_of: FH,
-    tiebreak_of: FK,
-) -> Vec<T>
+pub fn causal_merge_dedup<T, K, FH, FK>(streams: Vec<Vec<T>>, hlc_of: FH, tiebreak_of: FK) -> Vec<T>
 where
     K: Ord + Clone,
     FH: Fn(&T) -> Hlc,
@@ -133,12 +129,7 @@ where
 /// subscription). The cursor is the consumer's last-seen Hlc, so a reconnecting
 /// subscriber gets exactly the unseen tail, deterministically — pass [`Hlc::ZERO`]
 /// for a fresh subscription (the whole stream).
-pub fn causal_after<T, K, FH, FK>(
-    items: Vec<T>,
-    cursor: Hlc,
-    hlc_of: FH,
-    tiebreak_of: FK,
-) -> Vec<T>
+pub fn causal_after<T, K, FH, FK>(items: Vec<T>, cursor: Hlc, hlc_of: FH, tiebreak_of: FK) -> Vec<T>
 where
     K: Ord,
     FH: Fn(&T) -> Hlc,
@@ -159,7 +150,11 @@ mod tests {
         assert_eq!(h.phys_ms(), 1_700_000_000_000);
         assert_eq!(h.counter(), 42);
         // counter is masked to 16 bits.
-        assert_eq!(Hlc::new(5, 0x1_0000).counter(), 0, "counter wraps at 16 bits");
+        assert_eq!(
+            Hlc::new(5, 0x1_0000).counter(),
+            0,
+            "counter wraps at 16 bits"
+        );
     }
 
     #[test]
@@ -261,14 +256,32 @@ mod tests {
 
     #[test]
     fn causal_after_returns_only_the_unseen_tail_in_order() {
-        let events = vec![ev(10, 0, "a"), ev(20, 0, "b"), ev(10, 1, "c"), ev(30, 0, "d")];
+        let events = vec![
+            ev(10, 0, "a"),
+            ev(20, 0, "b"),
+            ev(10, 1, "c"),
+            ev(30, 0, "d"),
+        ];
         let ids = |v: Vec<(Hlc, String)>| v.into_iter().map(|e| e.1).collect::<Vec<_>>();
         // cursor at the "c" event (hlc 10/1): only strictly-later events, ordered.
         let cursor = Hlc::new(10, 1);
-        assert_eq!(ids(causal_after(events.clone(), cursor, |e| e.0, |e| e.1.clone())), vec!["b", "d"]);
+        assert_eq!(
+            ids(causal_after(
+                events.clone(),
+                cursor,
+                |e| e.0,
+                |e| e.1.clone()
+            )),
+            vec!["b", "d"]
+        );
         // ZERO cursor → whole stream, causally ordered.
         assert_eq!(
-            ids(causal_after(events.clone(), Hlc::ZERO, |e| e.0, |e| e.1.clone())),
+            ids(causal_after(
+                events.clone(),
+                Hlc::ZERO,
+                |e| e.0,
+                |e| e.1.clone()
+            )),
             vec!["a", "c", "b", "d"]
         );
         // cursor past the end → empty (caller is fully caught up).
@@ -282,7 +295,11 @@ mod tests {
         let m1 = causal_merge_dedup(vec![g1.clone(), g2.clone()], |e| e.0, |e| e.1.clone());
         let m2 = causal_merge_dedup(vec![g2, g1], |e| e.0, |e| e.1.clone());
         let ids = |m: Vec<(Hlc, String)>| m.into_iter().map(|e| e.1).collect::<Vec<_>>();
-        assert_eq!(ids(m1), ids(m2), "stream order does not change the firehose");
+        assert_eq!(
+            ids(m1),
+            ids(m2),
+            "stream order does not change the firehose"
+        );
     }
 
     #[test]
@@ -290,11 +307,16 @@ mod tests {
         // Thread one clock through an adversarial wall-time sequence (forward
         // jumps, stalls, and backward jumps) — every stamp must strictly exceed
         // the previous, the property the whole causal ordering rests on.
-        let walls = [100u64, 100, 50, 100, 100, 200, 0, 200, 201, 1, 201, 5_000, 5_000];
+        let walls = [
+            100u64, 100, 50, 100, 100, 200, 0, 200, 201, 1, 201, 5_000, 5_000,
+        ];
         let mut clk = Hlc::ZERO;
         for w in walls {
             let next = clk.send(w);
-            assert!(next > clk, "send not strictly monotonic at wall={w}: {clk:?} -> {next:?}");
+            assert!(
+                next > clk,
+                "send not strictly monotonic at wall={w}: {clk:?} -> {next:?}"
+            );
             clk = next;
         }
     }
@@ -312,8 +334,14 @@ mod tests {
                             let local = Hlc::new(lp, lc);
                             let remote = Hlc::new(rp, rc);
                             let m = local.recv(remote, w);
-                            assert!(m > local, "recv !> local: {local:?} {remote:?} w={w} -> {m:?}");
-                            assert!(m > remote, "recv !> remote: {local:?} {remote:?} w={w} -> {m:?}");
+                            assert!(
+                                m > local,
+                                "recv !> local: {local:?} {remote:?} w={w} -> {m:?}"
+                            );
+                            assert!(
+                                m > remote,
+                                "recv !> remote: {local:?} {remote:?} w={w} -> {m:?}"
+                            );
                             assert!(
                                 m.phys_ms() >= lp.max(rp).max(w),
                                 "recv physical below max input"
@@ -330,8 +358,12 @@ mod tests {
         // Any permutation of the same event set sorts to the identical sequence
         // (deterministic total order across replicas). Sweep several rotations.
         let base = vec![
-            ev(10, 0, "a"), ev(10, 1, "b"), ev(20, 0, "c"),
-            ev(5, 3, "d"), ev(20, 0, "c"), ev(7, 0, "e"),
+            ev(10, 0, "a"),
+            ev(10, 1, "b"),
+            ev(20, 0, "c"),
+            ev(5, 3, "d"),
+            ev(20, 0, "c"),
+            ev(7, 0, "e"),
         ];
         let canonical = order(&base);
         for rot in 0..base.len() {
@@ -363,7 +395,10 @@ mod tests {
         let h = Hlc::new(1_700_000_000_000, 7);
         let hlc_bytes = serde_ipld_dagcbor::to_vec(&h).unwrap();
         let u64_bytes = serde_ipld_dagcbor::to_vec(&h.0).unwrap();
-        assert_eq!(hlc_bytes, u64_bytes, "Hlc must encode identically to a bare u64");
+        assert_eq!(
+            hlc_bytes, u64_bytes,
+            "Hlc must encode identically to a bare u64"
+        );
         // a raw u64 decodes straight into an Hlc.
         let from_u64: Hlc = serde_ipld_dagcbor::from_slice(&u64_bytes).unwrap();
         assert_eq!(from_u64, h);

--- a/crates/kotoba-dht/src/audit.rs
+++ b/crates/kotoba-dht/src/audit.rs
@@ -225,7 +225,10 @@ pub struct SlashSchedule {
 impl SlashSchedule {
     /// A schedule; `max_bps` is clamped to `10_000` (never more than the bond).
     pub fn new(step_bps: u32, max_bps: u32) -> Self {
-        Self { step_bps, max_bps: max_bps.min(10_000) }
+        Self {
+            step_bps,
+            max_bps: max_bps.min(10_000),
+        }
     }
 
     /// The slash fraction (bps) for `consecutive_failures`: `0` for a clean peer,
@@ -931,10 +934,13 @@ mod tests {
         assert_eq!(back, r);
         // the evidence wrapper (also pinned) round-trips too.
         let ev = AvailabilityEvidence::from_result(&r);
-        let back_ev: AvailabilityEvidence =
-            ciborium::from_reader(ev.to_cbor().as_slice()).unwrap();
+        let back_ev: AvailabilityEvidence = ciborium::from_reader(ev.to_cbor().as_slice()).unwrap();
         assert_eq!(back_ev, ev);
-        assert_eq!(back_ev.cid(), ev.cid(), "evidence CID stable across round-trip");
+        assert_eq!(
+            back_ev.cid(),
+            ev.cid(),
+            "evidence CID stable across round-trip"
+        );
     }
 
     #[test]
@@ -943,13 +949,15 @@ mod tests {
         let validator = NodeId::from_pubkey(b"auditor");
         let audit = slash_audit(&peer, 0.2);
         // signer is injected: here a trivial "hash" so the test stays key-free.
-        let (warrant, evidence) =
-            availability_slash_warrant(&audit, &validator, 1234, |msg| {
-                crate::availability_proof::hash_block(msg)
-            })
-            .expect("slash verdict yields a warrant");
+        let (warrant, evidence) = availability_slash_warrant(&audit, &validator, 1234, |msg| {
+            crate::availability_proof::hash_block(msg)
+        })
+        .expect("slash verdict yields a warrant");
 
-        assert_eq!(warrant.rule_id, ValidationRule::AvailabilityProofFailed as u8);
+        assert_eq!(
+            warrant.rule_id,
+            ValidationRule::AvailabilityProofFailed as u8
+        );
         assert_eq!(warrant.accused, peer.0.to_vec());
         assert_eq!(warrant.validator, validator.0.to_vec());
         assert_eq!(warrant.ts, 1234);
@@ -957,9 +965,10 @@ mod tests {
         assert_eq!(warrant.evidence, evidence.cid());
         assert_eq!(evidence.cid(), KotobaCid::from_bytes(&evidence.to_cbor()));
         // signature is over the canonical payload (recomputable by a verifier).
-        let expect_sig = crate::availability_proof::hash_block(&warrant_signing_bytes(
-            &Warrant { sig: Vec::new(), ..warrant.clone() },
-        ));
+        let expect_sig = crate::availability_proof::hash_block(&warrant_signing_bytes(&Warrant {
+            sig: Vec::new(),
+            ..warrant.clone()
+        }));
         assert_eq!(warrant.sig, expect_sig);
         // evidence round-trips and reflects the failed result.
         let back: AvailabilityEvidence =
@@ -973,7 +982,11 @@ mod tests {
     fn no_warrant_for_non_slash_verdicts() {
         let peer = NodeId::from_pubkey(b"p");
         let validator = NodeId::from_pubkey(b"v");
-        for action in [AuditAction::Reward, AuditAction::None, AuditAction::Unreachable] {
+        for action in [
+            AuditAction::Reward,
+            AuditAction::None,
+            AuditAction::Unreachable,
+        ] {
             let audit = PeerAudit {
                 peer: peer.clone(),
                 result: Some(VerificationResult {
@@ -988,7 +1001,11 @@ mod tests {
             assert!(availability_slash_warrant(&audit, &validator, 0, |m| m.to_vec()).is_none());
         }
         // Slash without a result (shouldn't happen, but guard it) → no warrant.
-        let no_result = PeerAudit { peer, result: None, action: AuditAction::Slash };
+        let no_result = PeerAudit {
+            peer,
+            result: None,
+            action: AuditAction::Slash,
+        };
         assert!(availability_slash_warrant(&no_result, &validator, 0, |m| m.to_vec()).is_none());
     }
 
@@ -996,8 +1013,12 @@ mod tests {
     fn distinct_failures_yield_distinct_evidence_cids() {
         let peer = NodeId::from_pubkey(b"peer");
         let validator = NodeId::from_pubkey(b"val");
-        let (w1, _) = availability_slash_warrant(&slash_audit(&peer, 0.1), &validator, 1, |m| m.to_vec()).unwrap();
-        let (w2, _) = availability_slash_warrant(&slash_audit(&peer, 0.4), &validator, 1, |m| m.to_vec()).unwrap();
+        let (w1, _) =
+            availability_slash_warrant(&slash_audit(&peer, 0.1), &validator, 1, |m| m.to_vec())
+                .unwrap();
+        let (w2, _) =
+            availability_slash_warrant(&slash_audit(&peer, 0.4), &validator, 1, |m| m.to_vec())
+                .unwrap();
         // different scores ⇒ different evidence ⇒ different CIDs ⇒ different sigs.
         assert_ne!(w1.evidence, w2.evidence);
         assert_ne!(w1.sig, w2.sig);
@@ -1072,15 +1093,27 @@ mod tests {
         assert_eq!(sched.fraction_bps(0), 0, "a clean peer is never slashed");
         assert_eq!(sched.fraction_bps(1), 2_500, "first miss is cheap (25%)");
         assert_eq!(sched.fraction_bps(2), 5_000);
-        assert_eq!(sched.fraction_bps(4), 10_000, "reaches full at the 4th miss");
-        assert_eq!(sched.fraction_bps(99), 10_000, "capped, never exceeds the bond");
+        assert_eq!(
+            sched.fraction_bps(4),
+            10_000,
+            "reaches full at the 4th miss"
+        );
+        assert_eq!(
+            sched.fraction_bps(99),
+            10_000,
+            "capped, never exceeds the bond"
+        );
     }
 
     #[test]
     fn graduated_slash_max_bps_clamped_to_full_bond() {
         let sched = SlashSchedule::new(1_000, 99_999);
         assert_eq!(sched.max_bps, 10_000, "cap can never exceed the whole bond");
-        assert_eq!(sched.fraction_bps(u64::MAX), 10_000, "saturating, no overflow");
+        assert_eq!(
+            sched.fraction_bps(u64::MAX),
+            10_000,
+            "saturating, no overflow"
+        );
     }
 
     #[test]
@@ -1090,7 +1123,7 @@ mod tests {
         assert_eq!(sched.slash_amount(1_000, 1), 250); // 25% of 1000
         assert_eq!(sched.slash_amount(1_000, 2), 500);
         assert_eq!(sched.slash_amount(1_000, 4), 1_000); // full
-        // negative / zero bond floors at 0; huge bond saturates without panic.
+                                                         // negative / zero bond floors at 0; huge bond saturates without panic.
         assert_eq!(sched.slash_amount(-5, 4), 0);
         assert_eq!(sched.slash_amount(i64::MAX, 4), i64::MAX);
     }

--- a/crates/kotoba-dht/src/dna.rs
+++ b/crates/kotoba-dht/src/dna.rs
@@ -99,7 +99,11 @@ mod tests {
         let more_rules = base.clone().with_rule("bond", cid("r2"));
         let bumped = DnaManifest::new("market", "1.1.0").with_rule("role", cid("r1"));
         let renamed = DnaManifest::new("forum", "1.0.0").with_rule("role", cid("r1"));
-        assert_ne!(base.dna_id(), more_rules.dna_id(), "adding a rule changes id");
+        assert_ne!(
+            base.dna_id(),
+            more_rules.dna_id(),
+            "adding a rule changes id"
+        );
         assert_ne!(base.dna_id(), bumped.dna_id(), "version bump changes id");
         assert_ne!(base.dna_id(), renamed.dna_id(), "rename changes id");
     }

--- a/crates/kotoba-dht/src/governance.rs
+++ b/crates/kotoba-dht/src/governance.rs
@@ -230,7 +230,10 @@ mod tests {
     fn duplicate_attestations_count_once() {
         let c = council(&["alice", "bob"]);
         let r = ratify(&[did("alice"), did("alice"), did("alice")], &c, 2);
-        assert_eq!(r.approvals, 1, "the same member attesting thrice is one approval");
+        assert_eq!(
+            r.approvals, 1,
+            "the same member attesting thrice is one approval"
+        );
         assert!(!r.ratified);
     }
 
@@ -251,8 +254,12 @@ mod tests {
         // padding attesters can ever cross the quorum. Deterministic sweep.
         let c = council(&["alice", "bob", "carol"]);
         let pool = [
-            did("alice"), did("alice"), did("bob"),       // dups
-            did("mallory"), did("eve"), did("carol"),     // non-members + member
+            did("alice"),
+            did("alice"),
+            did("bob"), // dups
+            did("mallory"),
+            did("eve"),
+            did("carol"), // non-members + member
         ];
         for take in 0..=pool.len() {
             let attesters = &pool[..take];
@@ -263,7 +270,10 @@ mod tests {
                     .filter(|a| c.contains(*a))
                     .collect::<HashSet<_>>()
                     .len();
-                assert_eq!(r.approvals, distinct_members, "approvals must be distinct members only");
+                assert_eq!(
+                    r.approvals, distinct_members,
+                    "approvals must be distinct members only"
+                );
                 assert!(r.approvals <= c.len(), "can't exceed the council size");
                 assert_eq!(r.threshold, threshold.max(1), "threshold clamped to >=1");
                 assert_eq!(r.ratified, distinct_members >= threshold.max(1));
@@ -285,7 +295,9 @@ mod tests {
     fn verify_and_ratify_accepts_quorum_of_valid_member_sigs() {
         let (a, b) = (key(1), key(2));
         let council: HashSet<[u8; 32]> =
-            [a.verifying_key().to_bytes(), b.verifying_key().to_bytes()].into_iter().collect();
+            [a.verifying_key().to_bytes(), b.verifying_key().to_bytes()]
+                .into_iter()
+                .collect();
         let v = ParamVersion::new("2.0.0", did("params"));
         let r = verify_and_ratify(&v, &[attest(&a, &v), attest(&b, &v)], &council, 2);
         assert_eq!(r.approvals, 2);
@@ -296,7 +308,9 @@ mod tests {
     fn verify_and_ratify_rejects_forged_wrong_message_and_nonmember() {
         let (a, b, mallory) = (key(1), key(2), key(9));
         let council: HashSet<[u8; 32]> =
-            [a.verifying_key().to_bytes(), b.verifying_key().to_bytes()].into_iter().collect();
+            [a.verifying_key().to_bytes(), b.verifying_key().to_bytes()]
+                .into_iter()
+                .collect();
         let v = ParamVersion::new("2.0.0", did("params"));
         let other = ParamVersion::new("2.0.1", did("params"));
 
@@ -334,7 +348,9 @@ mod tests {
     fn active_params_advances_only_on_ratified_change() {
         let (a, b) = (key(1), key(2));
         let council: HashSet<[u8; 32]> =
-            [a.verifying_key().to_bytes(), b.verifying_key().to_bytes()].into_iter().collect();
+            [a.verifying_key().to_bytes(), b.verifying_key().to_bytes()]
+                .into_iter()
+                .collect();
         let v0 = ParamVersion::new("1.0.0", did("p0"));
         let mut active = ActiveParams::new(v0.clone());
         assert_eq!(active.current_id(), v0.id());
@@ -352,7 +368,11 @@ mod tests {
         let v2 = ParamVersion::new("3.0.0", did("p2"));
         let r2 = active.try_activate(v2.clone(), &[attest(&a, &v2)], &council, 2);
         assert!(!r2.ratified);
-        assert_eq!(active.current_id(), v1.id(), "pointer unchanged on rejection");
+        assert_eq!(
+            active.current_id(),
+            v1.id(),
+            "pointer unchanged on rejection"
+        );
         assert_eq!(active.history(), &[v0.id()], "history unchanged");
     }
 
@@ -366,6 +386,9 @@ mod tests {
         let r = active.try_activate(v0.clone(), &[attest(&a, &v0)], &council, 1);
         assert!(r.ratified);
         assert_eq!(active.current_id(), v0.id());
-        assert!(active.history().is_empty(), "re-activating current adds no history");
+        assert!(
+            active.history().is_empty(),
+            "re-activating current adds no history"
+        );
     }
 }

--- a/crates/kotoba-dht/src/lib.rs
+++ b/crates/kotoba-dht/src/lib.rs
@@ -33,20 +33,20 @@ pub use dna::{DnaManifest, ValidationRuleRef};
 pub use governance::{
     ratify, verify_and_ratify, ActiveParams, Attestation, ParamVersion, Ratification,
 };
-pub use validation::{
-    enforce, load_rules, validate_tx, PhysicsRule, RuleSpec, ValidationOutcome,
+pub use membrane::{
+    bonded_candidates, select_replicas, stake_to_replicate_enabled, ReplicaCandidate,
 };
-pub use membrane::{bonded_candidates, select_replicas, stake_to_replicate_enabled, ReplicaCandidate};
 pub use neighborhood::Neighborhood;
+pub use neighborhood_store::{
+    cid_address, proof_from_store, NeighborhoodBlockStore, PeerTransport,
+};
+pub use node_id::NodeId;
 pub use replication::{
     audit_replication, replication_plan, ReplicationPolicy, ReplicationPolicyStore,
     ReplicationStatus,
 };
 pub use reputation::{prefer_by_reputation, EarnRateBand};
-pub use neighborhood_store::{
-    cid_address, proof_from_store, NeighborhoodBlockStore, PeerTransport,
-};
-pub use node_id::NodeId;
 pub use settlement::{RetainerOwed, SettlementBatch, SettlementLine, SettlementSchedule};
 pub use source_chain::{ChainContent, ChainEntry, SourceChain};
+pub use validation::{enforce, load_rules, validate_tx, PhysicsRule, RuleSpec, ValidationOutcome};
 pub use warrant::{warrant_signing_bytes, ValidationRule, Warrant};

--- a/crates/kotoba-dht/src/membrane.rs
+++ b/crates/kotoba-dht/src/membrane.rs
@@ -49,9 +49,19 @@ pub fn select_replicas(
     membrane_on: bool,
 ) -> Vec<NodeId> {
     // 1+2: admission (bond) then XOR-proximity K-set.
-    let nd: Vec<(NodeId, KotobaCid)> =
-        peers.iter().map(|(n, d, _)| (n.clone(), d.clone())).collect();
-    let bonded = bonded_candidates(address, &nd, root, policy.min_bond_mkoto, pins, K, membrane_on);
+    let nd: Vec<(NodeId, KotobaCid)> = peers
+        .iter()
+        .map(|(n, d, _)| (n.clone(), d.clone()))
+        .collect();
+    let bonded = bonded_candidates(
+        address,
+        &nd,
+        root,
+        policy.min_bond_mkoto,
+        pins,
+        K,
+        membrane_on,
+    );
     // 3: reorder the admitted K-set by reputation (proximity = stable tie-break).
     let rep: std::collections::HashMap<&NodeId, u64> =
         peers.iter().map(|(n, _, r)| (n, *r)).collect();
@@ -68,7 +78,12 @@ pub fn select_replicas(
 /// itself stays pure and testable.
 pub fn stake_to_replicate_enabled() -> bool {
     std::env::var("KOTOBA_STAKE_TO_REPLICATE")
-        .map(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "on" | "yes"))
+        .map(|v| {
+            matches!(
+                v.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "on" | "yes"
+            )
+        })
         .unwrap_or(false)
 }
 
@@ -148,8 +163,9 @@ mod tests {
     fn membrane_off_is_plain_k_nearest() {
         let root = did("rootA");
         let addr = nid(b"rootA-addr");
-        let peers: Vec<(NodeId, KotobaCid)> =
-            (0..10u8).map(|i| (nid(&[i; 4]), did(&format!("did{i}")))).collect();
+        let peers: Vec<(NodeId, KotobaCid)> = (0..10u8)
+            .map(|i| (nid(&[i; 4]), did(&format!("did{i}"))))
+            .collect();
         // empty PinIndex + high floor: with the membrane ON nobody qualifies...
         let pins = PinIndex::new();
         assert!(bonded_candidates(&addr, &peers, &root, 5_000, &pins, 7, true).is_empty());
@@ -157,7 +173,10 @@ mod tests {
         let got = bonded_candidates(&addr, &peers, &root, 5_000, &pins, 7, false);
         let want: Vec<NodeId> = {
             let all: Vec<NodeId> = peers.iter().map(|(n, _)| n.clone()).collect();
-            NodeId::k_nearest(&addr, &all, 7).into_iter().cloned().collect()
+            NodeId::k_nearest(&addr, &all, 7)
+                .into_iter()
+                .cloned()
+                .collect()
         };
         assert_eq!(got, want);
         assert_eq!(got.len(), 7);
@@ -274,7 +293,10 @@ mod tests {
 
         let selected = select_replicas(&root, &addr, &peers, &policy, &pins, true);
         // admission: sybil (no bond) is excluded despite huge reputation.
-        assert!(!selected.contains(&sybil_n), "unbonded Sybil must not be admitted");
+        assert!(
+            !selected.contains(&sybil_n),
+            "unbonded Sybil must not be admitted"
+        );
         // both bonded peers are in; quinn is preferred (higher reputation) first.
         assert_eq!(selected, vec![quinn_n, peggy_n]);
     }
@@ -338,7 +360,10 @@ mod tests {
                 "no duplicates"
             );
             for n in &selected {
-                assert!(eligible.contains(n), "selected a non-eligible node (Sybil leak!)");
+                assert!(
+                    eligible.contains(n),
+                    "selected a non-eligible node (Sybil leak!)"
+                );
             }
             if floor > 5_000 {
                 assert!(selected.is_empty(), "floor above all bonds admits nobody");

--- a/crates/kotoba-dht/src/neighborhood_store.rs
+++ b/crates/kotoba-dht/src/neighborhood_store.rs
@@ -660,8 +660,8 @@ mod tests {
         let (local, id) = local_node(b"local");
         let p1 = MemPeer::new(b"peer-1");
         let p2 = MemPeer::new(b"peer-2");
-        let store = NeighborhoodBlockStore::new(local.clone(), id)
-            .with_peers(vec![p1.clone(), p2.clone()]);
+        let store =
+            NeighborhoodBlockStore::new(local.clone(), id).with_peers(vec![p1.clone(), p2.clone()]);
         let cid = KotobaCid::from_bytes(b"graph-head");
         // local + p1 hold it; p2 (a contracted pinner) does not yet.
         local.put(&cid, b"graph-head").unwrap();

--- a/crates/kotoba-dht/src/replication.rs
+++ b/crates/kotoba-dht/src/replication.rs
@@ -301,7 +301,9 @@ mod tests {
         ciborium::into_writer(&st, &mut buf).unwrap();
         let back: ReplicationStatus = ciborium::from_reader(buf.as_slice()).unwrap();
         assert_eq!(back, st);
-        assert!(!back.satisfied && back.under_replicated_by == 2 && back.missing_pin_peers.len() == 1);
+        assert!(
+            !back.satisfied && back.under_replicated_by == 2 && back.missing_pin_peers.len() == 1
+        );
     }
 
     // ── replication_plan — the enforcement decision (ADR-001 p4) ───────────
@@ -322,7 +324,11 @@ mod tests {
         let st = audit_replication(&policy, 1, &holders);
         assert_eq!(st.under_replicated_by, 2);
         let plan = replication_plan(&st, &holders, &[nid(b"a"), nid(b"b"), nid(b"c"), nid(b"d")]);
-        assert_eq!(plan, vec![nid(b"b"), nid(b"c")], "two fresh candidates, in order");
+        assert_eq!(
+            plan,
+            vec![nid(b"b"), nid(b"c")],
+            "two fresh candidates, in order"
+        );
     }
 
     #[test]
@@ -349,7 +355,11 @@ mod tests {
         let st = audit_replication(&policy, 2, &holders);
         assert!(!st.satisfied);
         let plan = replication_plan(&st, &holders, &[nid(b"c")]);
-        assert_eq!(plan, vec![pinner], "only the missing pinner; no extra replicas");
+        assert_eq!(
+            plan,
+            vec![pinner],
+            "only the missing pinner; no extra replicas"
+        );
     }
 
     #[test]
@@ -368,8 +378,7 @@ mod tests {
         // assert the audit + the recovery plan always obey their contracts.
         let pinner = nid(b"pinner");
         let holders_opts: [&[&[u8]]; 4] = [&[], &[b"h1"], &[b"h1", b"h2"], &[b"pinner"]];
-        let cand_opts: [&[&[u8]]; 4] =
-            [&[], &[b"c1"], &[b"h1", b"c1", b"c2"], &[b"pinner", b"c1"]];
+        let cand_opts: [&[&[u8]]; 4] = [&[], &[b"c1"], &[b"h1", b"c1", b"c2"], &[b"pinner", b"c1"]];
         for min in 0usize..4 {
             for use_pinner in [false, true] {
                 let mut policy = ReplicationPolicy::new(min);
@@ -383,7 +392,10 @@ mod tests {
                     let held: HashSet<&_> = holders.iter().collect();
 
                     // audit contract.
-                    assert_eq!(st.under_replicated_by, policy.min_replicas.saturating_sub(observed));
+                    assert_eq!(
+                        st.under_replicated_by,
+                        policy.min_replicas.saturating_sub(observed)
+                    );
                     for p in &st.missing_pin_peers {
                         assert!(policy.pin_peers.contains(p), "missing not from pin_peers");
                         assert!(!held.contains(p), "a held peer reported missing");

--- a/crates/kotoba-dht/src/reputation.rs
+++ b/crates/kotoba-dht/src/reputation.rs
@@ -78,7 +78,7 @@ impl EarnRateBand {
 /// an XOR-sorted eligible set and proximity remains the tie-breaker.
 pub fn prefer_by_reputation(eligible: &[(NodeId, u64)], k: usize) -> Vec<NodeId> {
     let mut ranked: Vec<&(NodeId, u64)> = eligible.iter().collect();
-    ranked.sort_by(|a, b| b.1.cmp(&a.1)); // stable; reputation descending
+    ranked.sort_by_key(|b| std::cmp::Reverse(b.1)); // stable; reputation descending
     ranked.into_iter().take(k).map(|(n, _)| n.clone()).collect()
 }
 

--- a/crates/kotoba-dht/src/reputation.rs
+++ b/crates/kotoba-dht/src/reputation.rs
@@ -31,19 +31,29 @@ impl EarnRateBand {
         if min_bps <= max_bps {
             Self { min_bps, max_bps }
         } else {
-            Self { min_bps: max_bps, max_bps: min_bps }
+            Self {
+                min_bps: max_bps,
+                max_bps: min_bps,
+            }
         }
     }
 
     /// The identity band (always ×1.0) — reputation weighting off.
     pub fn identity() -> Self {
-        Self { min_bps: 10_000, max_bps: 10_000 }
+        Self {
+            min_bps: 10_000,
+            max_bps: 10_000,
+        }
     }
 
     /// Multiplier in bps for a reputation fraction `r ∈ [0,1]` (clamped): linear
     /// interpolation across the band. `r = 0 → min_bps`, `r = 1 → max_bps`.
     pub fn multiplier_bps(&self, rep_fraction: f64) -> u32 {
-        let r = if rep_fraction.is_nan() { 0.0 } else { rep_fraction.clamp(0.0, 1.0) };
+        let r = if rep_fraction.is_nan() {
+            0.0
+        } else {
+            rep_fraction.clamp(0.0, 1.0)
+        };
         let span = (self.max_bps - self.min_bps) as f64;
         self.min_bps + (span * r).round() as u32
     }
@@ -82,7 +92,10 @@ mod tests {
 
     #[test]
     fn band_normalises_reversed_bounds() {
-        assert_eq!(EarnRateBand::new(20_000, 5_000), EarnRateBand::new(5_000, 20_000));
+        assert_eq!(
+            EarnRateBand::new(20_000, 5_000),
+            EarnRateBand::new(5_000, 20_000)
+        );
     }
 
     #[test]
@@ -125,7 +138,10 @@ mod tests {
             let mut prev = b.min_bps;
             for &r in &reps {
                 let m = b.multiplier_bps(r);
-                assert!(b.min_bps <= m && m <= b.max_bps, "multiplier {m} outside band");
+                assert!(
+                    b.min_bps <= m && m <= b.max_bps,
+                    "multiplier {m} outside band"
+                );
                 // monotonic across the in-range, ascending reps (skip NaN/negatives
                 // which clamp to the floor).
                 if r >= 0.0 && !r.is_nan() {
@@ -135,9 +151,14 @@ mod tests {
                 // scaling stays within [units*min, units*max]/10000, no panic.
                 for &units in &[0u64, 1, 1_000, u64::MAX] {
                     let scaled = b.scale_units(units, r);
-                    let lo = (units as u128 * b.min_bps as u128 / 10_000).min(u64::MAX as u128) as u64;
-                    let hi = (units as u128 * b.max_bps as u128 / 10_000).min(u64::MAX as u128) as u64;
-                    assert!(scaled >= lo && scaled <= hi, "scaled {scaled} outside [{lo},{hi}]");
+                    let lo =
+                        (units as u128 * b.min_bps as u128 / 10_000).min(u64::MAX as u128) as u64;
+                    let hi =
+                        (units as u128 * b.max_bps as u128 / 10_000).min(u64::MAX as u128) as u64;
+                    assert!(
+                        scaled >= lo && scaled <= hi,
+                        "scaled {scaled} outside [{lo},{hi}]"
+                    );
                 }
             }
         }
@@ -152,11 +173,7 @@ mod tests {
 
     #[test]
     fn prefer_orders_by_reputation_desc_and_caps_k() {
-        let pool = vec![
-            (nid(b"low"), 10u64),
-            (nid(b"high"), 100),
-            (nid(b"mid"), 50),
-        ];
+        let pool = vec![(nid(b"low"), 10u64), (nid(b"high"), 100), (nid(b"mid"), 50)];
         let got = prefer_by_reputation(&pool, 2);
         assert_eq!(got, vec![nid(b"high"), nid(b"mid")]);
     }
@@ -166,7 +183,10 @@ mod tests {
         // Equal reputation ⇒ input order preserved (input is XOR-sorted upstream,
         // so proximity stays the tie-breaker).
         let pool = vec![(nid(b"near"), 7u64), (nid(b"far"), 7)];
-        assert_eq!(prefer_by_reputation(&pool, 2), vec![nid(b"near"), nid(b"far")]);
+        assert_eq!(
+            prefer_by_reputation(&pool, 2),
+            vec![nid(b"near"), nid(b"far")]
+        );
     }
 
     #[test]
@@ -181,7 +201,12 @@ mod tests {
             let pool: Vec<(NodeId, u64)> = eligible
                 .iter()
                 .enumerate()
-                .map(|(i, n)| (n.clone(), (seed.wrapping_mul(31).wrapping_add(i as u64)) % 97))
+                .map(|(i, n)| {
+                    (
+                        n.clone(),
+                        (seed.wrapping_mul(31).wrapping_add(i as u64)) % 97,
+                    )
+                })
                 .collect();
             let preferred = prefer_by_reputation(&pool, 8);
             // never invents a node...

--- a/crates/kotoba-dht/src/settlement.rs
+++ b/crates/kotoba-dht/src/settlement.rs
@@ -227,15 +227,18 @@ mod tests {
     fn retainer_owed_excludes_slash_and_aggregates_reward() {
         let schedule = SettlementSchedule::new(100);
         let intents = vec![
-            intent(b"alice", SettlementKind::Reward, 3, 0), // 300
-            intent(b"alice", SettlementKind::Reward, 2, 1), // +200 → 500
-            intent(b"bob", SettlementKind::Reward, 1, 0),   // 100
+            intent(b"alice", SettlementKind::Reward, 3, 0),  // 300
+            intent(b"alice", SettlementKind::Reward, 2, 1),  // +200 → 500
+            intent(b"bob", SettlementKind::Reward, 1, 0),    // 100
             intent(b"mallory", SettlementKind::Slash, 9, 0), // excluded
         ];
         let owed = RetainerOwed::from_intents(&intents, schedule);
         assert_eq!(owed.total_micros, 600, "reward only; slash excluded");
         assert_eq!(owed.per_peer.len(), 2, "alice aggregated, mallory dropped");
-        assert!(owed.per_peer.iter().all(|l| l.kind == SettlementKind::Reward));
+        assert!(owed
+            .per_peer
+            .iter()
+            .all(|l| l.kind == SettlementKind::Reward));
         let alice = NodeId::from_pubkey(b"alice");
         let alice_line = owed.per_peer.iter().find(|l| l.peer == alice).unwrap();
         assert_eq!(alice_line.usdc_micros, 500);
@@ -244,10 +247,8 @@ mod tests {
     #[test]
     fn retainer_owed_empty_when_no_rewards() {
         let schedule = SettlementSchedule::new(10);
-        let owed = RetainerOwed::from_intents(
-            &[intent(b"x", SettlementKind::Slash, 5, 0)],
-            schedule,
-        );
+        let owed =
+            RetainerOwed::from_intents(&[intent(b"x", SettlementKind::Slash, 5, 0)], schedule);
         assert!(owed.is_empty());
         assert_eq!(owed.total_micros, 0);
     }

--- a/crates/kotoba-dht/src/settlement.rs
+++ b/crates/kotoba-dht/src/settlement.rs
@@ -112,7 +112,7 @@ impl SettlementBatch {
 /// sorted deterministically. Slash lines are excluded — this is what the node
 /// owes *out* for availability served, not what it claws back.
 ///
-/// Pure: built from a non-draining [`SettlementIntentSink::snapshot`] so reading
+/// Pure: built from a non-draining [`crate::audit::SettlementIntentSink::snapshot`] so reading
 /// the owed retainer never consumes the settle hand-off queue.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RetainerOwed {

--- a/crates/kotoba-dht/src/validation.rs
+++ b/crates/kotoba-dht/src/validation.rs
@@ -22,7 +22,10 @@ use std::collections::HashSet;
 pub enum ValidationOutcome {
     Valid,
     /// Rejected by `rule_id` with a human-readable `reason`.
-    Rejected { rule_id: String, reason: String },
+    Rejected {
+        rule_id: String,
+        reason: String,
+    },
 }
 
 impl ValidationOutcome {
@@ -109,7 +112,11 @@ impl PhysicsRule for MaxTxSize {
     }
     fn check(&self, tx: &[Datom]) -> Result<(), String> {
         if tx.len() > self.max {
-            return Err(format!("transaction has {} datoms, max is {}", tx.len(), self.max));
+            return Err(format!(
+                "transaction has {} datoms, max is {}",
+                tx.len(),
+                self.max
+            ));
         }
         Ok(())
     }
@@ -168,10 +175,18 @@ where
 {
     let mut rules = Vec::with_capacity(dna.rules().len());
     for r in dna.rules() {
-        let bytes = fetch(&r.content)
-            .ok_or_else(|| format!("rule `{}`: content {} not found", r.id, r.content.to_multibase()))?;
+        let bytes = fetch(&r.content).ok_or_else(|| {
+            format!(
+                "rule `{}`: content {} not found",
+                r.id,
+                r.content.to_multibase()
+            )
+        })?;
         if KotobaCid::from_bytes(&bytes) != r.content {
-            return Err(format!("rule `{}`: content CID mismatch (tampered blob)", r.id));
+            return Err(format!(
+                "rule `{}`: content CID mismatch (tampered blob)",
+                r.id
+            ));
         }
         let spec: RuleSpec = ciborium::from_reader(bytes.as_slice())
             .map_err(|e| format!("rule `{}`: undecodable RuleSpec: {e}", r.id))?;
@@ -258,7 +273,10 @@ mod tests {
 
     #[test]
     fn max_tx_size_caps_transaction() {
-        let r = rules(vec![Box::new(MaxTxSize { id: "size".into(), max: 2 })]);
+        let r = rules(vec![Box::new(MaxTxSize {
+            id: "size".into(),
+            max: 2,
+        })]);
         assert!(validate_tx(&r, &[assert_d("a"), assert_d("b")]).is_valid());
         assert!(!validate_tx(&r, &[assert_d("a"), assert_d("b"), assert_d("c")]).is_valid());
     }
@@ -267,7 +285,10 @@ mod tests {
     fn first_failing_rule_is_reported_deterministically() {
         // size runs first and fails; schema would also fail but size short-circuits.
         let r = rules(vec![
-            Box::new(MaxTxSize { id: "size".into(), max: 0 }),
+            Box::new(MaxTxSize {
+                id: "size".into(),
+                max: 0,
+            }),
             Box::new(AllowedAttributes {
                 id: "schema".into(),
                 allowed: HashSet::new(),
@@ -283,7 +304,10 @@ mod tests {
 
     #[test]
     fn rulespec_content_cid_is_deterministic_and_interprets() {
-        let spec = RuleSpec::MaxTxSize { id: "size".into(), max: 5 };
+        let spec = RuleSpec::MaxTxSize {
+            id: "size".into(),
+            max: 5,
+        };
         assert_eq!(spec.content_cid(), spec.content_cid());
         assert_eq!(spec.content_cid(), KotobaCid::from_bytes(&spec.to_cbor()));
         let rule = spec.into_rule();
@@ -298,9 +322,18 @@ mod tests {
         // an equal value, content_cid must be deterministic, and into_rule must
         // preserve the id + accept/reject semantics.
         let specs = vec![
-            RuleSpec::AllowedAttributes { id: "schema".into(), allowed: vec!["name".into()] },
-            RuleSpec::ForbiddenAttribute { id: "noroot".into(), attr: "system/root".into() },
-            RuleSpec::MaxTxSize { id: "size".into(), max: 2 },
+            RuleSpec::AllowedAttributes {
+                id: "schema".into(),
+                allowed: vec!["name".into()],
+            },
+            RuleSpec::ForbiddenAttribute {
+                id: "noroot".into(),
+                attr: "system/root".into(),
+            },
+            RuleSpec::MaxTxSize {
+                id: "size".into(),
+                max: 2,
+            },
         ];
         for spec in specs {
             // CBOR round-trips to an equal RuleSpec.
@@ -318,12 +351,18 @@ mod tests {
             assert_eq!(spec.into_rule().id(), id);
         }
         // a decoded spec enforces identically to the original (semantics preserved).
-        let orig = RuleSpec::ForbiddenAttribute { id: "f".into(), attr: "x".into() };
-        let decoded: RuleSpec =
-            ciborium::from_reader(orig.clone().to_cbor().as_slice()).unwrap();
+        let orig = RuleSpec::ForbiddenAttribute {
+            id: "f".into(),
+            attr: "x".into(),
+        };
+        let decoded: RuleSpec = ciborium::from_reader(orig.clone().to_cbor().as_slice()).unwrap();
         let ro: Vec<Box<dyn PhysicsRule>> = vec![orig.into_rule()];
         let rd: Vec<Box<dyn PhysicsRule>> = vec![decoded.into_rule()];
-        for tx in [vec![assert_d("x")], vec![assert_d("ok")], vec![retract_d("x")]] {
+        for tx in [
+            vec![assert_d("x")],
+            vec![assert_d("ok")],
+            vec![retract_d("x")],
+        ] {
             assert_eq!(
                 validate_tx(&ro, &tx).is_valid(),
                 validate_tx(&rd, &tx).is_valid(),
@@ -339,7 +378,10 @@ mod tests {
             id: "schema".into(),
             allowed: vec!["name".into(), "role".into()],
         };
-        let size = RuleSpec::MaxTxSize { id: "size".into(), max: 3 };
+        let size = RuleSpec::MaxTxSize {
+            id: "size".into(),
+            max: 3,
+        };
         let dna = DnaManifest::new("market", "1.0.0")
             .with_rule("schema", schema.content_cid())
             .with_rule("size", size.content_cid());
@@ -362,7 +404,10 @@ mod tests {
 
     #[test]
     fn load_rules_errors_on_missing_content() {
-        let spec = RuleSpec::MaxTxSize { id: "size".into(), max: 1 };
+        let spec = RuleSpec::MaxTxSize {
+            id: "size".into(),
+            max: 1,
+        };
         let dna = DnaManifest::new("d", "1").with_rule("size", spec.content_cid());
         let Err(err) = load_rules(&dna, |_| None) else {
             panic!("expected missing-content error");
@@ -372,10 +417,17 @@ mod tests {
 
     #[test]
     fn load_rules_rejects_tampered_content() {
-        let spec = RuleSpec::MaxTxSize { id: "size".into(), max: 1 };
+        let spec = RuleSpec::MaxTxSize {
+            id: "size".into(),
+            max: 1,
+        };
         let dna = DnaManifest::new("d", "1").with_rule("size", spec.content_cid());
         // serve different bytes than the referenced CID addresses → integrity fail.
-        let tampered = RuleSpec::MaxTxSize { id: "size".into(), max: 999 }.to_cbor();
+        let tampered = RuleSpec::MaxTxSize {
+            id: "size".into(),
+            max: 999,
+        }
+        .to_cbor();
         let Err(err) = load_rules(&dna, |_| Some(tampered.clone())) else {
             panic!("expected integrity error");
         };
@@ -453,7 +505,9 @@ mod tests {
         };
         let dna = DnaManifest::new("d", "1").with_rule("schema", schema.content_cid());
         let store: std::collections::HashMap<KotobaCid, Vec<u8>> =
-            [(schema.content_cid(), schema.to_cbor())].into_iter().collect();
+            [(schema.content_cid(), schema.to_cbor())]
+                .into_iter()
+                .collect();
         let fetch = |c: &KotobaCid| store.get(c).cloned();
 
         assert!(enforce(&dna, fetch, &[assert_d("name")]).is_valid());
@@ -462,7 +516,10 @@ mod tests {
 
     #[test]
     fn enforce_rejects_when_dna_cannot_load() {
-        let spec = RuleSpec::MaxTxSize { id: "size".into(), max: 1 };
+        let spec = RuleSpec::MaxTxSize {
+            id: "size".into(),
+            max: 1,
+        };
         let dna = DnaManifest::new("d", "1").with_rule("size", spec.content_cid());
         // content missing → enforce rejects (not silently accepts).
         match enforce(&dna, |_| None, &[assert_d("x")]) {

--- a/crates/kotoba-dht/src/validation.rs
+++ b/crates/kotoba-dht/src/validation.rs
@@ -1,7 +1,7 @@
 //! # Validation hook — enforcing a DNA's shared physics (ADR-001 phase 3 / GROWTH p9)
 //!
 //! The enforcement side of [`crate::dna`]: a proposed transaction is checked
-//! against the DNA's [`ValidationRule`]s before it commits (and on merge results).
+//! against the DNA's `ValidationRule`s before it commits (and on merge results).
 //! Validation is **pure and deterministic** — the same transaction under the same
 //! rules yields the same verdict on every replica, which is what lets a
 //! merge-on-conflict Merkle-CRDT converge without coordination (ADR-001).

--- a/crates/kotoba-dht/tests/stake_to_replicate_e2e.rs
+++ b/crates/kotoba-dht/tests/stake_to_replicate_e2e.rs
@@ -96,14 +96,29 @@ fn observed_bond_drives_both_admission_and_slash() {
         warrant.rule_id,
         ValidationRule::AvailabilityProofFailed as u8
     );
-    assert_eq!(warrant.evidence, evidence.cid(), "evidence is content-addressed");
+    assert_eq!(
+        warrant.evidence,
+        evidence.cid(),
+        "evidence is content-addressed"
+    );
 
     // The slash is sized from the SAME observed bond that admitted peggy.
     let schedule = SlashSchedule::new(2_500, 10_000); // 25% per consecutive miss
     let bond = pins.max_bond_for(&peggy_did, &root);
-    assert_eq!(bond, 6_000, "slash reads the very bond that gated admission");
-    assert_eq!(schedule.slash_amount(bond, 1), 1_500, "first miss → 25% of 6000");
-    assert_eq!(schedule.slash_amount(bond, 4), 6_000, "sustained failure → full bond");
+    assert_eq!(
+        bond, 6_000,
+        "slash reads the very bond that gated admission"
+    );
+    assert_eq!(
+        schedule.slash_amount(bond, 1),
+        1_500,
+        "first miss → 25% of 6000"
+    );
+    assert_eq!(
+        schedule.slash_amount(bond, 4),
+        6_000,
+        "sustained failure → full bond"
+    );
 }
 
 #[test]
@@ -120,7 +135,11 @@ fn membrane_off_admits_unbonded_and_slash_reads_zero_bond() {
     let peers = vec![(node_a.clone(), did_a.clone(), 0u64)];
 
     let selected = select_replicas(&root, &addr, &peers, &policy, &pins, false);
-    assert_eq!(selected, vec![node_a], "membrane off admits the unbonded peer");
+    assert_eq!(
+        selected,
+        vec![node_a],
+        "membrane off admits the unbonded peer"
+    );
 
     let schedule = SlashSchedule::new(2_500, 10_000);
     assert_eq!(

--- a/crates/kotoba-evm/src/anchor.rs
+++ b/crates/kotoba-evm/src/anchor.rs
@@ -261,7 +261,10 @@ mod tests {
         committer[19] = 0xAB; // a real relayer address
         let st = verify_finality(&head, Some(committer));
         assert!(st.anchored);
-        assert!(st.is_final, "a non-zero committer at the local root = finality");
+        assert!(
+            st.is_final,
+            "a non-zero committer at the local root = finality"
+        );
     }
 
     #[test]
@@ -295,7 +298,14 @@ mod tests {
     #[test]
     fn finality_summary_counts_finalized_and_pending() {
         let head = KotobaCid::from_bytes(b"h");
-        let final_st = verify_finality(&head, Some({ let mut a = [0u8; 20]; a[19] = 1; a }));
+        let final_st = verify_finality(
+            &head,
+            Some({
+                let mut a = [0u8; 20];
+                a[19] = 1;
+                a
+            }),
+        );
         let pending_st = verify_finality(&head, None);
         assert_eq!(finality_summary(&[]), FinalitySummary::default());
         let s = finality_summary(&[final_st, pending_st, final_st]);
@@ -313,11 +323,19 @@ mod tests {
         // committer shapes × batch compositions.
         let head = KotobaCid::from_bytes(b"head");
         let committers = [
-            None,                                   // no record → pending
-            Some([0u8; 20]),                        // zero address → pending
-            Some({ let mut a = [0u8; 20]; a[0] = 1; a }),  // non-zero → final
-            Some({ let mut a = [0u8; 20]; a[19] = 1; a }), // non-zero → final
-            Some([0xFF; 20]),                       // non-zero → final
+            None,            // no record → pending
+            Some([0u8; 20]), // zero address → pending
+            Some({
+                let mut a = [0u8; 20];
+                a[0] = 1;
+                a
+            }), // non-zero → final
+            Some({
+                let mut a = [0u8; 20];
+                a[19] = 1;
+                a
+            }), // non-zero → final
+            Some([0xFF; 20]), // non-zero → final
         ];
         let mut statuses = Vec::new();
         for c in committers {
@@ -333,7 +351,10 @@ mod tests {
             let s = finality_summary(&statuses[..n]);
             assert_eq!(s.tracked, n);
             assert_eq!(s.finalized + s.pending, s.tracked, "partition must hold");
-            assert_eq!(s.finalized, statuses[..n].iter().filter(|x| x.is_final).count());
+            assert_eq!(
+                s.finalized,
+                statuses[..n].iter().filter(|x| x.is_final).count()
+            );
         }
     }
 

--- a/crates/kotoba-lattice/src/deploy.rs
+++ b/crates/kotoba-lattice/src/deploy.rs
@@ -116,7 +116,9 @@ mod tests {
         let msgs = deploy_messages(&AppManifest::from_edn(src).unwrap(), &resolved);
         match &msgs[0].1 {
             LatticeMessage::PutRoutes { routes, .. } => {
-                assert!(routes.kse_targets("t").contains(&"bafyCompiled".to_string()));
+                assert!(routes
+                    .kse_targets("t")
+                    .contains(&"bafyCompiled".to_string()));
             }
             _ => panic!("expected PutRoutes"),
         }

--- a/crates/kotoba-lattice/src/lib.rs
+++ b/crates/kotoba-lattice/src/lib.rs
@@ -35,7 +35,6 @@ pub mod trigger;
 
 pub use control::{app_to_quads, desired_from_quads, ControlQuad};
 pub use deploy::deploy_messages;
-pub use routes::TriggerRoutes;
 pub use error::LatticeError;
 pub use manifest::{AppManifest, ComponentSpec, Lang, LinkSpec, Placement, TriggerSpec};
 pub use node::{LatticeController, RecordingTransport, Transport};
@@ -46,4 +45,5 @@ pub use protocol::{
     topic, Auction, Award, Bid, Constraints, Heartbeat, LatticeMessage, Link, NodeRole,
 };
 pub use reconcile::{award_winners, need_actions, observed_counts, score_bid, NeedAction};
+pub use routes::TriggerRoutes;
 pub use trigger::{delta_triggers, fired_by_batch, fired_by_datom, DeltaTrigger};

--- a/crates/kotoba-lattice/src/routes.rs
+++ b/crates/kotoba-lattice/src/routes.rs
@@ -47,7 +47,8 @@ impl TriggerRoutes {
                         }
                     }
                     "cron" => {
-                        r.cron.push((cid.clone(), t.schedule.clone().unwrap_or_default()));
+                        r.cron
+                            .push((cid.clone(), t.schedule.clone().unwrap_or_default()));
                     }
                     "http" => {
                         if let Some(route) = &t.route {
@@ -133,7 +134,10 @@ mod tests {
         let r = routes();
         assert_eq!(r.http_target("/reply"), Some("bafyReply"));
         assert_eq!(r.http_target("/nope"), None);
-        assert_eq!(r.cron, vec![("bafyReply".to_string(), "every 5m".to_string())]);
+        assert_eq!(
+            r.cron,
+            vec![("bafyReply".to_string(), "every 5m".to_string())]
+        );
     }
 
     #[test]
@@ -147,12 +151,17 @@ mod tests {
     fn resolved_cid_overrides_placeholder() {
         let resolved = BTreeMap::from([("fanout".to_string(), "bafyFanout".to_string())]);
         let r = TriggerRoutes::from_app(&AppManifest::from_edn(APP).unwrap(), &resolved);
-        assert!(r.kse_targets("kotoba/mail/in").contains(&"bafyFanout".to_string()));
+        assert!(r
+            .kse_targets("kotoba/mail/in")
+            .contains(&"bafyFanout".to_string()));
     }
 
     #[test]
     fn empty_app_has_empty_routes() {
-        let r = TriggerRoutes::from_app(&AppManifest::from_edn(r#"{:kotoba.app/name "x"}"#).unwrap(), &BTreeMap::new());
+        let r = TriggerRoutes::from_app(
+            &AppManifest::from_edn(r#"{:kotoba.app/name "x"}"#).unwrap(),
+            &BTreeMap::new(),
+        );
         assert!(r.is_empty());
     }
 

--- a/crates/kotoba-runtime/src/executor.rs
+++ b/crates/kotoba-runtime/src/executor.rs
@@ -110,7 +110,15 @@ impl WasmExecutor {
     ) -> Result<InvokeResult, RuntimeError> {
         use wasmtime::component::Val;
         let args = vec![Val::List(ctx_cbor.iter().map(|b| Val::U8(*b)).collect())];
-        self.invoke(program_cid, wasm_bytes, agent_did, "run", args, quad_snapshot, head_commits)
+        self.invoke(
+            program_cid,
+            wasm_bytes,
+            agent_did,
+            "run",
+            args,
+            quad_snapshot,
+            head_commits,
+        )
     }
 
     /// HTTP trigger (M11): `on-http(req-cbor) -> result` — same ABI as `run`.
@@ -125,7 +133,15 @@ impl WasmExecutor {
     ) -> Result<InvokeResult, RuntimeError> {
         use wasmtime::component::Val;
         let args = vec![Val::List(req_cbor.iter().map(|b| Val::U8(*b)).collect())];
-        self.invoke(program_cid, wasm_bytes, agent_did, "on-http", args, quad_snapshot, head_commits)
+        self.invoke(
+            program_cid,
+            wasm_bytes,
+            agent_did,
+            "on-http",
+            args,
+            quad_snapshot,
+            head_commits,
+        )
     }
 
     /// Cron trigger (M11): `on-tick(epoch-ms: u64) -> result`.
@@ -140,7 +156,15 @@ impl WasmExecutor {
     ) -> Result<InvokeResult, RuntimeError> {
         use wasmtime::component::Val;
         let args = vec![Val::U64(epoch_ms)];
-        self.invoke(program_cid, wasm_bytes, agent_did, "on-tick", args, quad_snapshot, head_commits)
+        self.invoke(
+            program_cid,
+            wasm_bytes,
+            agent_did,
+            "on-tick",
+            args,
+            quad_snapshot,
+            head_commits,
+        )
     }
 
     /// KSE-topic trigger (M11): `on-kse(topic: string, payload: list<u8>) -> result`.
@@ -160,7 +184,15 @@ impl WasmExecutor {
             Val::String(topic),
             Val::List(payload.iter().map(|b| Val::U8(*b)).collect()),
         ];
-        self.invoke(program_cid, wasm_bytes, agent_did, "on-kse", args, quad_snapshot, head_commits)
+        self.invoke(
+            program_cid,
+            wasm_bytes,
+            agent_did,
+            "on-kse",
+            args,
+            quad_snapshot,
+            head_commits,
+        )
     }
 
     /// Invoke a named component export via dynamic `Val` dispatch, applying the

--- a/crates/kotoba-server/src/dht_audit.rs
+++ b/crates/kotoba-server/src/dht_audit.rs
@@ -14,9 +14,7 @@
 use crate::dht_transport::HttpProofFetcher;
 use kotoba_core::cid::KotobaCid;
 use kotoba_core::store::BlockStore;
-use kotoba_dht::{
-    AuditAction, AuditScheduler, AvailabilityAuditor, NodeId, SettlementIntentSink,
-};
+use kotoba_dht::{AuditAction, AuditScheduler, AvailabilityAuditor, NodeId, SettlementIntentSink};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -98,10 +96,7 @@ pub fn resolve_endpoints(urls: &[String]) -> HashMap<NodeId, String> {
         if base.is_empty() {
             continue;
         }
-        let info_url = format!(
-            "{base}/xrpc/{}",
-            crate::availability_xrpc::NSID_DHT_INFO
-        );
+        let info_url = format!("{base}/xrpc/{}", crate::availability_xrpc::NSID_DHT_INFO);
         let Ok(resp) = client.get(&info_url).send() else {
             continue;
         };
@@ -114,7 +109,9 @@ pub fn resolve_endpoints(urls: &[String]) -> HashMap<NodeId, String> {
         let Some(hex_id) = body.get("node_id").and_then(|v| v.as_str()) else {
             continue;
         };
-        let Ok(bytes) = hex::decode(hex_id) else { continue };
+        let Ok(bytes) = hex::decode(hex_id) else {
+            continue;
+        };
         let Ok(arr) = <[u8; 32]>::try_from(bytes.as_slice()) else {
             continue;
         };
@@ -264,7 +261,10 @@ mod tests {
         std::env::set_var("KOTOBA_IPFS", "off");
         let state = Arc::new(KotobaState::new(None).expect("state"));
         let block = KotobaCid::from_bytes(b"audit-runner-block");
-        state.block_store.put(&block, b"audit-runner-block").unwrap();
+        state
+            .block_store
+            .put(&block, b"audit-runner-block")
+            .unwrap();
         let server_node: NodeId = state.local_node_id.clone();
 
         let app = build_router(state.clone());
@@ -279,10 +279,15 @@ mod tests {
             // Auditor holds its own copy so it can verify the peer's proof.
             let local = Arc::new(kotoba_store::MemoryBlockStore::new());
             local.put(&block, b"audit-runner-block").unwrap();
-            let endpoints =
-                HashMap::from([(server_node.clone(), format!("http://{addr}"))]);
+            let endpoints = HashMap::from([(server_node.clone(), format!("http://{addr}"))]);
             let sink = Arc::new(SettlementIntentSink::new(10, 5));
-            let summary = audit_epoch(local, endpoints, 1, std::slice::from_ref(&block), sink.clone());
+            let summary = audit_epoch(
+                local,
+                endpoints,
+                1,
+                std::slice::from_ref(&block),
+                sink.clone(),
+            );
 
             // the reward verdict became a pending settlement intent...
             let pending = sink.snapshot();
@@ -313,8 +318,13 @@ mod tests {
             // endpoint points nowhere listening.
             let endpoints = HashMap::from([(dead, "http://127.0.0.1:1".to_string())]);
             let sink = Arc::new(SettlementIntentSink::new(10, 5));
-            let summary =
-                audit_epoch(local, endpoints, 1, std::slice::from_ref(&block), sink.clone());
+            let summary = audit_epoch(
+                local,
+                endpoints,
+                1,
+                std::slice::from_ref(&block),
+                sink.clone(),
+            );
             assert_eq!(sink.snapshot().len(), 0, "unreachable → no intent");
             summary
         })
@@ -391,7 +401,11 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(resolved.len(), 1, "discovered exactly one peer from its URL");
+        assert_eq!(
+            resolved.len(),
+            1,
+            "discovered exactly one peer from its URL"
+        );
         assert!(
             resolved.contains_key(&server_node),
             "resolved node id matches the server's real local_node_id"
@@ -477,7 +491,10 @@ mod tests {
 
         std::env::set_var("KOTOBA_DHT_AUDIT_INTERVAL_SECS", "0");
         std::env::set_var("KOTOBA_DHT_AUDIT_PEERS", "http://p:1");
-        assert!(AuditLoopConfig::from_env().is_none(), "interval 0 → disabled");
+        assert!(
+            AuditLoopConfig::from_env().is_none(),
+            "interval 0 → disabled"
+        );
 
         std::env::set_var("KOTOBA_DHT_AUDIT_INTERVAL_SECS", "30");
         std::env::remove_var("KOTOBA_DHT_AUDIT_PEERS");

--- a/crates/kotoba-server/src/dna_integrity.rs
+++ b/crates/kotoba-server/src/dna_integrity.rs
@@ -221,7 +221,11 @@ mod tests {
                 :integrity/closed-attrs [:a/x :b/y]}"#,
         )
         .unwrap();
-        assert_eq!(a.dna_id(), b.dna_id(), "same physics → same DNA id (graph-independent)");
+        assert_eq!(
+            a.dna_id(),
+            b.dna_id(),
+            "same physics → same DNA id (graph-independent)"
+        );
         assert_eq!(a.dna_id(), a.dna_id(), "deterministic");
     }
 
@@ -230,11 +234,19 @@ mod tests {
         let base = rules();
         let mut stricter = base.clone();
         stricter.deny_attrs.insert(":secret".into());
-        assert_ne!(base.dna_id(), stricter.dna_id(), "an added deny changes the DNA id");
+        assert_ne!(
+            base.dna_id(),
+            stricter.dna_id(),
+            "an added deny changes the DNA id"
+        );
 
         let mut not_append = base.clone();
         not_append.append_only = false;
-        assert_ne!(base.dna_id(), not_append.dna_id(), "append-only flag changes id");
+        assert_ne!(
+            base.dna_id(),
+            not_append.dna_id(),
+            "append-only flag changes id"
+        );
 
         // open (no closed-attrs) differs from any closed schema.
         let mut open = base.clone();

--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -1053,7 +1053,10 @@ async fn mesh_http(
         .http_target(&full)
         .map(str::to_string);
     let Some(cid) = cid else {
-        return (StatusCode::NOT_FOUND, format!("no mesh component for route {full}"))
+        return (
+            StatusCode::NOT_FOUND,
+            format!("no mesh component for route {full}"),
+        )
             .into_response();
     };
     match net_actor::invoke_trigger(
@@ -2068,7 +2071,9 @@ pub async fn run() -> anyhow::Result<()> {
                 ));
 
                 tracing::info!("kotoba-net swarm started (QUIC + GossipSub + Kademlia)");
-                state.attach_gossip(publish_tx).attach_lattice_inject(inject_tx)
+                state
+                    .attach_gossip(publish_tx)
+                    .attach_lattice_inject(inject_tx)
             }
             Err(e) => {
                 tracing::warn!(err = %e, "swarm init failed — running without p2p");

--- a/crates/kotoba-server/src/mishmar_observe.rs
+++ b/crates/kotoba-server/src/mishmar_observe.rs
@@ -481,11 +481,23 @@ mod tests {
     fn observe_finality_reads_committer_over_eth_call() {
         let head = KotobaCid::from_bytes(b"final-head");
         // non-zero committer → final.
-        let st = observe_finality(&FakeCall { result: address_word(0xAA) }, "0xanchor", &head);
+        let st = observe_finality(
+            &FakeCall {
+                result: address_word(0xAA),
+            },
+            "0xanchor",
+            &head,
+        );
         assert!(st.is_final);
         assert_eq!(st.root_hash, kotoba_evm::anchor::root_hash_of(&head));
         // zero committer (never anchored) → not final.
-        let zero = observe_finality(&FakeCall { result: address_word(0) }, "0xanchor", &head);
+        let zero = observe_finality(
+            &FakeCall {
+                result: address_word(0),
+            },
+            "0xanchor",
+            &head,
+        );
         assert!(!zero.is_final);
     }
 
@@ -512,7 +524,10 @@ mod tests {
         }
         assert!(FinalityLoopConfig::from_env().is_none(), "unset → disabled");
         std::env::set_var("KOTOBA_FINALITY_INTERVAL_SECS", "60");
-        assert!(FinalityLoopConfig::from_env().is_none(), "no rpc/anchor → disabled");
+        assert!(
+            FinalityLoopConfig::from_env().is_none(),
+            "no rpc/anchor → disabled"
+        );
         std::env::set_var("KOTOBA_ANCHOR_RPC_URL", "http://base-rpc:8545");
         std::env::set_var("KOTOBA_ANCHOR_ADDRESS", "0xanchor");
         let cfg = FinalityLoopConfig::from_env().expect("enabled");
@@ -520,7 +535,10 @@ mod tests {
         assert_eq!(cfg.anchor_address, "0xanchor");
         // interval 0 disables even with rpc/anchor set.
         std::env::set_var("KOTOBA_FINALITY_INTERVAL_SECS", "0");
-        assert!(FinalityLoopConfig::from_env().is_none(), "interval 0 → disabled");
+        assert!(
+            FinalityLoopConfig::from_env().is_none(),
+            "interval 0 → disabled"
+        );
         for k in [
             "KOTOBA_FINALITY_INTERVAL_SECS",
             "KOTOBA_ANCHOR_RPC_URL",
@@ -539,15 +557,22 @@ mod tests {
         ));
         // a non-zero committer at the active version id → params anchored/final.
         let st = observe_params_finality(
-            &FakeCall { result: address_word(0xAB) },
+            &FakeCall {
+                result: address_word(0xAB),
+            },
             "0xanchor",
             &active,
         );
         assert!(st.is_final);
-        assert_eq!(st.root_hash, kotoba_evm::anchor::root_hash_of(&active.current_id()));
+        assert_eq!(
+            st.root_hash,
+            kotoba_evm::anchor::root_hash_of(&active.current_id())
+        );
         // zero committer → not yet anchored.
         let pending = observe_params_finality(
-            &FakeCall { result: address_word(0) },
+            &FakeCall {
+                result: address_word(0),
+            },
             "0xanchor",
             &active,
         );
@@ -561,8 +586,13 @@ mod tests {
             KotobaCid::from_bytes(b"head-a"),
             KotobaCid::from_bytes(b"head-b"),
         ];
-        let pairs =
-            observe_finalities(&FakeCall { result: address_word(0xAB) }, "0xanchor", &heads);
+        let pairs = observe_finalities(
+            &FakeCall {
+                result: address_word(0xAB),
+            },
+            "0xanchor",
+            &heads,
+        );
         assert_eq!(pairs.len(), 2);
         assert_eq!(pairs[0].0, heads[0]); // order + head preserved
         let statuses: Vec<_> = pairs.iter().map(|(_, s)| *s).collect();

--- a/crates/kotoba-server/src/net_actor.rs
+++ b/crates/kotoba-server/src/net_actor.rs
@@ -194,14 +194,19 @@ async fn apply_deploy_msg(
     match lmsg {
         kotoba_lattice::LatticeMessage::PutTriggers { triggers, .. } => {
             *delta_triggers = triggers.clone();
-            tracing::info!(n = delta_triggers.len(), "lattice: datom-Δ triggers installed");
+            tracing::info!(
+                n = delta_triggers.len(),
+                "lattice: datom-Δ triggers installed"
+            );
         }
         kotoba_lattice::LatticeMessage::PutRoutes { routes: r, .. } => {
             for topic in r.kse_topics() {
                 swarm.subscribe(topic).ok();
             }
             tracing::info!(
-                kse = r.kse.len(), cron = r.cron.len(), http = r.http.len(),
+                kse = r.kse.len(),
+                cron = r.cron.len(),
+                http = r.http.len(),
                 "lattice: event-source routes installed"
             );
             *routes = r.clone();
@@ -667,10 +672,27 @@ mod tests {
         let cid = KotobaCid::from_bytes(b"absent-component").to_multibase();
         let did = "did:self";
         assert!(invoke_trigger(&exec, &store, did, &cid, ComponentTrigger::Run).is_none());
-        assert!(invoke_trigger(&exec, &store, did, &cid, ComponentTrigger::Http(b"req".to_vec())).is_none());
-        assert!(invoke_trigger(&exec, &store, did, &cid, ComponentTrigger::Tick(1_700_000_000_000)).is_none());
         assert!(invoke_trigger(
-            &exec, &store, did, &cid,
+            &exec,
+            &store,
+            did,
+            &cid,
+            ComponentTrigger::Http(b"req".to_vec())
+        )
+        .is_none());
+        assert!(invoke_trigger(
+            &exec,
+            &store,
+            did,
+            &cid,
+            ComponentTrigger::Tick(1_700_000_000_000)
+        )
+        .is_none());
+        assert!(invoke_trigger(
+            &exec,
+            &store,
+            did,
+            &cid,
             ComponentTrigger::Kse("kotoba/mail/in".into(), b"payload".to_vec())
         )
         .is_none());
@@ -699,9 +721,14 @@ mod tests {
         let exec = test_executor();
         let cid = kc.to_multibase();
         // present but uncompilable → every variant returns None (no panic)
-        assert!(invoke_trigger(&exec, &store, "did:self", &cid, ComponentTrigger::Tick(5)).is_none());
+        assert!(
+            invoke_trigger(&exec, &store, "did:self", &cid, ComponentTrigger::Tick(5)).is_none()
+        );
         assert!(invoke_trigger(
-            &exec, &store, "did:self", &cid,
+            &exec,
+            &store,
+            "did:self",
+            &cid,
             ComponentTrigger::Kse("t".into(), b"p".to_vec())
         )
         .is_none());
@@ -813,13 +840,24 @@ mod tests {
             Arc::new(kotoba_store::MemoryBlockStore::new());
         let quad_store = Arc::new(QuadStore::new(Arc::clone(&journal), Arc::clone(&store)));
         let executor = Arc::new(kotoba_runtime::WasmExecutor::new(10_000_000).unwrap());
-        let mesh_routes =
-            Arc::new(tokio::sync::RwLock::new(kotoba_lattice::TriggerRoutes::default()));
+        let mesh_routes = Arc::new(tokio::sync::RwLock::new(
+            kotoba_lattice::TriggerRoutes::default(),
+        ));
         let (_inject_tx, inject_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
 
         tokio::spawn(run(
-            node, pub_rx, journal, pin_tx, pout_rx, store, quad_store, None, false, executor,
-            mesh_routes, inject_rx,
+            node,
+            pub_rx,
+            journal,
+            pin_tx,
+            pout_rx,
+            store,
+            quad_store,
+            None,
+            false,
+            executor,
+            mesh_routes,
+            inject_rx,
         ));
 
         // observer waits for the run-node's heartbeat (interval is 5 s; first

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -2209,9 +2209,7 @@ fn verify_datomic_cacao_payload_with_operations(
 
 /// Decode a `cacao_b64`-derived CBOR blob into a delegation chain: a single CACAO
 /// (CBOR map, depth-1) or a `[root, leaf]` array (depth-2 team delegation).
-fn decode_cacao_chain(
-    cbor: &[u8],
-) -> Result<kotoba_auth::DelegationChain, (StatusCode, String)> {
+fn decode_cacao_chain(cbor: &[u8]) -> Result<kotoba_auth::DelegationChain, (StatusCode, String)> {
     match kotoba_auth::Cacao::from_cbor(cbor) {
         Ok(cacao) => Ok(kotoba_auth::DelegationChain::new(cacao)),
         Err(_) => kotoba_auth::DelegationChain::from_cbor_chain(cbor)
@@ -7343,16 +7341,16 @@ fn effective_replication_policy(
     let min_replicas = min_replicas_env
         .and_then(|s| s.parse::<usize>().ok())
         .unwrap_or(if peer_count > 0 { 2 } else { 1 });
-    let min_bond_mkoto = min_bond_env.and_then(|s| s.parse::<i64>().ok()).unwrap_or(0);
+    let min_bond_mkoto = min_bond_env
+        .and_then(|s| s.parse::<i64>().ok())
+        .unwrap_or(0);
     kotoba_dht::ReplicationPolicy::new(min_replicas).with_min_bond(min_bond_mkoto)
 }
 
 /// The owed-retainer view (ADR-002 p3) for `node.status`, from a settlement
 /// sink's pending intents. Reward-only, per-peer + total USDC micros. Pure over
 /// the snapshot (non-draining) so reading status never consumes the settle queue.
-fn owed_retainer_json(
-    sink: &kotoba_dht::SettlementIntentSink,
-) -> serde_json::Value {
+fn owed_retainer_json(sink: &kotoba_dht::SettlementIntentSink) -> serde_json::Value {
     let owed = kotoba_dht::RetainerOwed::from_intents(
         &sink.snapshot(),
         kotoba_dht::SettlementSchedule::new(1),
@@ -9664,16 +9662,16 @@ mod tests {
         datomic_pull, datomic_pull_many, datomic_q, datomic_q_emit_cids, datomic_seek_datoms,
         datomic_sync, datomic_transact, datomic_tx_range, datomic_with, did_document_publish,
         didcomm_send, distributed_graph_ipns_name, effective_replication_policy,
-        enforce_datomic_range_tx_scope, owed_retainer_json,
-        is_did_web_ip_host, protocol_payload_tx_cid, vc_issue, vp_capability_projection,
-        warm_datomic_resident_cache, AtprotoRepoWriteReq, AuthCapabilityProjection,
-        DatomicBasisTReq, DatomicDatomsIndex, DatomicDatomsReq, DatomicDbStatsReq, DatomicEntidReq,
-        DatomicEntityReq, DatomicHistoryReq, DatomicIdentReq, DatomicIndexPullReq,
-        DatomicIndexRangeReq, DatomicLogReq, DatomicPullManyReq, DatomicPullReq, DatomicQReq,
-        DatomicSeekDatomsReq, DatomicSyncReq, DatomicTransactReq, DatomicTxRangeReq,
-        DatomicWarmOutcome, DatomicWithReq, DidCommSendReq, DidDocumentPublishReq, VcIssueReq,
-        ZCAP_ALLOWED_ACTION_IRI, ZCAP_CAPABILITY_INVOCATION_IRI, ZCAP_CONTROLLER_IRI,
-        ZCAP_INVOCATION_PROOF_IRI, ZCAP_INVOCATION_TARGET_IRI, ZCAP_INVOKER_IRI,
+        enforce_datomic_range_tx_scope, is_did_web_ip_host, owed_retainer_json,
+        protocol_payload_tx_cid, vc_issue, vp_capability_projection, warm_datomic_resident_cache,
+        AtprotoRepoWriteReq, AuthCapabilityProjection, DatomicBasisTReq, DatomicDatomsIndex,
+        DatomicDatomsReq, DatomicDbStatsReq, DatomicEntidReq, DatomicEntityReq, DatomicHistoryReq,
+        DatomicIdentReq, DatomicIndexPullReq, DatomicIndexRangeReq, DatomicLogReq,
+        DatomicPullManyReq, DatomicPullReq, DatomicQReq, DatomicSeekDatomsReq, DatomicSyncReq,
+        DatomicTransactReq, DatomicTxRangeReq, DatomicWarmOutcome, DatomicWithReq, DidCommSendReq,
+        DidDocumentPublishReq, VcIssueReq, ZCAP_ALLOWED_ACTION_IRI, ZCAP_CAPABILITY_INVOCATION_IRI,
+        ZCAP_CONTROLLER_IRI, ZCAP_INVOCATION_PROOF_IRI, ZCAP_INVOCATION_TARGET_IRI,
+        ZCAP_INVOKER_IRI,
     };
     use crate::server::KotobaState;
     use axum::response::IntoResponse;
@@ -9710,7 +9708,10 @@ mod tests {
         assert_eq!(bad.min_replicas, 2);
         assert_eq!(bad.min_bond_mkoto, 0);
         // min_replicas is clamped to ≥ 1 even if env says 0.
-        assert_eq!(effective_replication_policy(Some("0"), None, 0).min_replicas, 1);
+        assert_eq!(
+            effective_replication_policy(Some("0"), None, 0).min_replicas,
+            1
+        );
     }
 
     #[test]
@@ -10497,8 +10498,20 @@ mod tests {
         };
 
         // root: org → member ; leaf: member → server. Serialize [root, leaf] as a CBOR array.
-        let root = sign(&owner_key, &owner_did, &member_did, "d2-root-1", &["datom:transact", "tx:create"]);
-        let leaf = sign(&member_key, &member_did, &aud, "d2-leaf-1", &["datom:transact", "tx:create"]);
+        let root = sign(
+            &owner_key,
+            &owner_did,
+            &member_did,
+            "d2-root-1",
+            &["datom:transact", "tx:create"],
+        );
+        let leaf = sign(
+            &member_key,
+            &member_did,
+            &aud,
+            "d2-leaf-1",
+            &["datom:transact", "tx:create"],
+        );
         let mut cbor = Vec::new();
         ciborium::into_writer(&vec![root, leaf], &mut cbor).unwrap();
         let chain_b64 = base64::engine::general_purpose::STANDARD.encode(cbor);
@@ -10526,7 +10539,13 @@ mod tests {
         }
 
         // a member WITHOUT delegation (bare single CACAO) cannot write the org graph
-        let solo = sign(&member_key, &member_did, &aud, "d2-solo-1", &["datom:transact", "tx:create"]);
+        let solo = sign(
+            &member_key,
+            &member_did,
+            &aud,
+            "d2-solo-1",
+            &["datom:transact", "tx:create"],
+        );
         let mut sb = Vec::new();
         ciborium::into_writer(&solo, &mut sb).unwrap();
         let solo_b64 = base64::engine::general_purpose::STANDARD.encode(sb);

--- a/crates/kotoba-wasm/src/lib.rs
+++ b/crates/kotoba-wasm/src/lib.rs
@@ -843,8 +843,11 @@ impl WriteCrypto {
                 s: String::new(),
             },
         };
-        leaf.s.s =
-            URL_SAFE_NO_PAD.encode(self.signing_key.sign(leaf.siwe_message().as_bytes()).to_bytes());
+        leaf.s.s = URL_SAFE_NO_PAD.encode(
+            self.signing_key
+                .sign(leaf.siwe_message().as_bytes())
+                .to_bytes(),
+        );
         let chain = vec![root, leaf];
         let mut cbor = Vec::new();
         ciborium::into_writer(&chain, &mut cbor).map_err(|e| e.to_string())?;
@@ -1607,16 +1610,16 @@ mod tests {
         }
 
         // Wrong capability / wrong graph are rejected.
-        assert!(kotoba_auth::DelegationChain::new(
-            kotoba_auth::Cacao::from_cbor(&cbor).unwrap()
-        )
-        .verify(graph, "datom:read")
-        .is_err());
-        assert!(kotoba_auth::DelegationChain::new(
-            kotoba_auth::Cacao::from_cbor(&cbor).unwrap()
-        )
-        .verify("bafy-other-graph", "datom:transact")
-        .is_err());
+        assert!(
+            kotoba_auth::DelegationChain::new(kotoba_auth::Cacao::from_cbor(&cbor).unwrap())
+                .verify(graph, "datom:read")
+                .is_err()
+        );
+        assert!(
+            kotoba_auth::DelegationChain::new(kotoba_auth::Cacao::from_cbor(&cbor).unwrap())
+                .verify("bafy-other-graph", "datom:transact")
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/kotoba-wasm/src/lib.rs
+++ b/crates/kotoba-wasm/src/lib.rs
@@ -796,6 +796,9 @@ impl WriteCrypto {
     /// then serializes `[root, leaf]` as a CBOR array → base64 for `cacao_b64`. The
     /// server verifies attenuation and binds the write to the ROOT issuer (the owner),
     /// so a team member can write to the org's graph (docs/gftd-office team sharing).
+    // CACAO delegation needs every field of the leaf claim; bundling them into a
+    // struct would not improve clarity at this single call site.
+    #[allow(clippy::too_many_arguments)]
     pub fn mint_delegated(
         &self,
         root_grant_b64: &str,


### PR DESCRIPTION
## Why

main drifted from the bumped Rust toolchain (rustfmt/clippy **0.1.96**, 2026-05-25), so the **Format** and **Clippy all-features** CI gates were red on *every* PR (e.g. #206), independent of each PR's own code.

## What

- **`cargo fmt`** across the workspace (30 files) — pure formatter output, no logic changes.
- **clippy 0.1.96 fixes** (`--workspace --all-targets --all-features -- -D warnings`):
  - `kotoba-dht` reputation: `sort_by(|a,b| b.cmp(a))` → `sort_by_key(Reverse)` (`unnecessary_sort_by`, machine-applicable).
  - `kotoba-wasm` `mint_delegated`: `#[allow(clippy::too_many_arguments)]` — every field of the CACAO leaf claim is needed at this one call site; a param struct wouldn't add clarity.

## Verification

- `cargo fmt --check` — clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean (exit 0)

No behavior changes; this is toolchain-realignment maintenance so subsequent PRs get green Rust gates again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)