### PR TITLE
feat(engi): gossip 経由の EN transfer を net_actor で受信→射影（mesh live 配線 R1）

### DIFF
--- a/crates/kotoba-dht/src/engi_chain.rs
+++ b/crates/kotoba-dht/src/engi_chain.rs
@@ -47,11 +47,14 @@ use kotoba_vault::agent_identity::AgentIdentity;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashSet, VecDeque};
 
-/// GossipSub topic carrying countersigned EN transfers across the mesh. A node
+/// GossipSub **KSE-topic name** carrying countersigned EN transfers across the
+/// mesh. This is the bare name (like `firehose` / `rekey/revoke`); the net layer
+/// maps it to the wire topic `kotoba/engi/transfer` via `gossipsub_topic`, so it
+/// must NOT carry the `kotoba/` prefix itself (that would double it). A node
 /// receiving a transfer here projects it into its [`crate::engi_chain`] balance
 /// view (after dedup via [`SeenTransfers`]); a *neighborhood validator* holding
 /// the spender's chain additionally audits solvency via [`audit_peer_chain`].
-pub const ENGI_TRANSFER_TOPIC: &str = "kotoba/engi/transfer";
+pub const ENGI_TRANSFER_TOPIC: &str = "engi/transfer";
 
 /// Default bound for [`SeenTransfers`] (matches the firehose seen-guard cap).
 pub const SEEN_TRANSFERS_CAP: usize = 8192;

--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -2071,6 +2071,7 @@ pub async fn run() -> anyhow::Result<()> {
                     Arc::clone(&state.executor),
                     Arc::clone(&state.mesh_routes),
                     inject_rx,
+                    Arc::clone(&state.engi),
                 ));
 
                 tracing::info!("kotoba-net swarm started (QUIC + GossipSub + Kademlia)");

--- a/crates/kotoba-server/src/net_actor.rs
+++ b/crates/kotoba-server/src/net_actor.rs
@@ -267,6 +267,32 @@ async fn apply_deploy_msg(
     }
 }
 
