### PR TITLE
fix(net): filter loopback addrs from Identify + log peer connect/disconnect

### DIFF
--- a/crates/kotoba-net/src/swarm.rs
+++ b/crates/kotoba-net/src/swarm.rs
@@ -17,6 +17,17 @@ use crate::protocol::KOTOBA_SYNC_PROTOCOL;
 
 pub type KotobaSwarmType = Swarm<KotobaBehaviour>;
 
+/// True if a multiaddr's IP component is loopback (127.0.0.0/8 or ::1). Used to
+/// drop loopback addresses a peer advertises via Identify — dialing them reaches
+/// the dialer's own localhost (a WrongPeerId storm), never the remote peer.
+pub(crate) fn multiaddr_is_loopback(addr: &Multiaddr) -> bool {
+    addr.iter().any(|p| match p {
+        Protocol::Ip4(ip) => ip.is_loopback(),
+        Protocol::Ip6(ip) => ip.is_loopback(),
+        _ => false,
+    })
+}
+
 /// NAT-traversal configuration (clean-room WireGuard/Tailscale-equivalent over
 /// libp2p — AutoNAT + Circuit Relay v2 + DCUtR).
 ///
@@ -350,9 +361,11 @@ impl KotobaSwarm {
 
                 // Connection events
                 SwarmEvent::ConnectionEstablished { peer_id, .. } => {
+                    tracing::info!(peer = %peer_id, "kotoba-net: peer connected");
                     return Some(KotobaNetEvent::PeerConnected(peer_id));
                 }
                 SwarmEvent::ConnectionClosed { peer_id, .. } => {
+                    tracing::info!(peer = %peer_id, "kotoba-net: peer disconnected");
                     return Some(KotobaNetEvent::PeerDisconnected(peer_id));
                 }
 
@@ -374,6 +387,13 @@ impl KotobaSwarm {
                     identify::Event::Received { peer_id, info, .. },
                 )) => {
                     for addr in info.listen_addrs {
+                        // Skip loopback addresses a peer advertises (a node listening
+                        // on 0.0.0.0 advertises 127.0.0.1 too): dialing those reaches
+                        // the DIALER's own localhost → a WrongPeerId storm. Only
+                        // routable addresses (LAN / Tailscale / public) are useful.
+                        if multiaddr_is_loopback(&addr) {
+                            continue;
+                        }
                         self.swarm
                             .behaviour_mut()
                             .kademlia


### PR DESCRIPTION
## What

Two small `kotoba-net` fixes that let a multi-node libp2p lattice form **cleanly over a real network** (Tailscale/LAN). Found while bringing up the `com-junkawasaki/murakumo` control plane on a 10-node Mac-mini fleet.

1. **Filter loopback addresses in the Identify handler.** A node listening on `0.0.0.0` advertises `127.0.0.1` among its `listen_addrs`. Peers fed those into Kademlia and then dialed `127.0.0.1:<port>` — which reaches the **dialer's own** localhost, producing a `WrongPeerId` storm that buried the routing table. We now skip loopback addrs (new `multiaddr_is_loopback` helper); only routable LAN/Tailscale/public addrs are kept.

2. **Log `ConnectionEstablished` / `ConnectionClosed` at info** (`kotoba-net: peer connected` / `disconnected`). The `/health` `peer_count` is the KDHT neighborhood, not the live libp2p link set, so there was no way to observe lattice connectivity from the outside.

## Verified

On a 10-node fleet over Tailscale: **9/10 nodes formed a full gossipsub mesh — 8 distinct links each — and `WrongPeerId` noise dropped to 0.** Before the loopback filter, nodes connected to a couple of peers but the routing table was dominated by failing `127.0.0.1` dials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)