### PR TITLE
feat(gitoffice): GitHub-style PR layer for office docs

### DIFF
--- a/crates/kotoba-wasm/web/cljs/shadow-cljs.edn
+++ b/crates/kotoba-wasm/web/cljs/shadow-cljs.edn
@@ -39,6 +39,10 @@
                discoverOperatorDid kotoba.office/discover-operator-did
                storeOrg        kotoba.office/store-org!
                storeGrant      kotoba.office/store-grant!
+               ;; GitOffice PR layer (docs/gftd-office doc e): normalize + diff/merge/gate
+               storeDocumentBody  kotoba.gitoffice-node/storeDocumentBody
+               storeWorkbookGrid  kotoba.gitoffice-node/storeWorkbookGrid
+               evaluateMerge      kotoba.gitoffice-node/evaluateMerge
                ;; membership grant -> CACAO bridge (doc b/d)
                mintCacaoViaNode kotoba.cacao/mint-cacao!
                mintDelegated    kotoba.cacao/mint-delegated!

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/gitdiff.cljc
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/gitdiff.cljc
@@ -1,0 +1,128 @@
+(ns kotoba.gitdiff
+  "GitOffice Phase 1 (doc e §3-§4 partial) — semantic diff + merge-base/LCA.
+
+   Pure (.cljc). Operates on the element-granular nodes produced by Phase 0
+   (gitoffice/body->blocks, grid->cells): a node set is a map {stable-id -> attr-map}.
+
+   - diff-nodes: stable-id keyed diff -> {:added :removed :moved :modified :unchanged}.
+     This is the SEMANTIC diff doc e argues for: not text lines but elements keyed by a
+     save-stable id (block elementId / cell A1 / shape ocz1:). A move (order-only change)
+     is distinguished from a content change; a content change carries per-attribute deltas.
+   - doc-nodes / sheet-nodes: lift Phase-0 datoms into node sets.
+   - commit-ancestors / merge-base: LCA over a commit DAG {commit -> {:parents [...]}} so a
+     3-way merge (Phase 3) has its common base."
+  (:require [kotoba.gitoffice :as g]
+            [clojure.set :as set]))
+
+;; ---------------------------------------------------------------------------
+;; node sets (lift Phase-0 datoms into {stable-id -> attrs})
+;; ---------------------------------------------------------------------------
+
+(defn doc-nodes
+  "{block-id -> {:kind :text :order :heading-level?}} for one doc."
+  [datoms doc-id]
+  (->> datoms
+       (keep (fn [[e a v]] (when (and (= a :block/parent) (= v doc-id)) e)))
+       distinct
+       (reduce (fn [m bid]
+                 (assoc m bid
+                        (cond-> {:kind  (g/v-one datoms bid :block/kind)
+                                 :text  (g/v-one datoms bid :block/text)
+                                 :order (g/v-one datoms bid :block/order)}
+                          (some? (g/v-one datoms bid :block/heading-level))
+                          (assoc :heading-level (g/v-one datoms bid :block/heading-level)))))
+               {})))
+
+(defn sheet-nodes
+  "{cell-id -> {:sheet :ref :row :col :value}} for one book."
+  [datoms book-id]
+  (->> datoms
+       (keep (fn [[e a v]] (when (and (= a :cell/book) (= v book-id)) e)))
+       distinct
+       (reduce (fn [m cid]
+                 (assoc m cid {:sheet (g/v-one datoms cid :cell/sheet)
+                               :ref   (g/v-one datoms cid :cell/ref)
+                               :row   (g/v-one datoms cid :cell/row)
+                               :col   (g/v-one datoms cid :cell/col)
+                               :value (g/v-one datoms cid :cell/value)}))
+               {})))
+
+;; ---------------------------------------------------------------------------
+;; semantic diff
+;; ---------------------------------------------------------------------------
+
+(defn- attr-deltas
+  "{attr [old new]} for keys that differ between two node attr-maps."
+  [o n]
+  (into {} (for [k (set/union (set (keys o)) (set (keys n)))
+                 :when (not= (get o k) (get n k))]
+             [k [(get o k) (get n k)]])))
+
+(defn diff-nodes
+  "Diff two node sets keyed by stable id.
+
+   opts :order-key  - attr that encodes sibling order (e.g. :order for docs). When the
+                      ONLY differing attr is the order-key, the change is :moved (from->to);
+                      otherwise it is :modified (deltas include the order change if any).
+                      Omit (or nil) for positional sets like cells (no reorder concept).
+
+   -> {:added    [{:id :node}...]
+       :removed  [{:id :node}...]
+       :moved    [{:id :from :to}...]
+       :modified [{:id :deltas {attr [old new]}}...]
+       :unchanged #{id...}}"
+  [base head & {:keys [order-key]}]
+  (reduce
+   (fn [acc id]
+     (let [o (get base id) n (get head id)]
+       (cond
+         (nil? o) (update acc :added conj {:id id :node n})
+         (nil? n) (update acc :removed conj {:id id :node o})
+         (= o n)  (update acc :unchanged conj id)
+         :else
+         (let [deltas (attr-deltas o n)]
+           (if (and order-key (= (keys deltas) (list order-key)))
+             (update acc :moved conj {:id id :from (get o order-key) :to (get n order-key)})
+             (update acc :modified conj {:id id :deltas deltas}))))))
+   {:added [] :removed [] :moved [] :modified [] :unchanged #{}}
+   (sort (set/union (set (keys base)) (set (keys head))))))
+
+(defn diff-doc   [base-datoms head-datoms doc-id]
+  (diff-nodes (doc-nodes base-datoms doc-id) (doc-nodes head-datoms doc-id) :order-key :order))
+(defn diff-sheet [base-datoms head-datoms book-id]
+  (diff-nodes (sheet-nodes base-datoms book-id) (sheet-nodes head-datoms book-id)))
+
+(defn empty-diff?
+  "True when nothing changed (only :unchanged populated)."
+  [d]
+  (every? empty? [(:added d) (:removed d) (:moved d) (:modified d)]))
+
+;; ---------------------------------------------------------------------------
+;; commit DAG / merge-base (LCA)
+;; ---------------------------------------------------------------------------
+
+(defn commit-ancestors
+  "Set of c and all its (transitive) parents in dag {commit {:parents [..]}}."
+  [dag c]
+  (loop [seen #{} stack [c]]
+    (if-let [x (peek stack)]
+      (if (seen x)
+        (recur seen (pop stack))
+        (recur (conj seen x) (into (pop stack) (get-in dag [x :parents]))))
+      seen)))
+
+(defn merge-base
+  "Best common ancestor(s) of a and b: common commit-ancestors with no other common
+   ancestor as a (proper) descendant. Returns a set (may be >1 on criss-cross)."
+  [dag a b]
+  (let [common (set/intersection (commit-ancestors dag a) (commit-ancestors dag b))]
+    (set (remove (fn [x]
+                   (some (fn [y] (and (not= x y)
+                                      (contains? (disj (commit-ancestors dag y) y) x)))
+                         common))
+                 common))))
+
+(defn merge-base-1
+  "Deterministic single merge-base (sorted first), or nil if histories are disjoint."
+  [dag a b]
+  (first (sort (merge-base dag a b))))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/gitdiff_test.clj
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/gitdiff_test.clj
@@ -1,0 +1,106 @@
+(ns kotoba.gitdiff-test
+  "Tests for the GitOffice Phase 1 semantic differ + merge-base/LCA."
+  (:require [clojure.test :refer [deftest is testing run-tests]]
+            [kotoba.gitoffice :as g]
+            [kotoba.gitdiff :as d]))
+
+;; ---------------------------------------------------------------------------
+;; docs diff: add / remove / move / modify on real normalized blocks
+;; ---------------------------------------------------------------------------
+
+(def base-body
+  [{:elementId "a" :kind "heading" :headingLevel 1 :text "概要"}
+   {:elementId "b" :kind "paragraph" :text "原材料費が上昇した。"}
+   {:elementId "c" :kind "paragraph" :text "結論。"}])
+
+(deftest doc-diff-detects-each-kind
+  (let [base (g/body->blocks "doc1" base-body)
+        ;; head: edit b's text, drop c, add d, and reorder (move heading a after b)
+        head-body [{:elementId "b" :kind "paragraph" :text "原材料費が大きく上昇した。"}
+                   {:elementId "a" :kind "heading" :headingLevel 1 :text "概要"}
+                   {:elementId "d" :kind "paragraph" :text "新しい段落。"}]
+        head (g/body->blocks "doc1" head-body)
+        diff (d/diff-doc base head "doc1")]
+    (is (= #{"d"} (set (map :id (:added diff)))))
+    (is (= #{"c"} (set (map :id (:removed diff)))))
+    (is (= #{"a"} (set (map :id (:moved diff)))) "a only moved (order-only change)")
+    (is (= #{"b"} (set (map :id (:modified diff)))) "b text changed")
+    (testing "modified carries the text delta"
+      (let [m (first (:modified diff))]
+        (is (= ["原材料費が上昇した。" "原材料費が大きく上昇した。"]
+               (get-in m [:deltas :text])))))))
+
+(deftest doc-diff-empty-when-identical
+  (let [base (g/body->blocks "doc1" base-body)]
+    (is (d/empty-diff? (d/diff-doc base base "doc1")))))
+
+(deftest move-vs-modify-distinguished
+  (testing "a block that both moves and edits is :modified (not :moved)"
+    (let [base (g/body->blocks "doc1"
+                               [{:elementId "x" :kind "paragraph" :text "one"}
+                                {:elementId "y" :kind "paragraph" :text "two"}])
+          head (g/body->blocks "doc1"
+                               [{:elementId "y" :kind "paragraph" :text "two!"}
+                                {:elementId "x" :kind "paragraph" :text "one"}])
+          diff (d/diff-doc base head "doc1")]
+      (is (= #{"x"} (set (map :id (:moved diff)))) "x moved only")
+      (is (= #{"y"} (set (map :id (:modified diff)))) "y moved+edited -> modified")
+      (is (contains? (:deltas (first (:modified diff))) :order)
+          "modified deltas include the order change too"))))
+
+;; ---------------------------------------------------------------------------
+;; sheets diff: cell add / remove / modify (no move concept — id is positional)
+;; ---------------------------------------------------------------------------
+
+(deftest sheet-diff-cellwise
+  (let [base (g/grid->cells "bk" {"S" [["10" "20"] ["30" "40"]]})
+        head (g/grid->cells "bk" {"S" [["10" "25"]      ; B1 20->25
+                                       ["30" ""]         ; B2 40-> removed (empty)
+                                       ["50" "60"]]})    ; A3,B3 added
+        diff (d/diff-sheet base head "bk")]
+    (is (= #{"S!A3" "S!B3"} (set (map :id (:added diff)))))
+    (is (= #{"S!B2"} (set (map :id (:removed diff)))))
+    (is (= #{"S!B1"} (set (map :id (:modified diff)))))
+    (is (empty? (:moved diff)) "cells never 'move' — position is identity")
+    (is (= ["20" "25"] (get-in (first (:modified diff)) [:deltas :value])))))
+
+;; ---------------------------------------------------------------------------
+;; merge-base / LCA over a commit DAG
+;; ---------------------------------------------------------------------------
+
+;;        c0
+;;        |
+;;        c1
+;;       /  \
+;;     c2    c3      (feature branch c3..c5 ; main c2..c4)
+;;     |     |
+;;     c4    c5
+(def dag
+  {"c0" {:parents []}
+   "c1" {:parents ["c0"]}
+   "c2" {:parents ["c1"]}
+   "c3" {:parents ["c1"]}
+   "c4" {:parents ["c2"]}
+   "c5" {:parents ["c3"]}})
+
+(deftest commit-ancestors-walk
+  (is (= #{"c4" "c2" "c1" "c0"} (d/commit-ancestors dag "c4")))
+  (is (= #{"c0"} (d/commit-ancestors dag "c0"))))
+
+(deftest merge-base-of-two-branches
+  (is (= #{"c1"} (d/merge-base dag "c4" "c5")) "LCA of the two branch tips is c1")
+  (is (= "c1" (d/merge-base-1 dag "c4" "c5")))
+  (testing "linear history: merge-base is the older commit"
+    (is (= #{"c1"} (d/merge-base dag "c1" "c4"))))
+  (testing "disjoint histories have no base"
+    (is (nil? (d/merge-base-1 {"x" {:parents []} "y" {:parents []}} "x" "y")))))
+
+(deftest merge-base-with-merge-commit
+  ;; c6 merges c4 and c5 ; merge-base(c6, c4) should be c4 itself
+  (let [dag2 (assoc dag "c6" {:parents ["c4" "c5"]})]
+    (is (= #{"c4"} (d/merge-base dag2 "c6" "c4")))
+    (is (= #{"c1"} (d/merge-base dag2 "c2" "c5")))))
+
+(defn -main []
+  (let [{:keys [fail error]} (run-tests 'kotoba.gitdiff-test)]
+    (+ (or fail 0) (or error 0))))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/gitmerge.cljc
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/gitmerge.cljc
@@ -1,0 +1,113 @@
+(ns kotoba.gitmerge
+  "GitOffice Phase 3 (doc e §4) — 3-way merge over element-granular node sets.
+
+   Pure (.cljc). Inputs are three node sets {stable-id -> attr-map} from Phase 0/1:
+   base (= merge-base), ours (base branch tip), theirs (PR branch tip).
+
+   Why this beats text 3-way merge for office docs (doc e §4):
+   - ATTRIBUTE-LEVEL auto-merge: ours edits one attr, theirs edits another, on the
+     SAME element -> both apply, no conflict (text merge would flag the whole line).
+   - Fractional-index ordering: two concurrent inserts are two ADDs -> never a conflict
+     (text merge collides on the same insertion point).
+   - A real conflict is narrow: the SAME element's SAME attribute changed both sides
+     to different values (or delete-vs-modify). Reported as :conflicts for a 3-pane UI."
+  (:require [kotoba.gitoffice :as g]
+            [kotoba.gitdiff :as d]
+            [clojure.set :as set]))
+
+;; ---------------------------------------------------------------------------
+;; per-attribute 3-way
+;; ---------------------------------------------------------------------------
+
+(defn- merge3-attr
+  "3-way merge of one attribute value. -> {:v val} or {:conflict {:base :ours :theirs}}."
+  [ba oa ta]
+  (cond
+    (= oa ta) {:v oa}        ; same on both (incl. both removed the attr)
+    (= oa ba) {:v ta}        ; ours unchanged -> take theirs
+    (= ta ba) {:v oa}        ; theirs unchanged -> take ours
+    :else     {:conflict {:base ba :ours oa :theirs ta}}))
+
+(defn- strip-nils [m] (into {} (remove (comp nil? val) m)))
+
+(defn- merge3-node
+  "3-way merge two present nodes attr-by-attr (b may be nil = added both sides).
+   -> {:node attrs} (clean) or {:conflict {attr {:base :ours :theirs}} :ours :theirs}."
+  [b o t]
+  (let [ks (set/union (set (keys b)) (set (keys o)) (set (keys t)))
+        per (into {} (map (fn [k] [k (merge3-attr (get b k) (get o k) (get t k))]) ks))
+        conflicts (into {} (keep (fn [[k r]] (when (:conflict r) [k (:conflict r)])) per))]
+    (if (seq conflicts)
+      {:conflict conflicts :ours o :theirs t}
+      {:node (strip-nils (into {} (map (fn [[k r]] [k (:v r)]) per)))})))
+
+;; ---------------------------------------------------------------------------
+;; node-set 3-way
+;; ---------------------------------------------------------------------------
+
+(defn merge3
+  "3-way merge of node sets. -> {:merged {id attrs} :conflicts {id info}}.
+   Conflict info :kind ∈ #{:attr :delete-modify}. A result with empty :conflicts is
+   clean and :merged is directly usable; otherwise resolve :conflicts then re-insert."
+  [base ours theirs]
+  (reduce
+   (fn [acc id]
+     (let [b (get base id) o (get ours id) t (get theirs id)]
+       (cond
+         (= o t) (cond-> acc (some? o) (assoc-in [:merged id] o))   ; agree (incl. both deleted)
+         (= o b) (cond-> acc (some? t) (assoc-in [:merged id] t))   ; theirs side moved (incl. delete: t=nil)
+         (= t b) (cond-> acc (some? o) (assoc-in [:merged id] o))   ; ours side moved
+         (nil? o) (assoc-in acc [:conflicts id]
+                            {:kind :delete-modify :deleted :ours :base b :theirs t})
+         (nil? t) (assoc-in acc [:conflicts id]
+                            {:kind :delete-modify :deleted :theirs :base b :ours o})
+         :else
+         (let [r (merge3-node b o t)]
+           (if (:conflict r)
+             (assoc-in acc [:conflicts id] {:kind :attr :attrs (:conflict r)
+                                            :ours o :theirs t})
+             (assoc-in acc [:merged id] (:node r)))))))
+   {:merged {} :conflicts {}}
+   (sort (set/union (set (keys base)) (set (keys ours)) (set (keys theirs))))))
+
+(defn clean? [result] (empty? (:conflicts result)))
+
+(defn resolve-conflict
+  "Resolve one conflicted id by supplying its final attr-map (or nil to delete);
+   moves it from :conflicts to :merged."
+  [result id node]
+  (-> result
+      (update :conflicts dissoc id)
+      (cond-> (some? node) (assoc-in [:merged id] node))))
+
+;; ---------------------------------------------------------------------------
+;; doc convenience: merged node set -> bodyJson (deterministic order)
+;; ---------------------------------------------------------------------------
+
+(def ^:private kw->kind
+  {:block/paragraph "paragraph" :block/heading "heading" :block/list-item "listItem"})
+
+(defn merged-doc->body
+  "Clean merged doc node set -> bodyJson, sibling order = [block/order, id] (ties by id)."
+  [merged]
+  (->> merged
+       (sort-by (fn [[id n]] [(:order n) id]))
+       (mapv (fn [[id n]]
+               (cond-> {:elementId id
+                        :kind (kw->kind (:kind n) "paragraph")
+                        :text (:text n)}
+                 (some? (:heading-level n)) (assoc :headingLevel (:heading-level n)))))))
+
+;; ---------------------------------------------------------------------------
+;; datom-level wrappers (base/ours/theirs are full datom vectors)
+;; ---------------------------------------------------------------------------
+
+(defn merge-doc   [base-datoms ours-datoms theirs-datoms doc-id]
+  (merge3 (d/doc-nodes base-datoms doc-id)
+          (d/doc-nodes ours-datoms doc-id)
+          (d/doc-nodes theirs-datoms doc-id)))
+
+(defn merge-sheet [base-datoms ours-datoms theirs-datoms book-id]
+  (merge3 (d/sheet-nodes base-datoms book-id)
+          (d/sheet-nodes ours-datoms book-id)
+          (d/sheet-nodes theirs-datoms book-id)))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/gitmerge_test.clj
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/gitmerge_test.clj
@@ -1,0 +1,127 @@
+(ns kotoba.gitmerge-test
+  "Tests for the GitOffice Phase 3 3-way merger."
+  (:require [clojure.test :refer [deftest is testing run-tests]]
+            [kotoba.gitoffice :as g]
+            [kotoba.gitdiff :as d]
+            [kotoba.gitmerge :as m]))
+
+;; ---------------------------------------------------------------------------
+;; clean cases: one-sided change, agreement, deletion
+;; ---------------------------------------------------------------------------
+
+(deftest one-sided-changes-auto-merge
+  (let [base {"a" {:kind :block/paragraph :text "x" :order "i"}}
+        ours (assoc-in base ["a" :text] "x-ours")          ; ours edits
+        theirs base                                         ; theirs unchanged
+        r (m/merge3 base ours theirs)]
+    (is (m/clean? r))
+    (is (= "x-ours" (get-in r [:merged "a" :text])))))
+
+(deftest delete-unchanged-side-is-clean
+  (testing "theirs deletes, ours unchanged -> clean delete (no conflict)"
+    (let [base {"a" {:text "x" :order "i"} "b" {:text "y" :order "r"}}
+          ours base
+          theirs (dissoc base "b")
+          r (m/merge3 base ours theirs)]
+      (is (m/clean? r))
+      (is (contains? (:merged r) "a"))
+      (is (not (contains? (:merged r) "b")) "b deleted in merge"))))
+
+;; ---------------------------------------------------------------------------
+;; the headline: ATTRIBUTE-LEVEL auto-merge (text 3-way would conflict)
+;; ---------------------------------------------------------------------------
+
+(deftest attribute-level-auto-merge
+  (testing "same element: ours edits heading-level, theirs edits text -> both apply"
+    (let [base   {"h" {:kind :block/heading :text "概要" :heading-level 1 :order "i"}}
+          ours   (assoc-in base ["h" :heading-level] 2)
+          theirs (assoc-in base ["h" :text] "概要(改)")
+          r (m/merge3 base ours theirs)]
+      (is (m/clean? r) "different attributes on the same element do NOT conflict")
+      (is (= 2 (get-in r [:merged "h" :heading-level])))
+      (is (= "概要(改)" (get-in r [:merged "h" :text]))))))
+
+;; ---------------------------------------------------------------------------
+;; real conflicts: same attr both sides, and delete-vs-modify
+;; ---------------------------------------------------------------------------
+
+(deftest same-attr-conflict
+  (let [base   {"p" {:kind :block/paragraph :text "orig" :order "i"}}
+        ours   (assoc-in base ["p" :text] "ours")
+        theirs (assoc-in base ["p" :text] "theirs")
+        r (m/merge3 base ours theirs)]
+    (is (not (m/clean? r)))
+    (is (= :attr (get-in r [:conflicts "p" :kind])))
+    (is (= {:base "orig" :ours "ours" :theirs "theirs"}
+           (get-in r [:conflicts "p" :attrs :text])))
+    (testing "resolve picks a value and clears the conflict"
+      (let [r2 (m/resolve-conflict r "p" {:kind :block/paragraph :text "theirs" :order "i"})]
+        (is (m/clean? r2))
+        (is (= "theirs" (get-in r2 [:merged "p" :text])))))))
+
+(deftest delete-modify-conflict
+  (let [base   {"p" {:text "orig" :order "i"}}
+        ours   (dissoc base "p")                  ; ours deletes
+        theirs (assoc-in base ["p" :text] "edit") ; theirs edits
+        r (m/merge3 base ours theirs)]
+    (is (= :delete-modify (get-in r [:conflicts "p" :kind])))
+    (is (= :ours (get-in r [:conflicts "p" :deleted])))))
+
+;; ---------------------------------------------------------------------------
+;; the fractional-index win: concurrent inserts never conflict
+;; ---------------------------------------------------------------------------
+
+(deftest concurrent-inserts-do-not-conflict
+  (testing "ours and theirs each insert a new block between a and b -> two ADDs, clean"
+    (let [base-body [{:elementId "a" :kind "paragraph" :text "A"}
+                     {:elementId "b" :kind "paragraph" :text "B"}]
+          base (d/doc-nodes (g/body->blocks "doc" base-body) "doc")
+          [oa ob] [(get-in base ["a" :order]) (get-in base ["b" :order])]
+          x-ord (g/order-between oa ob)
+          y-ord (g/order-between x-ord ob)        ; distinct key to keep ids orderable
+          ours   (assoc base "x" {:kind :block/paragraph :text "X" :order x-ord})
+          theirs (assoc base "y" {:kind :block/paragraph :text "Y" :order y-ord})
+          r (m/merge3 base ours theirs)]
+      (is (m/clean? r) "concurrent inserts are not a conflict")
+      (is (= #{"a" "b" "x" "y"} (set (keys (:merged r)))) "both inserts kept")
+      (testing "final order interleaves correctly: A < X < Y < B"
+        (let [body (m/merged-doc->body (:merged r))]
+          (is (= ["A" "X" "Y" "B"] (mapv :text body))))))))
+
+;; ---------------------------------------------------------------------------
+;; end-to-end via datom wrappers
+;; ---------------------------------------------------------------------------
+
+(deftest merge-doc-datom-wrapper
+  (let [base (g/body->blocks "doc"
+                             [{:elementId "a" :kind "heading" :headingLevel 1 :text "T"}
+                              {:elementId "b" :kind "paragraph" :text "body"}])
+        ours (g/body->blocks "doc"
+                             [{:elementId "a" :kind "heading" :headingLevel 1 :text "T (ours)"}
+                              {:elementId "b" :kind "paragraph" :text "body"}])
+        theirs (g/body->blocks "doc"
+                               [{:elementId "a" :kind "heading" :headingLevel 1 :text "T"}
+                                {:elementId "b" :kind "paragraph" :text "body (theirs)"}])
+        r (m/merge-doc base ours theirs "doc")]
+    (is (m/clean? r) "ours edits block a, theirs edits block b -> no conflict")
+    (is (= "T (ours)" (get-in r [:merged "a" :text])))
+    (is (= "body (theirs)" (get-in r [:merged "b" :text])))))
+
+(deftest merge-sheet-cellwise
+  (testing "edits to different cells auto-merge; same cell conflicts"
+    (let [base   (g/grid->cells "bk" {"S" [["1" "2"]]})
+          ours   (g/grid->cells "bk" {"S" [["1x" "2"]]})  ; A1
+          theirs (g/grid->cells "bk" {"S" [["1" "2y"]]})  ; B1
+          r (m/merge-sheet base ours theirs "bk")]
+      (is (m/clean? r))
+      (is (= "1x" (get-in r [:merged "S!A1" :value])))
+      (is (= "2y" (get-in r [:merged "S!B1" :value]))))
+    (let [base   (g/grid->cells "bk" {"S" [["1"]]})
+          ours   (g/grid->cells "bk" {"S" [["1o"]]})
+          theirs (g/grid->cells "bk" {"S" [["1t"]]})
+          r (m/merge-sheet base ours theirs "bk")]
+      (is (= :attr (get-in r [:conflicts "S!A1" :kind]))))))
+
+(defn -main []
+  (let [{:keys [fail error]} (run-tests 'kotoba.gitmerge-test)]
+    (+ (or fail 0) (or error 0))))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/gitoffice.cljc
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/gitoffice.cljc
@@ -1,0 +1,394 @@
+(ns kotoba.gitoffice
+  "GitOffice Phase 0 (doc e) — normalization + collaboration converters.
+
+   Two jobs, both pure (.cljc, babashka/Clojure, no platform deps):
+
+   1. NORMALIZE the DEPLOYED coarse blob model into the element-granular datom
+      model that semantic diff/merge needs (doc e §13, option 1):
+        - docs   :doc/bodyJson  ({elementId,kind,headingLevel?,text} list) <-> :block/* blocks
+        - sheets :sheet/gridJson ({title [[cell]]})                        <-> :cell/* cells
+        - revision bridge: :doc/revisionId \"rev-N\" / :sheet/revision N   <-> :rev/* + CommitDag seq
+      The deployed body is FLAT (no nesting), so blocks are direct children of the doc.
+      Block ordering uses a fractional-index string (insert-friendly, CRDT-migratable);
+      cells are sparse (only non-empty), keyed by absolute A1 ref = the stable diff id.
+
+   2. COLLABORATION metadata (doc e §2) <-> datoms: issue / pr / review / comment.
+      Bijective like p0/office.cljc (vector of [e a v]); bodies are plain here
+      (encrypted via assertEncrypted at write time in real use).
+
+   Entity ids are caller-supplied LOGICAL ids (real ids = kotoba commit() CIDs).
+   Blocks keep their bodyJson elementId as the stable id so re-normalize is idempotent."
+  (:require [clojure.string :as str]
+            [clojure.edn :as edn]))
+
+;; ---------------------------------------------------------------------------
+;; schema registry  (additive to p0/office.cljc; Datomic-style attribute meta)
+;; ---------------------------------------------------------------------------
+
+(def schema
+  {;; --- block (element-granular doc body; flat under the doc) ---
+   :block/kind          {:db/valueType :keyword :db/cardinality :one}
+   :block/text          {:db/valueType :string  :db/cardinality :one
+                         :db/encrypted true :doc "signal:v1: via assertEncrypted in real use"}
+   :block/order         {:db/valueType :string  :db/cardinality :one
+                         :doc "fractional-index string (insert-friendly)"}
+   :block/parent        {:db/valueType :ref     :db/cardinality :one}
+   :block/heading-level {:db/valueType :long    :db/cardinality :one}
+
+   ;; --- cell (sparse spreadsheet cell; id = \"<sheet>!<A1>\") ---
+   :cell/book           {:db/valueType :ref     :db/cardinality :one}
+   :cell/sheet          {:db/valueType :string  :db/cardinality :one}
+   :cell/ref            {:db/valueType :string  :db/cardinality :one :db/doc "A1, e.g. B2"}
+   :cell/row            {:db/valueType :long    :db/cardinality :one :db/doc "0-based"}
+   :cell/col            {:db/valueType :long    :db/cardinality :one :db/doc "0-based"}
+   :cell/value          {:db/valueType :string  :db/cardinality :one :db/doc "no-float: string"}
+
+   ;; --- revision <-> commit bridge (ETag/If-Match <-> CommitDag) ---
+   :rev/of              {:db/valueType :ref     :db/cardinality :one :db/doc "doc/book entity"}
+   :rev/label           {:db/valueType :string  :db/cardinality :one :db/doc "\"rev-N\" (docs) / \"N\""}
+   :rev/seq             {:db/valueType :long    :db/cardinality :one :db/doc "monotone counter"}
+   :rev/commit          {:db/valueType :string  :db/cardinality :one :db/doc "CommitDag commit CID"}
+
+   ;; --- repo / ref (branch,tag) ---
+   :repo/id             {:db/valueType :string  :db/cardinality :one :db/unique :identity}
+   :repo/kind           {:db/valueType :keyword :db/cardinality :one}
+   :repo/owner-org      {:db/valueType :ref     :db/cardinality :one}
+   :repo/default-ref    {:db/valueType :string  :db/cardinality :one}
+   :ref/name            {:db/valueType :string  :db/cardinality :one :db/unique :identity}
+   :ref/repo            {:db/valueType :ref     :db/cardinality :one}
+   :ref/kind            {:db/valueType :keyword :db/cardinality :one}
+   :ref/commit          {:db/valueType :string  :db/cardinality :one}
+   :ref/protected       {:db/valueType :boolean :db/cardinality :one}
+
+   ;; --- issue ---
+   :issue/id            {:db/valueType :string  :db/cardinality :one :db/unique :identity}
+   :issue/repo          {:db/valueType :ref     :db/cardinality :one}
+   :issue/number        {:db/valueType :long    :db/cardinality :one}
+   :issue/title         {:db/valueType :string  :db/cardinality :one}
+   :issue/body          {:db/valueType :string  :db/cardinality :one :db/encrypted true}
+   :issue/author        {:db/valueType :did     :db/cardinality :one}
+   :issue/state         {:db/valueType :keyword :db/cardinality :one}
+   :issue/label         {:db/valueType :string  :db/cardinality :many}
+   :issue/anchor        {:db/valueType :string  :db/cardinality :many}
+   :issue/created-at    {:db/valueType :long    :db/cardinality :one}
+
+   ;; --- pull request ---
+   :pr/id               {:db/valueType :string  :db/cardinality :one :db/unique :identity}
+   :pr/repo             {:db/valueType :ref     :db/cardinality :one}
+   :pr/number           {:db/valueType :long    :db/cardinality :one}
+   :pr/title            {:db/valueType :string  :db/cardinality :one}
+   :pr/author           {:db/valueType :did     :db/cardinality :one}
+   :pr/base-ref         {:db/valueType :string  :db/cardinality :one}
+   :pr/head-ref         {:db/valueType :string  :db/cardinality :one}
+   :pr/base-commit      {:db/valueType :string  :db/cardinality :one}
+   :pr/head-commit      {:db/valueType :string  :db/cardinality :one}
+   :pr/merge-base       {:db/valueType :string  :db/cardinality :one}
+   :pr/state            {:db/valueType :keyword :db/cardinality :one}
+   :pr/closes-issue     {:db/valueType :ref     :db/cardinality :many}
+   :pr/merged-commit    {:db/valueType :string  :db/cardinality :one}
+
+   ;; --- review ---
+   :review/id           {:db/valueType :string  :db/cardinality :one :db/unique :identity}
+   :review/pr           {:db/valueType :ref     :db/cardinality :one}
+   :review/reviewer     {:db/valueType :did     :db/cardinality :one}
+   :review/state        {:db/valueType :keyword :db/cardinality :one}
+   :review/at-commit    {:db/valueType :string  :db/cardinality :one}
+   :review/vc           {:db/valueType :string  :db/cardinality :one}
+
+   ;; --- comment (element-anchored = GitHub line comment) ---
+   :comment/id          {:db/valueType :string  :db/cardinality :one :db/unique :identity}
+   :comment/on          {:db/valueType :ref     :db/cardinality :one}
+   :comment/author      {:db/valueType :did     :db/cardinality :one}
+   :comment/body        {:db/valueType :string  :db/cardinality :one :db/encrypted true}
+   :comment/anchor      {:db/valueType :string  :db/cardinality :one}
+   :comment/side        {:db/valueType :keyword :db/cardinality :one}
+   :comment/resolved    {:db/valueType :boolean :db/cardinality :one}
+   :comment/created-at  {:db/valueType :long    :db/cardinality :one}})
+
+;; ---------------------------------------------------------------------------
+;; small EAV helpers (same shape as p0/office.cljc)
+;; ---------------------------------------------------------------------------
+
+(defn v-one
+  "First value for (e,a). Uses reduce (not `some`) so a stored boolean false is
+   returned, not skipped as falsey."
+  [datoms e a]
+  (reduce (fn [_ [de da v]] (when (and (= de e) (= da a)) (reduced v))) nil datoms))
+(defn v-many [datoms e a] (set (keep (fn [[de da v]] (when (and (= de e) (= da a)) v)) datoms)))
+
+;; ---------------------------------------------------------------------------
+;; fractional indexing (order keys are base-36 fractions, compared lexically)
+;; ---------------------------------------------------------------------------
+
+(def ^:private digits "0123456789abcdefghijklmnopqrstuvwxyz")
+(def ^:private base (count digits))
+(def ^:private dval (into {} (map-indexed (fn [i c] [c i]) digits)))
+(defn- digs->str [vs] (apply str (map #(nth digits %) vs)))
+
+(defn order-between
+  "Fractional index strictly between a and b (lexicographic order).
+   a nil/\"\" = lower bound (0); b nil = upper bound (1). Requires a < b.
+
+   Keys must be CANONICAL (no trailing '0' digit): a trailing zero makes a key
+   fraction-equal to its prefix (\"1\" == \"10\"), so no key can sit strictly between
+   them and the midpoint walk would emit an out-of-range key. Generated keys are
+   always canonical; a non-canonical key only enters via external/CRDT import, so we
+   reject it loudly rather than corrupt the order silently."
+  [a b]
+  (let [a (or a "")]
+    (when (and (seq a) (= \0 (last a)))
+      (throw (ex-info "invalid order key (trailing zero)" {:key a})))
+    (when (some? b)
+      (when (or (= "" b) (= \0 (last b)))
+        (throw (ex-info "invalid order key (trailing zero / empty)" {:key b})))
+      (when-not (neg? (compare a b))
+        (throw (ex-info "order keys not ascending" {:a a :b b}))))
+    (let [av (vec a)
+          bv (when (seq b) (vec b))]
+      (loop [i 0 acc []]
+        (let [da (if (< i (count av)) (dval (nth av i)) 0)
+              db (if (and bv (< i (count bv))) (dval (nth bv i)) base)]
+          (if (< (inc da) db)
+            (digs->str (conj acc (quot (+ da db) 2)))
+            (recur (inc i) (conj acc da))))))))
+
+(defn initial-orders
+  "n strictly-increasing order keys (one per list position)."
+  [n]
+  (loop [i 0 prev nil acc []]
+    (if (= i n)
+      acc
+      (let [k (order-between prev nil)]
+        (recur (inc i) k (conj acc k))))))
+
+;; ---------------------------------------------------------------------------
+;; A1 notation
+;; ---------------------------------------------------------------------------
+
+(defn col->a1 [c]
+  (loop [n (inc c) s ""]
+    (if (zero? n)
+      s
+      (recur (quot (dec n) 26)
+             (str (char (+ 65 (mod (dec n) 26))) s)))))
+
+(defn a1->col [letters]
+  (dec (reduce (fn [acc ch] (+ (* acc 26) (- (int ch) 64))) 0 letters))) ; -> 0-based
+
+(defn cell-id [sheet row col] (str sheet "!" (col->a1 col) (inc row)))
+
+;; ===========================================================================
+;; 1a. docs  bodyJson  <->  :block/* blocks
+;; ===========================================================================
+
+(def ^:private kind->kw
+  {"paragraph" :block/paragraph "heading" :block/heading "listItem" :block/list-item})
+(def ^:private kw->kind (into {} (map (fn [[k v]] [v k]) kind->kw)))
+
+(defn body->blocks
+  "bodyJson element list -> datoms. doc-id = parent. Element :elementId is the stable
+   block id (re-normalize is idempotent). Order = fractional index from position."
+  [doc-id body]
+  (let [orders (initial-orders (count body))]
+    (into []
+          (mapcat (fn [{:keys [elementId kind headingLevel text]} ord]
+                    (let [bid elementId]
+                      (cond-> [[bid :block/parent doc-id]
+                               [bid :block/kind (kind->kw (or kind "paragraph") :block/paragraph)]
+                               [bid :block/order ord]
+                               [bid :block/text (or text "")]]
+                        (some? headingLevel) (conj [bid :block/heading-level headingLevel]))))
+                  body orders))))
+
+(defn blocks->body
+  "datoms -> bodyJson element list (sorted by :block/order)."
+  [datoms doc-id]
+  (->> datoms
+       (keep (fn [[e a v]] (when (and (= a :block/parent) (= v doc-id)) e)))
+       distinct
+       (sort-by (fn [e] [(v-one datoms e :block/order) e]))  ; [order id]: deterministic on ties
+       (mapv (fn [bid]
+               (let [hl (v-one datoms bid :block/heading-level)]
+                 (cond-> {:elementId bid
+                          :kind (kw->kind (v-one datoms bid :block/kind) "paragraph")
+                          :text (v-one datoms bid :block/text)}
+                   (some? hl) (assoc :headingLevel hl)))))))
+
+;; ===========================================================================
+;; 1b. sheets  gridJson  <->  :cell/* cells   (sparse, A1-keyed)
+;; ===========================================================================
+
+(defn- nonempty? [v] (not (or (nil? v) (= "" v))))
+
+(defn bbox
+  "Bounding rectangle [rows cols] over non-empty cells of one 2D grid (0,0 if none)."
+  [grid]
+  (let [coords (for [r (range (count grid))
+                     c (range (count (nth grid r)))
+                     :when (nonempty? (get-in grid [r c]))]
+                 [r c])]
+    (if (seq coords)
+      [(inc (apply max (map first coords))) (inc (apply max (map second coords)))]
+      [0 0])))
+
+(defn trim-grid
+  "Canonicalize one grid to its non-empty bounding rectangle (drops trailing
+   empty rows/cols). The round-trip fixed point for sparse cells."
+  [grid]
+  (let [[rows cols] (bbox grid)]
+    (vec (for [r (range rows)]
+           (vec (for [c (range cols)]
+                  (let [v (get-in grid [r c])] (if (nil? v) "" v))))))))
+
+(defn grid->cells
+  "gridJson {sheet [[cell]]} -> datoms (sparse: only non-empty cells)."
+  [book-id grid-json]
+  (into []
+        (mapcat (fn [[sheet grid]]
+                  (for [r (range (count grid))
+                        c (range (count (nth grid r)))
+                        :when (nonempty? (get-in grid [r c]))
+                        :let [id (cell-id sheet r c)]
+                        d [[id :cell/book book-id]
+                           [id :cell/sheet sheet]
+                           [id :cell/ref (str (col->a1 c) (inc r))]
+                           [id :cell/row r]
+                           [id :cell/col c]
+                           [id :cell/value (get-in grid [r c])]]]
+                    d)))
+        grid-json))
+
+(defn cells->grid
+  "datoms -> gridJson {sheet [[cell]]} (each sheet trimmed to its bounding rect)."
+  [datoms book-id]
+  (let [cell-ids (->> datoms
+                      (keep (fn [[e a v]] (when (and (= a :cell/book) (= v book-id)) e)))
+                      distinct)
+        by-sheet (group-by #(v-one datoms % :cell/sheet) cell-ids)]
+    (into {}
+          (for [[sheet ids] by-sheet]
+            (let [rows (inc (apply max (map #(v-one datoms % :cell/row) ids)))
+                  cols (inc (apply max (map #(v-one datoms % :cell/col) ids)))
+                  m    (into {} (map (fn [id] [[(v-one datoms id :cell/row)
+                                               (v-one datoms id :cell/col)]
+                                              (v-one datoms id :cell/value)]) ids))]
+              [sheet (vec (for [r (range rows)]
+                            (vec (for [c (range cols)] (get m [r c] "")))))])))))
+
+;; ===========================================================================
+;; 1c. revision <-> commit bridge
+;; ===========================================================================
+
+(defn parse-rev
+  "\"rev-7\" -> 7 ; \"7\" -> 7."
+  [label]
+  (let [s (str label)
+        s (if (str/starts-with? s "rev-") (subs s 4) s)]
+    (edn/read-string s)))
+
+(defn rev->datoms
+  "{:id :of :label :seq :commit} -> datoms (commit optional until commit() runs)."
+  [{:keys [id of label seq commit]}]
+  (cond-> [[id :rev/of of]
+           [id :rev/label label]
+           [id :rev/seq seq]]
+    (some? commit) (conj [id :rev/commit commit])))
+
+(defn datoms->rev [datoms id]
+  (cond-> {:id id
+           :of    (v-one datoms id :rev/of)
+           :label (v-one datoms id :rev/label)
+           :seq   (v-one datoms id :rev/seq)}
+    (v-one datoms id :rev/commit) (assoc :commit (v-one datoms id :rev/commit))))
+
+;; ===========================================================================
+;; 2. collaboration metadata  <->  datoms   (issue / pr / review / comment)
+;; ===========================================================================
+
+(defn issue->datoms [{:keys [id repo number title body author state labels anchors created-at]}]
+  (into (cond-> [[id :issue/repo repo]
+                 [id :issue/number number]
+                 [id :issue/title title]
+                 [id :issue/author author]
+                 [id :issue/state state]
+                 [id :issue/created-at created-at]]
+          (some? body) (conj [id :issue/body body]))
+        (concat (map (fn [l] [id :issue/label l]) labels)
+                (map (fn [a] [id :issue/anchor a]) anchors))))
+
+(defn datoms->issue [datoms id]
+  (cond-> {:id id
+           :repo       (v-one datoms id :issue/repo)
+           :number     (v-one datoms id :issue/number)
+           :title      (v-one datoms id :issue/title)
+           :author     (v-one datoms id :issue/author)
+           :state      (v-one datoms id :issue/state)
+           :created-at (v-one datoms id :issue/created-at)
+           :labels     (v-many datoms id :issue/label)
+           :anchors    (v-many datoms id :issue/anchor)}
+    (v-one datoms id :issue/body) (assoc :body (v-one datoms id :issue/body))))
+
+(defn pr->datoms [{:keys [id repo number title author base-ref head-ref
+                          base-commit head-commit merge-base state
+                          closes-issues merged-commit]}]
+  (into (cond-> [[id :pr/repo repo]
+                 [id :pr/number number]
+                 [id :pr/title title]
+                 [id :pr/author author]
+                 [id :pr/base-ref base-ref]
+                 [id :pr/head-ref head-ref]
+                 [id :pr/base-commit base-commit]
+                 [id :pr/head-commit head-commit]
+                 [id :pr/state state]]
+          (some? merge-base)    (conj [id :pr/merge-base merge-base])
+          (some? merged-commit) (conj [id :pr/merged-commit merged-commit]))
+        (map (fn [i] [id :pr/closes-issue i]) closes-issues)))
+
+(defn datoms->pr [datoms id]
+  (cond-> {:id id
+           :repo          (v-one datoms id :pr/repo)
+           :number        (v-one datoms id :pr/number)
+           :title         (v-one datoms id :pr/title)
+           :author        (v-one datoms id :pr/author)
+           :base-ref      (v-one datoms id :pr/base-ref)
+           :head-ref      (v-one datoms id :pr/head-ref)
+           :base-commit   (v-one datoms id :pr/base-commit)
+           :head-commit   (v-one datoms id :pr/head-commit)
+           :state         (v-one datoms id :pr/state)
+           :closes-issues (v-many datoms id :pr/closes-issue)}
+    (v-one datoms id :pr/merge-base)    (assoc :merge-base (v-one datoms id :pr/merge-base))
+    (v-one datoms id :pr/merged-commit) (assoc :merged-commit (v-one datoms id :pr/merged-commit))))
+
+(defn review->datoms [{:keys [id pr reviewer state at-commit vc]}]
+  (cond-> [[id :review/pr pr]
+           [id :review/reviewer reviewer]
+           [id :review/state state]
+           [id :review/at-commit at-commit]]
+    (some? vc) (conj [id :review/vc vc])))
+
+(defn datoms->review [datoms id]
+  (cond-> {:id id
+           :pr        (v-one datoms id :review/pr)
+           :reviewer  (v-one datoms id :review/reviewer)
+           :state     (v-one datoms id :review/state)
+           :at-commit (v-one datoms id :review/at-commit)}
+    (v-one datoms id :review/vc) (assoc :vc (v-one datoms id :review/vc))))
+
+(defn comment->datoms [{:keys [id on author body anchor side resolved created-at]}]
+  (cond-> [[id :comment/on on]
+           [id :comment/author author]
+           [id :comment/body body]
+           [id :comment/created-at created-at]]
+    (some? anchor)   (conj [id :comment/anchor anchor])
+    (some? side)     (conj [id :comment/side side])
+    (some? resolved) (conj [id :comment/resolved resolved])))
+
+(defn datoms->comment [datoms id]
+  (cond-> {:id id
+           :on         (v-one datoms id :comment/on)
+           :author     (v-one datoms id :comment/author)
+           :body       (v-one datoms id :comment/body)
+           :created-at (v-one datoms id :comment/created-at)}
+    (v-one datoms id :comment/anchor)   (assoc :anchor (v-one datoms id :comment/anchor))
+    (v-one datoms id :comment/side)     (assoc :side (v-one datoms id :comment/side))
+    (some? (v-one datoms id :comment/resolved)) (assoc :resolved (v-one datoms id :comment/resolved))))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/gitoffice_node.cljs
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/gitoffice_node.cljs
@@ -1,0 +1,142 @@
+(ns kotoba.gitoffice-node
+  "CLJS interop: drive the wasm KotobaNode with the GitOffice converters.
+
+   The portable logic lives in kotoba.gitoffice / gitdiff / gitmerge / gitpolicy
+   (pure .cljc, babashka-tested). This namespace is the thin transact / commit /
+   datomicQ glue — it mirrors kotoba.office exactly (same v_edn wire codec), so a
+   normalized doc/book and its PR metadata land on the same local kotoba node the
+   office editor already uses.
+
+   Diff/merge across two commits: pull the head node-set with `doc-datoms`/`book-datoms`
+   and the base node-set from a hydrated snapshot (kotoba.node/hydrate-and-query-verified!),
+   then call the pure gitdiff/gitmerge fns. As-of wiring is the caller's choice of
+   snapshot; this ns does not hide it."
+  (:require [kotoba.gitoffice :as g]
+            [kotoba.gitdiff :as d]
+            [kotoba.gitmerge :as m]
+            [kotoba.gitpolicy :as p]
+            [kotoba.node :as node]
+            [clojure.string :as str]))
+
+;; ---------------------------------------------------------------------------
+;; v_edn codec over the GitOffice schema (mirrors kotoba.office encode/decode)
+;; ---------------------------------------------------------------------------
+
+(def schema (merge g/schema p/schema))
+(defn- value-type [a] (get-in schema [a :db/valueType] :string))
+
+(defn- encode [a v]
+  (case (value-type a)
+    (:string :ref :did)       (js/JSON.stringify (str v))
+    (:keyword :long :boolean) (str v)
+    (js/JSON.stringify (str v))))
+
+(defn- decode [a s]
+  (case (value-type a)
+    (:string :ref :did) s
+    :keyword            (keyword s)
+    :long               (js/parseInt s 10)
+    :boolean            (= "true" s)
+    s))
+
+(defn- a->kw [a] (keyword (cond-> a (str/starts-with? a ":") (subs 1))))
+
+;; ---------------------------------------------------------------------------
+;; write: [e a v] datoms -> local transact + commit
+;; ---------------------------------------------------------------------------
+
+(defn tx-json
+  "[[e a v]...] -> JSON string for KotobaNode.transact (same shape as kotoba.office)."
+  [datoms]
+  (js/JSON.stringify
+   (clj->js (mapv (fn [[e a v]] {:e e :a (str a) :v_edn (encode a v)}) datoms))))
+
+(defn write-datoms!
+  "Transact datoms locally and commit. Returns the root CID."
+  [^js node datoms]
+  (.transact node (tx-json datoms))
+  (.commit node))
+
+(defn store-doc!
+  "Normalize a Google-Docs-shaped body (vector of {:elementId :kind :headingLevel? :text})
+   into :block/* datoms under doc-id and commit. Returns root CID."
+  [^js node doc-id body]
+  (write-datoms! node (g/body->blocks doc-id body)))
+
+(defn store-book!
+  "Normalize a Sheets gridJson ({sheet [[cell]]}) into sparse :cell/* datoms and commit."
+  [^js node book-id grid]
+  (write-datoms! node (g/grid->cells book-id grid)))
+
+;; ---------------------------------------------------------------------------
+;; read: datomicQ -> typed [e a v] datoms (mirrors kotoba.office all-rows)
+;; ---------------------------------------------------------------------------
+
+(defn- all-rows
+  "All [e a-str scalar] triples from the local engine (decoded scalars)."
+  [^js node]
+  (js->clj (js/JSON.parse (.datomicQ node "[:find ?e ?a ?v :where [?e ?a ?v]]" "[]"))))
+
+(defn- typed-datoms
+  "all-rows -> [e a-kw typed-v] keeping only rows whose entity passes `keep-e?`."
+  [^js node keep-e?]
+  (->> (all-rows node)
+       (keep (fn [[e a s]]
+               (when (keep-e? e a)
+                 (let [ak (a->kw a)] [e ak (decode ak s)]))))
+       vec))
+
+(defn doc-datoms
+  "Current :block/* (+ doc) datoms for one doc — feed to gitdiff/gitmerge."
+  [^js node doc-id]
+  (let [block? (->> (all-rows node)
+                    (keep (fn [[e a s]] (when (and (= a ":block/parent") (= s doc-id)) e)))
+                    set)]
+    (typed-datoms node (fn [e _a] (or (block? e) (= e doc-id))))))
+
+(defn book-datoms
+  "Current :cell/* datoms for one book."
+  [^js node book-id]
+  (let [cell? (->> (all-rows node)
+                   (keep (fn [[e a s]] (when (and (= a ":cell/book") (= s book-id)) e)))
+                   set)]
+    (typed-datoms node (fn [e _a] (cell? e)))))
+
+(defn pr-datoms
+  "Every datom relevant to merge-gating a PR (pr/review/policy/ci/issue/ref)."
+  [^js node]
+  (typed-datoms node
+                (fn [_e a] (some #(str/starts-with? a %)
+                                 [":pr/" ":review/" ":policy/" ":ci/" ":issue/" ":ref/"]))))
+
+;; ---------------------------------------------------------------------------
+;; convenience: diff / merge / gate against the live node
+;; ---------------------------------------------------------------------------
+
+(defn diff-doc
+  "Semantic diff of one doc between two datom snapshots (base, head)."
+  [base-datoms head-datoms doc-id]
+  (d/diff-doc base-datoms head-datoms doc-id))
+
+(defn merge-doc
+  "3-way merge of one doc across three datom snapshots."
+  [base-datoms ours-datoms theirs-datoms doc-id]
+  (m/merge-doc base-datoms ours-datoms theirs-datoms doc-id))
+
+(defn evaluate-merge!
+  "Pull PR-related datoms from the live node and decide mergeability of pr-id."
+  [^js node pr-id]
+  (p/evaluate-merge (pr-datoms node) pr-id))
+
+;; ---------------------------------------------------------------------------
+;; JS-facing exports (wrap clj data -> js for non-cljs callers)
+;; ---------------------------------------------------------------------------
+
+(defn ^:export storeDocumentBody [^js node doc-id body-json]
+  (store-doc! node doc-id (js->clj body-json :keywordize-keys true)))
+
+(defn ^:export storeWorkbookGrid [^js node book-id grid-json]
+  (store-book! node book-id (js->clj grid-json :keywordize-keys true)))
+
+(defn ^:export evaluateMerge [^js node pr-id]
+  (clj->js (evaluate-merge! node pr-id)))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/gitoffice_test.clj
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/gitoffice_test.clj
@@ -1,0 +1,177 @@
+(ns kotoba.gitoffice-test
+  "Round-trip + invariant tests for the GitOffice Phase 0 converters.
+   Run: bb test  (from this dir)."
+  (:require [clojure.test :refer [deftest is testing run-tests]]
+            [kotoba.gitoffice :as g]))
+
+;; ---------------------------------------------------------------------------
+;; fractional indexing
+;; ---------------------------------------------------------------------------
+
+(deftest order-strictly-increasing
+  (let [ks (g/initial-orders 50)]
+    (is (= 50 (count ks)))
+    (is (= ks (sort ks)) "initial order keys are lexicographically increasing")
+    (is (apply distinct? ks) "no duplicate order keys")))
+
+(deftest order-between-rejects-noncanonical
+  (testing "trailing-zero / empty / non-ascending keys are rejected, not silently corrupted"
+    (is (thrown? clojure.lang.ExceptionInfo (g/order-between "1" "10")))  ; trailing-zero upper
+    (is (thrown? clojure.lang.ExceptionInfo (g/order-between "10" nil)))  ; trailing-zero lower
+    (is (thrown? clojure.lang.ExceptionInfo (g/order-between "" "")))     ; empty upper
+    (is (thrown? clojure.lang.ExceptionInfo (g/order-between "b" "a")))   ; non-ascending
+    (testing "canonical keys with a shared prefix still work"
+      (let [k (g/order-between "1" "11")]
+        (is (< (compare "1" k) 0))
+        (is (< (compare k "11") 0))))))
+
+(deftest order-between-inserts
+  (testing "a key can always be inserted between two adjacent keys"
+    (let [[a b] (g/initial-orders 2)
+          mid   (g/order-between a b)]
+      (is (< (compare a mid) 0))
+      (is (< (compare mid b) 0)))
+    (testing "repeated head-inserts stay ordered"
+      (let [b (first (g/initial-orders 1))
+            k1 (g/order-between nil b)
+            k2 (g/order-between nil k1)]
+        (is (< (compare k1 b) 0))
+        (is (< (compare k2 k1) 0))))))
+
+;; ---------------------------------------------------------------------------
+;; A1 notation
+;; ---------------------------------------------------------------------------
+
+(deftest a1-roundtrip
+  (is (= "A" (g/col->a1 0)))
+  (is (= "B" (g/col->a1 1)))
+  (is (= "Z" (g/col->a1 25)))
+  (is (= "AA" (g/col->a1 26)))
+  (is (= "AB" (g/col->a1 27)))
+  (doseq [c [0 1 25 26 27 51 52 700]]
+    (is (= c (g/a1->col (g/col->a1 c))) (str "col " c " round-trips")))
+  (is (= "Sheet1!B2" (g/cell-id "Sheet1" 1 1))))
+
+;; ---------------------------------------------------------------------------
+;; docs: bodyJson <-> blocks
+;; ---------------------------------------------------------------------------
+
+(def sample-body
+  [{:elementId "el0" :kind "heading" :headingLevel 1 :text "概要"}
+   {:elementId "el1" :kind "paragraph" :text "原材料費が上昇した。"}
+   {:elementId "el2" :kind "listItem" :text "項目A"}
+   {:elementId "el3" :kind "paragraph" :text ""}])
+
+(deftest body-roundtrip
+  (let [ds (g/body->blocks "doc1" sample-body)
+        b' (g/blocks->body ds "doc1")]
+    (is (= sample-body b') "bodyJson -> blocks -> bodyJson is identity")
+    (testing "blocks are children of the doc with a heading-level only where present"
+      (is (= "doc1" (g/v-one ds "el1" :block/parent)))
+      (is (= 1 (g/v-one ds "el0" :block/heading-level)))
+      (is (nil? (g/v-one ds "el1" :block/heading-level))))))
+
+(deftest body-normalize-idempotent
+  (testing "re-normalizing keeps the same stable block ids (elementId)"
+    (let [ds1 (g/body->blocks "doc1" sample-body)
+          b'  (g/blocks->body ds1 "doc1")
+          ds2 (g/body->blocks "doc1" b')]
+      (is (= (set ds1) (set ds2))))))
+
+;; ---------------------------------------------------------------------------
+;; sheets: gridJson <-> cells
+;; ---------------------------------------------------------------------------
+
+(def sample-grid
+  {"Sheet1" [["売上" "Q1" "Q2"]
+             ["製品A" "100" "120"]
+             ["製品B" "" "80"]]})
+
+(deftest grid-roundtrip
+  (let [ds (g/grid->cells "book1" sample-grid)
+        g' (g/cells->grid ds "book1")]
+    (is (= (update sample-grid "Sheet1" g/trim-grid) g')
+        "gridJson -> sparse cells -> gridJson equals the trimmed grid")
+    (testing "cells are sparse (the empty B3 is not stored)"
+      (is (nil? (g/v-one ds "Sheet1!B3" :cell/value)))
+      (is (= "120" (g/v-one ds "Sheet1!C2" :cell/value))))))
+
+(deftest grid-trailing-empties-trim
+  (testing "trailing empty rows/cols are dropped by the sparse canonical form"
+    (let [grid {"S" [["x" "" ""] ["" "" ""]]}
+          ds   (g/grid->cells "bk" grid)
+          g'   (g/cells->grid ds "bk")]
+      (is (= {"S" [["x"]]} g')))))
+
+;; ---------------------------------------------------------------------------
+;; revision <-> commit bridge
+;; ---------------------------------------------------------------------------
+
+(deftest rev-roundtrip
+  (is (= 7 (g/parse-rev "rev-7")))
+  (is (= 7 (g/parse-rev "7")))
+  (let [r {:id "r1" :of "doc1" :label "rev-3" :seq 3 :commit "bafy..."}
+        ds (g/rev->datoms r)]
+    (is (= r (g/datoms->rev ds "r1")))
+    (testing "commit is optional before commit() runs"
+      (let [r2 {:id "r2" :of "doc1" :label "rev-0" :seq 0}]
+        (is (= r2 (g/datoms->rev (g/rev->datoms r2) "r2")))))))
+
+;; ---------------------------------------------------------------------------
+;; collaboration metadata <-> datoms
+;; ---------------------------------------------------------------------------
+
+(deftest issue-roundtrip
+  (let [i {:id "i1" :repo "repo1" :number 1 :title "色が崩れる"
+           :body "スライド3の表" :author "did:key:zAlice" :state :issue.state/open
+           :created-at 1719100000000 :labels #{"bug" "slides"}
+           :anchors #{"ocz1:abc"}}]
+    (is (= i (g/datoms->issue (g/issue->datoms i) "i1")))))
+
+(deftest pr-roundtrip
+  (let [p {:id "pr1" :repo "repo1" :number 2 :title "色を修正"
+           :author "did:key:zBob" :base-ref "refs/heads/main"
+           :head-ref "refs/heads/fix-color" :base-commit "bafyBASE"
+           :head-commit "bafyHEAD" :merge-base "bafyMB" :state :pr.state/open
+           :closes-issues #{"i1"}}]
+    (is (= p (g/datoms->pr (g/pr->datoms p) "pr1"))))
+  (testing "optional merge-base/merged-commit omitted"
+    (let [p {:id "pr2" :repo "repo1" :number 3 :title "x" :author "did:key:zC"
+             :base-ref "refs/heads/main" :head-ref "refs/heads/y"
+             :base-commit "b" :head-commit "h" :state :pr.state/draft
+             :closes-issues #{}}]
+      (is (= p (g/datoms->pr (g/pr->datoms p) "pr2"))))))
+
+(deftest review-roundtrip
+  (let [r {:id "rv1" :pr "pr1" :reviewer "did:key:zCarol"
+           :state :review.state/approved :at-commit "bafyHEAD" :vc "bafyVC"}]
+    (is (= r (g/datoms->review (g/review->datoms r) "rv1")))))
+
+(deftest comment-roundtrip
+  (let [c {:id "c1" :on "pr1" :author "did:key:zCarol"
+           :body "ここは赤すぎる" :anchor "ocz1:abc" :side :side/head
+           :resolved false :created-at 1719100001000}]
+    (is (= c (g/datoms->comment (g/comment->datoms c) "c1")))))
+
+;; ---------------------------------------------------------------------------
+;; cross-cutting invariant: a normalized doc round-trips THROUGH the blob the
+;; deployed app stores, with the collaboration layer attached but separable.
+;; ---------------------------------------------------------------------------
+
+(deftest stale-review-detectable
+  (testing "an approval at an old head is distinguishable from one at the current head"
+    (let [pr  (g/pr->datoms {:id "pr1" :repo "r" :number 1 :title "t"
+                             :author "did:key:zB" :base-ref "refs/heads/main"
+                             :head-ref "refs/heads/x" :base-commit "b"
+                             :head-commit "HEAD2" :state :pr.state/open
+                             :closes-issues #{}})
+          rv  (g/review->datoms {:id "rv1" :pr "pr1" :reviewer "did:key:zC"
+                                 :state :review.state/approved :at-commit "HEAD1"})
+          ds  (into pr rv)
+          head (g/v-one ds "pr1" :pr/head-commit)
+          approved-at (g/v-one ds "rv1" :review/at-commit)]
+      (is (not= head approved-at) "review.at-commit != pr.head-commit => stale"))))
+
+(defn -main []
+  (let [{:keys [fail error]} (run-tests 'kotoba.gitoffice-test)]
+    (+ (or fail 0) (or error 0))))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/gitpolicy.cljc
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/gitpolicy.cljc
@@ -1,0 +1,154 @@
+(ns kotoba.gitpolicy
+  "GitOffice merge-policy gate (doc e §5-§6) — pure (.cljc).
+
+   Decides, over the Phase-0 collaboration datoms, whether a PR may merge:
+   required approvals, stale-review dismissal, required reviewers (CODEOWNERS-ish),
+   branch protection, and required CI checks. Then `land-pr-tx` produces the
+   retract/assert ops to advance the base ref to the merge commit, mark the PR merged,
+   and close its linked issues. These are the same checks doc e §6 expresses as
+   datomicQ — here as plain folds so they are unit-testable without a running kotoba."
+  (:require [kotoba.gitoffice :as g]
+            [clojure.set :as set]))
+
+;; ---------------------------------------------------------------------------
+;; schema (additive): branch-protection policy + CI results
+;; ---------------------------------------------------------------------------
+
+(def schema
+  {:policy/repo                {:db/valueType :ref     :db/cardinality :one}
+   :policy/required-approvals  {:db/valueType :long    :db/cardinality :one}
+   :policy/required-reviewer   {:db/valueType :did     :db/cardinality :many}
+   :policy/dismiss-stale       {:db/valueType :boolean :db/cardinality :one}
+   :policy/require-ci          {:db/valueType :keyword :db/cardinality :many}
+
+   :ci/pr                      {:db/valueType :ref     :db/cardinality :one}
+   :ci/check                   {:db/valueType :keyword :db/cardinality :one}
+   :ci/state                   {:db/valueType :keyword :db/cardinality :one} ; :ci.state/pass|fail|pending
+   :ci/at-commit               {:db/valueType :string  :db/cardinality :one}})
+
+(defn policy->datoms [{:keys [id repo required-approvals required-reviewers
+                              dismiss-stale require-ci]}]
+  (into (cond-> [[id :policy/repo repo]]
+          (some? required-approvals) (conj [id :policy/required-approvals required-approvals])
+          (some? dismiss-stale)      (conj [id :policy/dismiss-stale dismiss-stale]))
+        (concat (map (fn [d] [id :policy/required-reviewer d]) required-reviewers)
+                (map (fn [c] [id :policy/require-ci c]) require-ci))))
+
+(defn ci->datoms [{:keys [id pr check state at-commit]}]
+  [[id :ci/pr pr] [id :ci/check check] [id :ci/state state] [id :ci/at-commit at-commit]])
+
+;; ---------------------------------------------------------------------------
+;; policy lookup (with GitHub-like defaults when a repo has no protection)
+;; ---------------------------------------------------------------------------
+
+(defn policy-for
+  "Effective policy map for a repo. No policy entity => unprotected (0 approvals)."
+  [datoms repo]
+  (let [pid (some (fn [[e a v]] (when (and (= a :policy/repo) (= v repo)) e)) datoms)]
+    {:required-approvals (or (and pid (g/v-one datoms pid :policy/required-approvals)) 0)
+     :required-reviewers (if pid (g/v-many datoms pid :policy/required-reviewer) #{})
+     :dismiss-stale      (if (and pid (some? (g/v-one datoms pid :policy/dismiss-stale)))
+                           (g/v-one datoms pid :policy/dismiss-stale)
+                           true)                       ; default: dismiss stale approvals
+     :require-ci         (if pid (g/v-many datoms pid :policy/require-ci) #{})}))
+
+;; ---------------------------------------------------------------------------
+;; effective review state per reviewer (latest-wins-by-rule, stale-aware)
+;; ---------------------------------------------------------------------------
+
+(defn effective-states
+  "{reviewer-did -> :approved | :changes-requested | :none}.
+   When dismiss-stale?, only reviews whose :review/at-commit = head count.
+   changes-requested dominates approved for the same reviewer."
+  [datoms pr-id head dismiss-stale?]
+  (let [rids (->> datoms
+                  (keep (fn [[e a v]] (when (and (= a :review/pr) (= v pr-id)) e)))
+                  distinct)
+        by-rev (group-by #(g/v-one datoms % :review/reviewer) rids)]
+    (into {}
+          (for [[did rs] by-rev]
+            (let [at-head  (filter #(= head (g/v-one datoms % :review/at-commit)) rs)
+                  ;; a review AT head always supersedes that reviewer's older reviews
+                  ;; (so a fresh approval clears an earlier changes-request). Only when
+                  ;; the reviewer has NO review at head does dismiss-stale decide whether
+                  ;; their stale reviews still count.
+                  relevant (cond
+                             (seq at-head)  at-head
+                             dismiss-stale? []
+                             :else          rs)
+                  states (set (map #(g/v-one datoms % :review/state) relevant))]
+              [did (cond
+                     (states :review.state/changes-requested) :changes-requested
+                     (states :review.state/approved)          :approved
+                     :else                                    :none)])))))
+
+(defn- ci-states
+  "{check -> :ci.state/*} for CI rows at the PR head. Contract: one result row per
+   (check, commit) — a re-run retracts+asserts the same entity, so a re-run to green
+   clears an earlier failure (last-result-wins, not fail-absorbing)."
+  [datoms pr-id head]
+  (->> datoms
+       (keep (fn [[e a v]] (when (and (= a :ci/pr) (= v pr-id)) e)))
+       distinct
+       (filter #(= head (g/v-one datoms % :ci/at-commit)))
+       (reduce (fn [m c]
+                 (assoc m (g/v-one datoms c :ci/check) (g/v-one datoms c :ci/state)))
+               {})))
+
+;; ---------------------------------------------------------------------------
+;; the merge gate
+;; ---------------------------------------------------------------------------
+
+(defn evaluate-merge
+  "Decide whether pr-id may merge. -> {:mergeable? :reasons [...] + diagnostics}."
+  [datoms pr-id]
+  (let [repo  (g/v-one datoms pr-id :pr/repo)
+        state (g/v-one datoms pr-id :pr/state)
+        head  (g/v-one datoms pr-id :pr/head-commit)
+        {:keys [required-approvals required-reviewers dismiss-stale require-ci]} (policy-for datoms repo)
+        est   (effective-states datoms pr-id head dismiss-stale)
+        approvals (set (keep (fn [[d s]] (when (= s :approved) d)) est))
+        changes   (set (keep (fn [[d s]] (when (= s :changes-requested) d)) est))
+        missing-app (max 0 (- required-approvals (count approvals)))
+        missing-req (set/difference required-reviewers approvals)
+        ci    (ci-states datoms pr-id head)
+        passing (set (keep (fn [[c s]] (when (= s :ci.state/pass) c)) ci))
+        failing (set (keep (fn [[c s]] (when (= s :ci.state/fail) c)) ci))
+        missing-ci (set/difference require-ci passing)
+        reasons (cond-> []
+                  (not= state :pr.state/open) (conj :not-open)
+                  (pos? missing-app)          (conj :insufficient-approvals)
+                  (seq missing-req)           (conj :missing-required-reviewer)
+                  (seq changes)               (conj :changes-requested)
+                  (seq failing)               (conj :ci-failing)
+                  (seq missing-ci)            (conj :ci-missing))]
+    {:mergeable? (empty? reasons)
+     :reasons reasons
+     :approvals approvals
+     :changes-requested changes
+     :missing-approvals missing-app
+     :missing-required-reviewers missing-req
+     :failing-ci failing
+     :missing-ci missing-ci}))
+
+;; ---------------------------------------------------------------------------
+;; landing a PR (advance base ref, mark merged, close issues) — pure tx ops
+;; ---------------------------------------------------------------------------
+
+(defn land-pr-tx
+  "Retract/assert ops to land pr-id at merged-commit (the 2-parent merge commit CID).
+   -> {:retract [[e a v]...] :assert [[e a v]...]}. Apply only after evaluate-merge passes."
+  [datoms pr-id merged-commit]
+  (let [base-ref  (g/v-one datoms pr-id :pr/base-ref)
+        ref-eid   (some (fn [[e a v]] (when (and (= a :ref/name) (= v base-ref)) e)) datoms)
+        old-ref   (and ref-eid (g/v-one datoms ref-eid :ref/commit))
+        old-state (g/v-one datoms pr-id :pr/state)
+        issues    (g/v-many datoms pr-id :pr/closes-issue)]
+    {:retract (cond-> [[pr-id :pr/state old-state]]
+                old-ref (conj [ref-eid :ref/commit old-ref])
+                true (into (keep (fn [i] (when-let [s (g/v-one datoms i :issue/state)]
+                                           [i :issue/state s])) issues)))
+     :assert  (cond-> [[pr-id :pr/state :pr.state/merged]
+                       [pr-id :pr/merged-commit merged-commit]]
+                ref-eid (conj [ref-eid :ref/commit merged-commit])
+                true (into (map (fn [i] [i :issue/state :issue.state/closed]) issues)))}))

--- a/crates/kotoba-wasm/web/cljs/src/kotoba/gitpolicy_test.clj
+++ b/crates/kotoba-wasm/web/cljs/src/kotoba/gitpolicy_test.clj
@@ -1,0 +1,182 @@
+(ns kotoba.gitpolicy-test
+  "Tests for the GitOffice merge-policy gate + land-pr."
+  (:require [clojure.test :refer [deftest is testing run-tests]]
+            [kotoba.gitoffice :as g]
+            [kotoba.gitpolicy :as p]))
+
+;; shared PR fixture (open, head = HEAD2)
+(defn- pr-datoms []
+  (g/pr->datoms {:id "pr1" :repo "repo1" :number 1 :title "fix"
+                 :author "did:key:zAuthor" :base-ref "refs/heads/main"
+                 :head-ref "refs/heads/fix" :base-commit "BASE"
+                 :head-commit "HEAD2" :state :pr.state/open :closes-issues #{}}))
+
+(defn- review [id reviewer state at]
+  (g/review->datoms {:id id :pr "pr1" :reviewer reviewer :state state :at-commit at}))
+
+;; ---------------------------------------------------------------------------
+;; unprotected vs required approvals
+;; ---------------------------------------------------------------------------
+
+(deftest unprotected-repo-is-mergeable
+  (let [ds (pr-datoms)
+        r (p/evaluate-merge ds "pr1")]
+    (is (:mergeable? r) "no policy => mergeable (unprotected branch)")
+    (is (empty? (:reasons r)))))
+
+(deftest required-approvals-gate
+  (let [pol (p/policy->datoms {:id "pol" :repo "repo1" :required-approvals 1})
+        ds  (into (pr-datoms) pol)]
+    (testing "no approval -> blocked"
+      (let [r (p/evaluate-merge ds "pr1")]
+        (is (not (:mergeable? r)))
+        (is (some #{:insufficient-approvals} (:reasons r)))
+        (is (= 1 (:missing-approvals r)))))
+    (testing "one approval at head -> mergeable"
+      (let [ds2 (into ds (review "rv1" "did:key:zR1" :review.state/approved "HEAD2"))
+            r (p/evaluate-merge ds2 "pr1")]
+        (is (:mergeable? r))
+        (is (= #{"did:key:zR1"} (:approvals r)))))))
+
+;; ---------------------------------------------------------------------------
+;; stale review dismissal
+;; ---------------------------------------------------------------------------
+
+(deftest stale-approval-dismissed
+  (let [pol (p/policy->datoms {:id "pol" :repo "repo1" :required-approvals 1
+                               :dismiss-stale true})
+        ds  (-> (pr-datoms)
+                (into pol)
+                (into (review "rv1" "did:key:zR1" :review.state/approved "HEAD1")))] ; old head
+    (testing "approval at an outdated commit does not count when dismiss-stale"
+      (let [r (p/evaluate-merge ds "pr1")]
+        (is (not (:mergeable? r)))
+        (is (empty? (:approvals r)))))
+    (testing "same setup but dismiss-stale=false -> the old approval counts"
+      (let [pol2 (p/policy->datoms {:id "pol" :repo "repo1" :required-approvals 1
+                                    :dismiss-stale false})
+            ds2  (-> (pr-datoms)
+                     (into pol2)
+                     (into (review "rv1" "did:key:zR1" :review.state/approved "HEAD1")))
+            r (p/evaluate-merge ds2 "pr1")]
+        (is (:mergeable? r))))))
+
+;; ---------------------------------------------------------------------------
+;; changes-requested blocks; required reviewer; CI
+;; ---------------------------------------------------------------------------
+
+(deftest fresh-approval-supersedes-stale-changes-request
+  (testing "a reviewer's approval AT head clears their earlier changes-request (any dismiss-stale)"
+    (doseq [dismiss [true false]]
+      (let [pol (p/policy->datoms {:id "pol" :repo "repo1" :required-approvals 1
+                                   :dismiss-stale dismiss})
+            ds  (-> (pr-datoms) (into pol)
+                    (into (review "rv-old" "did:key:zR1" :review.state/changes-requested "HEAD1"))
+                    (into (review "rv-new" "did:key:zR1" :review.state/approved "HEAD2")))
+            r (p/evaluate-merge ds "pr1")]
+        (is (:mergeable? r) (str "dismiss-stale=" dismiss ": head approval wins"))
+        (is (= #{"did:key:zR1"} (:approvals r)))
+        (is (empty? (:changes-requested r)))))))
+
+(deftest ci-rerun-to-green-clears-failure
+  (testing "a failed check re-run to pass at the same head is satisfied (not fail-absorbing)"
+    (let [pol (p/policy->datoms {:id "pol" :repo "repo1" :required-approvals 0
+                                 :require-ci #{:ci/build}})
+          ;; retract+assert contract => only the latest row exists; model the green re-run
+          ds  (-> (pr-datoms) (into pol)
+                  (into (p/ci->datoms {:id "ci-build" :pr "pr1" :check :ci/build
+                                       :state :ci.state/pass :at-commit "HEAD2"})))
+          r (p/evaluate-merge ds "pr1")]
+      (is (:mergeable? r))
+      (is (empty? (:failing-ci r))))))
+
+(deftest changes-requested-blocks
+  (let [pol (p/policy->datoms {:id "pol" :repo "repo1" :required-approvals 0})
+        ds  (-> (pr-datoms) (into pol)
+                (into (review "rv1" "did:key:zR1" :review.state/changes-requested "HEAD2")))
+        r (p/evaluate-merge ds "pr1")]
+    (is (not (:mergeable? r)))
+    (is (some #{:changes-requested} (:reasons r)))))
+
+(deftest required-reviewer-gate
+  (let [pol (p/policy->datoms {:id "pol" :repo "repo1" :required-approvals 1
+                               :required-reviewers #{"did:key:zOwner"}})]
+    (testing "approved by someone else but not the required reviewer -> blocked"
+      (let [ds (-> (pr-datoms) (into pol)
+                   (into (review "rv1" "did:key:zR1" :review.state/approved "HEAD2")))
+            r (p/evaluate-merge ds "pr1")]
+        (is (not (:mergeable? r)))
+        (is (= #{"did:key:zOwner"} (:missing-required-reviewers r)))))
+    (testing "approved by the required reviewer -> mergeable"
+      (let [ds (-> (pr-datoms) (into pol)
+                   (into (review "rv1" "did:key:zOwner" :review.state/approved "HEAD2")))
+            r (p/evaluate-merge ds "pr1")]
+        (is (:mergeable? r))))))
+
+(deftest required-ci-gate
+  (let [pol (p/policy->datoms {:id "pol" :repo "repo1" :required-approvals 0
+                               :require-ci #{:ci/no-refuted :ci/coverage}})]
+    (testing "missing a required check -> blocked"
+      (let [ds (-> (pr-datoms) (into pol)
+                   (into (p/ci->datoms {:id "ci1" :pr "pr1" :check :ci/coverage
+                                        :state :ci.state/pass :at-commit "HEAD2"})))
+            r (p/evaluate-merge ds "pr1")]
+        (is (not (:mergeable? r)))
+        (is (= #{:ci/no-refuted} (:missing-ci r)))))
+    (testing "a failing check -> blocked even if present"
+      (let [ds (-> (pr-datoms) (into pol)
+                   (into (p/ci->datoms {:id "ci1" :pr "pr1" :check :ci/coverage
+                                        :state :ci.state/pass :at-commit "HEAD2"}))
+                   (into (p/ci->datoms {:id "ci2" :pr "pr1" :check :ci/no-refuted
+                                        :state :ci.state/fail :at-commit "HEAD2"})))
+            r (p/evaluate-merge ds "pr1")]
+        (is (some #{:ci-failing} (:reasons r)))
+        (is (= #{:ci/no-refuted} (:failing-ci r)))))
+    (testing "all required checks pass at head -> mergeable"
+      (let [ds (-> (pr-datoms) (into pol)
+                   (into (p/ci->datoms {:id "ci1" :pr "pr1" :check :ci/coverage
+                                        :state :ci.state/pass :at-commit "HEAD2"}))
+                   (into (p/ci->datoms {:id "ci2" :pr "pr1" :check :ci/no-refuted
+                                        :state :ci.state/pass :at-commit "HEAD2"})))
+            r (p/evaluate-merge ds "pr1")]
+        (is (:mergeable? r))))))
+
+(deftest already-merged-not-mergeable
+  (let [ds (g/pr->datoms {:id "pr1" :repo "repo1" :number 1 :title "x"
+                          :author "did:key:zA" :base-ref "refs/heads/main"
+                          :head-ref "refs/heads/y" :base-commit "B" :head-commit "H"
+                          :state :pr.state/merged :closes-issues #{}})
+        r (p/evaluate-merge ds "pr1")]
+    (is (not (:mergeable? r)))
+    (is (some #{:not-open} (:reasons r)))))
+
+;; ---------------------------------------------------------------------------
+;; landing a PR: advance ref, mark merged, close issues
+;; ---------------------------------------------------------------------------
+
+(deftest land-pr-advances-ref-and-closes-issues
+  (let [ds (-> []
+               (into (g/pr->datoms {:id "pr1" :repo "repo1" :number 1 :title "x"
+                                    :author "did:key:zA" :base-ref "refs/heads/main"
+                                    :base-commit "BASE" :head-ref "refs/heads/y"
+                                    :head-commit "HEAD2" :state :pr.state/open
+                                    :closes-issues #{"i1"}}))
+               (into [["mainref" :ref/name "refs/heads/main"]
+                      ["mainref" :ref/commit "BASE"]])
+               (into (g/issue->datoms {:id "i1" :repo "repo1" :number 1 :title "bug"
+                                       :author "did:key:zA" :state :issue.state/open
+                                       :created-at 0 :labels #{} :anchors #{}})))
+        tx (p/land-pr-tx ds "pr1" "MERGEDCID")]
+    (testing "ref advances to the merge commit"
+      (is (some #{["mainref" :ref/commit "BASE"]} (:retract tx)))
+      (is (some #{["mainref" :ref/commit "MERGEDCID"]} (:assert tx))))
+    (testing "PR marked merged with the merge commit"
+      (is (some #{["pr1" :pr/state :pr.state/merged]} (:assert tx)))
+      (is (some #{["pr1" :pr/merged-commit "MERGEDCID"]} (:assert tx))))
+    (testing "linked issue is closed"
+      (is (some #{["i1" :issue/state :issue.state/open]} (:retract tx)))
+      (is (some #{["i1" :issue/state :issue.state/closed]} (:assert tx))))))
+
+(defn -main []
+  (let [{:keys [fail error]} (run-tests 'kotoba.gitpolicy-test)]
+    (+ (or fail 0) (or error 0))))


### PR DESCRIPTION
Normalizes the coarse office blob model into element-granular datoms and adds semantic diff / 3-way merge / merge-policy, giving docs/sheets/slides a GitHub-like issue/PR/review/merge workflow. Design: `docs/gftd-office/e-pull-request-system.md` (in com-junkawasaki/root).

## Modules (CLJS, `crates/kotoba-wasm/web/cljs/src/kotoba/`)
- `gitoffice` — `:doc/bodyJson`⇄`:block/*`, `:sheet/gridJson`⇄`:cell/*` normalization, fractional-index order, revision bridge, issue/pr/review/comment converters
- `gitdiff` — stable-id semantic diff (add/remove/move/modified) + commit-DAG merge-base/LCA
- `gitmerge` — 3-way merge: attribute-level auto-merge, conflict reporting, concurrent fractional inserts never conflict
- `gitpolicy` — merge gate (required approvals / stale dismissal / required reviewers / required CI) + land-pr
- `gitoffice-node` — `KotobaNode` transact/commit/datomicQ glue + ESM exports

## Verification
- `bb` 39 tests / 129 assertions, 0 failures
- `shadow-cljs release web` → Build completed, **0 warnings**

## Review fixes included
Adversarial review found and this PR fixes: order-between corrupting on non-canonical (trailing-zero) keys → now rejected; stale changes-request sticking forever → head review supersedes; CI fail-absorbing → last-result-wins; non-deterministic body order on tied keys → id tie-break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)