+/// Project a gossiped countersigned EN transfer into the local ledger cache.
+/// Decodes the CBOR [`kotoba_dht::MutualCreditTransfer`], dedups by `transfer_id`
+/// via `seen` (a re-gossiped transfer is applied at most once), and applies it
+/// through [`crate::engi::Engi::project_transfer`] (an unconditional net-zero
+/// mirror of a committed chain fact). Returns `true` iff newly projected; a
+/// duplicate or undecodable envelope returns `false` without mutating the ledger.
+async fn handle_engi_transfer(
+    data: &[u8],
+    seen: &mut kotoba_dht::SeenTransfers,
+    engi: &crate::engi::Engi,
+) -> bool {
+    match ciborium::from_reader::<kotoba_dht::MutualCreditTransfer, _>(data) {
+        Ok(t) => {
+            if !seen.insert(t.body.transfer_id()) {
+                return false; // duplicate gossip — already projected
+            }
+            engi.project_transfer(&t).await;
+            true
+        }
+        Err(e) => {
+            tracing::warn!(err = %e, "engi/transfer: bad MutualCreditTransfer envelope — skipped");
+            false
+        }
+    }
+}
+
 pub async fn run(
     mut swarm: KotobaSwarm,
     mut publish_rx: tokio::sync::mpsc::Receiver<(String, Vec<u8>)>,
@@ -285,11 +311,18 @@ pub async fn run(
     // mesh.deploy endpoint) are fed here so the node installs its own triggers/
     // routes + subscribes KSE topics — gossipsub does not deliver to self.
     mut lattice_inject_rx: tokio::sync::mpsc::Receiver<Vec<u8>>,
+    // EN mutual-credit ledger (projection cache): gossiped countersigned transfers
+    // on `engi/transfer` are projected here (ADR-engi-mutual-credit-on-chain).
+    engi: Arc<crate::engi::Engi>,
 ) {
     swarm.subscribe("quad/assert").ok();
     swarm.subscribe("quad/retract").ok();
     swarm.subscribe(REKEY_REVOKE_TOPIC).ok();
+    swarm.subscribe(kotoba_dht::ENGI_TRANSFER_TOPIC).ok();
     swarm.subscribe_pregel().ok();
+
+    // Dedup guard for gossiped EN transfers (project each at most once per node).
+    let mut engi_seen = kotoba_dht::SeenTransfers::default();
 
     // Full gossip topic string as published by KotobaSwarm (has "kotoba/" prefix)
     let pregel_full_topic = format!("kotoba/{PREGEL_GOSSIP_TOPIC}");
@@ -656,6 +689,13 @@ pub async fn run(
                                 if let Some(reg) = &pre_key_registry {
                                     reg.apply_revocation_warrant_bytes(&data).await;
                                 }
+                            } else if kse_name == kotoba_dht::ENGI_TRANSFER_TOPIC {
+                                // Countersigned EN transfer (engi-mutual-credit):
+                                // decode + dedup + project into the local ledger
+                                // cache. The transfer is already a committed fact
+                                // on both parties' Source Chains, so projection is
+                                // an unconditional net-zero mirror.
+                                handle_engi_transfer(&data, &mut engi_seen, &engi).await;
                             } else {
                                 let maybe_quad_op = if kse_name == "quad/assert" {
                                     serde_json::from_slice::<Quad>(&data).ok().map(|quad| (quad, true))
@@ -727,6 +767,48 @@ mod tests {
 
     fn cid(byte: u8) -> KotobaCid {
         KotobaCid([byte; 36])
+    }
+
+    fn engi_transfer_bytes(spender: &str, receiver: &str, amount: i64) -> Vec<u8> {
+        // project_transfer mirrors a committed chain fact and never inspects the
+        // signatures, so a dummy-signed body exercises the gossip-receive path.
+        let t = kotoba_dht::MutualCreditTransfer {
+            body: kotoba_dht::TransferBody {
+                spender: spender.to_string(),
+                receiver: receiver.to_string(),
+                amount,
+                spender_prev: None,
+                receiver_prev: None,
+                nonce: 0,
+                ts: 0,
+            },
+            spender_sig: Vec::new(),
+            receiver_sig: Vec::new(),
+        };
+        let mut buf = Vec::new();
+        ciborium::into_writer(&t, &mut buf).unwrap();
+        buf
+    }
+
+    #[tokio::test]
+    async fn handle_engi_transfer_projects_dedups_and_skips_garbage() {
+        let engi = crate::engi::Engi::from_env("did:key:op".to_string());
+        let mut seen = kotoba_dht::SeenTransfers::default();
+        let bytes = engi_transfer_bytes("did:key:a", "did:key:b", 250);
+
+        // First sighting is decoded, deduped-in, and projected (net-zero).
+        assert!(handle_engi_transfer(&bytes, &mut seen, &engi).await);
+        assert_eq!(engi.balance("did:key:a").await, -250);
+        assert_eq!(engi.balance("did:key:b").await, 250);
+
+        // Re-gossiped duplicate is dropped — not applied twice.
+        assert!(!handle_engi_transfer(&bytes, &mut seen, &engi).await);
+        assert_eq!(engi.balance("did:key:a").await, -250);
+        assert_eq!(engi.balance("did:key:b").await, 250);
+
+        // Undecodable bytes are skipped without panic or mutation.
+        assert!(!handle_engi_transfer(b"not cbor", &mut seen, &engi).await);
+        assert!(engi.ledger().await.is_balanced());
     }
 
     // ── KOTOBA Mesh M4: component placement path (start_component) ──
@@ -973,6 +1055,7 @@ mod tests {
             kotoba_lattice::TriggerRoutes::default(),
         ));
         let (_inject_tx, inject_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(8);
+        let engi = crate::engi::Engi::from_env("did:key:test-op".to_string());
 
         tokio::spawn(run(
             node,
@@ -987,6 +1070,7 @@ mod tests {
             executor,
             mesh_routes,
             inject_rx,
+            engi,
         ));
 
         // observer waits for the run-node's heartbeat (interval is 5 s; first

--- a/docs/ADR-engi-mutual-credit-on-chain.md
+++ b/docs/ADR-engi-mutual-credit-on-chain.md
@@ -88,11 +88,17 @@ etzhayyim-exclusive). EN is internal contribution accounting only.
 
 ## Wire / gossip
 
-- Topic `kotoba/engi/transfer` (`ENGI_TRANSFER_TOPIC`) carries countersigned
-  transfers for projection across the mesh.
+- `ENGI_TRANSFER_TOPIC` is the bare KSE-topic name `engi/transfer` (like
+  `firehose` / `rekey/revoke`); the net layer maps it to the wire topic
+  `kotoba/engi/transfer` via `gossipsub_topic`. It carries countersigned transfers
+  for projection across the mesh.
 - `SeenTransfers` (bounded ring+set keyed by `transfer_id`, cap
   `SEEN_TRANSFERS_CAP = 8192`) dedups re-gossiped transfers — mirrors the
   firehose `FirehoseSeen` guard.
+- `net_actor` (feature `p2p`) subscribes the topic and, on each inbound message,
+  runs `handle_engi_transfer` → decode `MutualCreditTransfer` → `SeenTransfers`
+  dedup → `Engi::project_transfer`. Outbound publish uses the existing generic
+  gossip channel (`(ENGI_TRANSFER_TOPIC, cbor)`).
 
 ## Status & follow-ups
 
@@ -104,13 +110,19 @@ with prev-pin + credit-limit), `replay_balance`, `validate_chain_transfers`,
 `Engi::{project_transfer, rebuild_from_transfers}`. 20 `engi_chain` unit tests +
 6 `Engi` projection tests, all green.
 
+**Landed (R1, net wiring):** `net_actor` (feature `p2p`) subscribes
+`ENGI_TRANSFER_TOPIC`, holds a `SeenTransfers` guard, and projects inbound
+transfers via `handle_engi_transfer` → `Engi::project_transfer`. `Engi` is
+threaded into `net_actor::run`. 1 handler unit test (project / dedup / skip
+garbage) green under `--features p2p`. Topic const corrected to the bare KSE name
+`engi/transfer` (the net layer adds the `kotoba/` prefix).
+
 **Deferred (next increments):**
 
-1. **net wiring** — subscribe/publish `kotoba/engi/transfer` in `net_actor.rs`
-   (one `swarm.subscribe(ENGI_TRANSFER_TOPIC)` + one inbound match arm calling
-   `SeenTransfers::insert` → `Engi::project_transfer`). Held back only because
-   `kotoba-net/src/swarm.rs` is concurrently dirty (background /loop); the wiring
-   is a ~10-line additive change once it lands.
+1. **outbound publish at transfer creation** — an XRPC endpoint / `EngiChain`
+   integration that, when this node records a spend/receive, gossips the
+   countersigned transfer on `ENGI_TRANSFER_TOPIC` via the generic publish
+   channel. (Inbound projection + subscribe already landed in R1.)
 2. **validator deployment** — a neighborhood node syncs a peer's chain via the
    existing bitswap `want_since`, runs `audit_peer_chain`, and gossips
    `mutual_credit_warrant`s on violations.


### PR DESCRIPTION
ADR-engi-mutual-credit-on-chain の **Deferred #1（net live 配線）**。#211 で入った
countersigned EN transfer を GossipSub で受信し、dedup して `Engi`（射影 cache）へ
project する live 配線。

## 変更
**`net_actor.rs`（feature `p2p`）**
- `ENGI_TRANSFER_TOPIC` を `swarm.subscribe`、`SeenTransfers` dedup guard を保持
- `handle_engi_transfer(data, seen, engi)` — CBOR decode → `transfer_id` で dedup
  → `Engi::project_transfer`（chain 確定 fact の net-zero ミラー。署名は chain 側で
  検証済みなので無条件適用）
- `Engi` を `net_actor::run` に thread（`lib.rs` 本番 spawn + テスト call site）

**`kotoba-dht/engi_chain.rs`**
- `ENGI_TRANSFER_TOPIC` を `"kotoba/engi/transfer"` → **bare KSE 名 `"engi/transfer"`** へ修正。
  `gossipsub_topic` が `kotoba/` を付与するため、prefix 重複（`kotoba/kotoba/...`）を回避。
  wire topic は従来どおり `kotoba/engi/transfer`、inbound は `strip_prefix("kotoba/")` で一致。

## テスト
- `net_actor::tests::handle_engi_transfer_projects_dedups_and_skips_garbage`（project / dedup /
  不正バイト skip）green（`--features p2p`）
- `cargo test -p kotoba-dht engi_chain` 20 green
- `cargo fmt --check` + `RUSTDOCFLAGS=-D warnings cargo doc --features p2p` ローカル確認済み

> net_actor は `#[cfg(feature = "p2p")]` 配下のため、**all-features gate** で検証されます（default gate には出ません）。

## スコープ外（次インクリメント）
- **outbound publish**: transfer 生成時（XRPC / `EngiChain` 統合）に generic gossip channel で
  `(ENGI_TRANSFER_TOPIC, cbor)` を送出。本 PR は inbound 受信＋射影まで。
- validator デプロイ / boot replay / fee の transfer 化（ADR §Deferred）

🤖 Generated with [Claude Code](https://claude.com/claude-code)