### PR TITLE
feat(engi): EN transfer の outbound publish + 受信検証境界 + did:key 解決（R2）

### DIFF
--- a/crates/kotoba-server/src/engi.rs
+++ b/crates/kotoba-server/src/engi.rs
@@ -84,6 +84,16 @@ pub const DEFAULT_CREDIT_LIMIT_EN: i64 = 1_000_000;
 /// go into credit. Higher reputation ⇒ more write headroom before a 402.
 pub const STAKE_MKOTO_PER_CREDIT_EN: u64 = 1_000;
 
+/// Resolve an agent DID to its 32-byte Ed25519 public key for verifying
+/// mutual-credit countersignatures. R2 supports `did:key` (the scheme
+/// `AgentIdentity` mints); other methods (`did:plc`, `did:web`) resolve to
+/// `None` until their resolution is wired. Used by the gossip-receive path and
+/// the `engi.transfer` endpoint to reject forged transfers before projecting,
+/// and as `kotoba_dht::audit_peer_chain`'s `resolve` closure.
+pub fn resolve_did_pubkey(did: &str) -> Option<[u8; 32]> {
+    kotoba_auth::parse_ed25519_did_key(did).ok()
+}
+
 /// Snapshot of the ledger's accounting at a point in time.
 ///
 /// Invariant for a correctly-functioning mutual-credit ledger: `net == 0`.
@@ -484,6 +494,20 @@ mod tests {
 
     fn engi(write_cost: i64, op: &str) -> Arc<Engi> {
         engi_persisted(write_cost, op, None)
+    }
+
+    #[test]
+    fn resolve_did_pubkey_roundtrips_did_key_and_rejects_others() {
+        // An AgentIdentity's DID is a did:key over its Ed25519 key — resolution
+        // must recover exactly that pubkey (the verify path depends on it).
+        let id = kotoba_vault::AgentIdentity::generate_ephemeral();
+        assert_eq!(
+            resolve_did_pubkey(&id.did),
+            Some(id.verifying_key().to_bytes())
+        );
+        // Non-did:key methods are not resolvable in R2.
+        assert!(resolve_did_pubkey("did:plc:abc123").is_none());
+        assert!(resolve_did_pubkey("not-a-did").is_none());
     }
 
     fn engi_persisted(write_cost: i64, op: &str, persist_path: Option<PathBuf>) -> Arc<Engi> {

--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -1259,6 +1259,10 @@ pub fn build_router(state: Arc<KotobaState>) -> Router {
             post(xrpc::econ_credit),
         )
         .route(
+            &format!("/xrpc/{}", xrpc::NSID_ENGI_TRANSFER),
+            post(xrpc::econ_transfer),
+        )
+        .route(
             &format!("/xrpc/{}", xrpc::NSID_ECON_BALANCE),
             post(xrpc::econ_balance),
         )

--- a/crates/kotoba-server/src/net_actor.rs
+++ b/crates/kotoba-server/src/net_actor.rs
@@ -267,30 +267,49 @@ async fn apply_deploy_msg(
     }
 }
 
-/// Project a gossiped countersigned EN transfer into the local ledger cache.
-/// Decodes the CBOR [`kotoba_dht::MutualCreditTransfer`], dedups by `transfer_id`
-/// via `seen` (a re-gossiped transfer is applied at most once), and applies it
-/// through [`crate::engi::Engi::project_transfer`] (an unconditional net-zero
-/// mirror of a committed chain fact). Returns `true` iff newly projected; a
-/// duplicate or undecodable envelope returns `false` without mutating the ledger.
+/// Project a gossiped countersigned EN transfer into the local ledger cache,
+/// after verifying it at the gossip boundary. Decodes the CBOR
+/// [`kotoba_dht::MutualCreditTransfer`], resolves both parties' `did:key`s and
+/// **verifies both countersignatures** (a forged or single-signed transfer is
+/// rejected, never projected), dedups by `transfer_id` via `seen`, then applies
+/// it through [`crate::engi::Engi::project_transfer`] (an unconditional net-zero
+/// mirror of a now-verified fact). Returns `true` iff newly projected; an
+/// undecodable, unresolvable, forged, or duplicate envelope returns `false`
+/// without mutating the ledger.
 async fn handle_engi_transfer(
     data: &[u8],
     seen: &mut kotoba_dht::SeenTransfers,
     engi: &crate::engi::Engi,
 ) -> bool {
-    match ciborium::from_reader::<kotoba_dht::MutualCreditTransfer, _>(data) {
-        Ok(t) => {
-            if !seen.insert(t.body.transfer_id()) {
-                return false; // duplicate gossip — already projected
-            }
-            engi.project_transfer(&t).await;
-            true
-        }
+    let t = match ciborium::from_reader::<kotoba_dht::MutualCreditTransfer, _>(data) {
+        Ok(t) => t,
         Err(e) => {
             tracing::warn!(err = %e, "engi/transfer: bad MutualCreditTransfer envelope — skipped");
-            false
+            return false;
         }
+    };
+    // Validator boundary: only project transfers whose BOTH countersignatures
+    // verify against the resolved did:key pubkeys. This is the gossip-edge guard
+    // that keeps a forged transfer from ever entering the projection.
+    let (Some(spk), Some(rpk)) = (
+        crate::engi::resolve_did_pubkey(&t.body.spender),
+        crate::engi::resolve_did_pubkey(&t.body.receiver),
+    ) else {
+        tracing::warn!(
+            spender = %t.body.spender, receiver = %t.body.receiver,
+            "engi/transfer: unresolvable DID (non-did:key) — skipped"
+        );
+        return false;
+    };
+    if let Err(e) = t.verify(&spk, &rpk) {
+        tracing::warn!(err = %e, "engi/transfer: invalid countersignature — rejected");
+        return false;
     }
+    if !seen.insert(t.body.transfer_id()) {
+        return false; // duplicate gossip — already projected
+    }
+    engi.project_transfer(&t).await;
+    true
 }
 
 pub async fn run(
@@ -769,42 +788,58 @@ mod tests {
         KotobaCid([byte; 36])
     }
 
-    fn engi_transfer_bytes(spender: &str, receiver: &str, amount: i64) -> Vec<u8> {
-        // project_transfer mirrors a committed chain fact and never inspects the
-        // signatures, so a dummy-signed body exercises the gossip-receive path.
-        let t = kotoba_dht::MutualCreditTransfer {
-            body: kotoba_dht::TransferBody {
-                spender: spender.to_string(),
-                receiver: receiver.to_string(),
-                amount,
-                spender_prev: None,
-                receiver_prev: None,
-                nonce: 0,
-                ts: 0,
-            },
-            spender_sig: Vec::new(),
-            receiver_sig: Vec::new(),
-        };
+    /// CBOR bytes of a transfer countersigned by `spender` and `cosigner`. When
+    /// `cosigner` is the real receiver the transfer verifies; passing a third
+    /// identity forges the counter-signature (used to drive the reject path).
+    fn signed_transfer_bytes(
+        spender: &kotoba_vault::AgentIdentity,
+        receiver: &kotoba_vault::AgentIdentity,
+        cosigner: &kotoba_vault::AgentIdentity,
+        amount: i64,
+    ) -> Vec<u8> {
+        let t = kotoba_dht::MutualCreditTransfer::countersign(
+            spender.did.clone(),
+            receiver.did.clone(),
+            amount,
+            None,
+            None,
+            0,
+            0,
+            &spender.signing_key,
+            &cosigner.signing_key,
+        )
+        .unwrap();
         let mut buf = Vec::new();
         ciborium::into_writer(&t, &mut buf).unwrap();
         buf
     }
 
     #[tokio::test]
-    async fn handle_engi_transfer_projects_dedups_and_skips_garbage() {
+    async fn handle_engi_transfer_verifies_projects_dedups_and_rejects() {
+        let a = kotoba_vault::AgentIdentity::generate_ephemeral();
+        let b = kotoba_vault::AgentIdentity::generate_ephemeral();
+        let eve = kotoba_vault::AgentIdentity::generate_ephemeral();
         let engi = crate::engi::Engi::from_env("did:key:op".to_string());
         let mut seen = kotoba_dht::SeenTransfers::default();
-        let bytes = engi_transfer_bytes("did:key:a", "did:key:b", 250);
 
-        // First sighting is decoded, deduped-in, and projected (net-zero).
-        assert!(handle_engi_transfer(&bytes, &mut seen, &engi).await);
-        assert_eq!(engi.balance("did:key:a").await, -250);
-        assert_eq!(engi.balance("did:key:b").await, 250);
+        // A properly countersigned transfer verifies and projects (net-zero).
+        let good = signed_transfer_bytes(&a, &b, &b, 250);
+        assert!(handle_engi_transfer(&good, &mut seen, &engi).await);
+        assert_eq!(engi.balance(&a.did).await, -250);
+        assert_eq!(engi.balance(&b.did).await, 250);
 
         // Re-gossiped duplicate is dropped — not applied twice.
-        assert!(!handle_engi_transfer(&bytes, &mut seen, &engi).await);
-        assert_eq!(engi.balance("did:key:a").await, -250);
-        assert_eq!(engi.balance("did:key:b").await, 250);
+        assert!(!handle_engi_transfer(&good, &mut seen, &engi).await);
+        assert_eq!(engi.balance(&a.did).await, -250);
+
+        // A forged counter-signature (eve, not b) is rejected before projection.
+        let forged = signed_transfer_bytes(&a, &b, &eve, 999);
+        assert!(!handle_engi_transfer(&forged, &mut seen, &engi).await);
+        assert_eq!(
+            engi.balance(&a.did).await,
+            -250,
+            "forged transfer must not apply"
+        );
 
         // Undecodable bytes are skipped without panic or mutation.
         assert!(!handle_engi_transfer(b"not cbor", &mut seen, &engi).await);

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -90,6 +90,11 @@ pub const NSID_VAULT_GET: &str = "com.etzhayyim.apps.kotoba.vault.get";
 /// existing clients keep working while new ones migrate to `engi.*`.
 pub const NSID_ENGI_BALANCE: &str = "com.etzhayyim.apps.kotoba.engi.balance";
 pub const NSID_ENGI_CREDIT: &str = "com.etzhayyim.apps.kotoba.engi.credit";
+/// Submit a **countersigned** mutual-credit transfer: verify both `did:key`
+/// signatures, project it into the local ledger, and gossip it to the mesh on
+/// `engi/transfer` (ADR-engi-mutual-credit-on-chain R2). Self-authorizing — the
+/// two signatures ARE the authorization, so there is no operator gate.
+pub const NSID_ENGI_TRANSFER: &str = "com.etzhayyim.apps.kotoba.engi.transfer";
 /// Deprecated aliases (pre-ENGI-rename); prefer `NSID_ENGI_*`.
 pub const NSID_ECON_BALANCE: &str = "com.etzhayyim.apps.kotoba.econ.balance";
 pub const NSID_ECON_CREDIT: &str = "com.etzhayyim.apps.kotoba.econ.credit";
@@ -934,6 +939,56 @@ pub async fn econ_credit(
         // legacy keys (deprecated — EN replaces mKOTO; kept for client compat)
         "credited_mkoto": req.amount,
         "balance_mkoto": balance,
+    })))
+}
+
+/// `engi.transfer` — submit a countersigned mutual-credit transfer.
+///
+/// Self-authorizing: the two `did:key` signatures over the transfer body ARE the
+/// authorization (no operator gate, unlike `engi.credit`). The handler resolves
+/// both DIDs, verifies BOTH signatures, projects the net-zero move into the local
+/// ledger, and gossips the transfer to the mesh on `engi/transfer` (CBOR) so peer
+/// nodes' [`crate::net_actor`] receive paths project it too. Returns the resulting
+/// balances and whether it was gossiped.
+pub async fn econ_transfer(
+    State(state): State<Arc<KotobaState>>,
+    Json(t): Json<kotoba_dht::MutualCreditTransfer>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let spk = crate::engi::resolve_did_pubkey(&t.body.spender).ok_or((
+        StatusCode::BAD_REQUEST,
+        "spender DID is not a resolvable did:key".to_string(),
+    ))?;
+    let rpk = crate::engi::resolve_did_pubkey(&t.body.receiver).ok_or((
+        StatusCode::BAD_REQUEST,
+        "receiver DID is not a resolvable did:key".to_string(),
+    ))?;
+    // Both countersignatures must verify — the transfer is self-authorizing.
+    t.verify(&spk, &rpk)
+        .map_err(|e| (StatusCode::BAD_REQUEST, format!("invalid transfer: {e}")))?;
+
+    // Project the verified net-zero move into the local ledger cache.
+    state.engi.project_transfer(&t).await;
+
+    // Gossip to the mesh (bare KSE topic; the swarm adds the `kotoba/` prefix).
+    let gossiped = if let Some(tx) = &state.gossip_tx {
+        let mut buf = Vec::new();
+        ciborium::into_writer(&t, &mut buf)
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("encode: {e}")))?;
+        tx.try_send((kotoba_dht::ENGI_TRANSFER_TOPIC.to_string(), buf))
+            .is_ok()
+    } else {
+        false
+    };
+
+    Ok(Json(serde_json::json!({
+        "transfer_id": t.body.transfer_id().to_multibase(),
+        "unit": "EN",
+        "spender": t.body.spender,
+        "receiver": t.body.receiver,
+        "amount_en": t.body.amount,
+        "spender_balance_en": state.engi.balance(&t.body.spender).await,
+        "receiver_balance_en": state.engi.balance(&t.body.receiver).await,
+        "gossiped": gossiped,
     })))
 }
 

--- a/docs/ADR-engi-mutual-credit-on-chain.md
+++ b/docs/ADR-engi-mutual-credit-on-chain.md
@@ -1,6 +1,6 @@
 # ADR — ENGI mutual-credit on the Source Chain (mesh-distributed EN)
 
-Status: **accepted (R0 landed: core types + neighborhood validator + projection)**
+Status: **accepted (R0 core types + R1 net receive + R2 verified outbound publish landed)**
 Supersedes the node-local-only ledger posture of `engi.rs` (ADR-2606013400).
 
 ## Context
@@ -117,19 +117,30 @@ threaded into `net_actor::run`. 1 handler unit test (project / dedup / skip
 garbage) green under `--features p2p`. Topic const corrected to the bare KSE name
 `engi/transfer` (the net layer adds the `kotoba/` prefix).
 
-**Deferred (next increments):**
+**Landed (R2, outbound publish + verified boundary + DID resolution):**
+- `engi::resolve_did_pubkey(did)` resolves `did:key` → Ed25519 pubkey
+  (`kotoba_auth::parse_ed25519_did_key`); the resolver `audit_peer_chain` and the
+  receive path both use.
+- **Inbound gossip is now verified**: `handle_engi_transfer` resolves both DIDs
+  and verifies BOTH countersignatures before projecting — a forged or
+  single-signed transfer is rejected at the gossip edge, never entering the cache.
+- **Outbound publish**: the `engi.transfer` XRPC endpoint (`NSID_ENGI_TRANSFER`,
+  self-authorizing — the two signatures ARE the auth) verifies, projects locally,
+  and gossips the CBOR transfer on `ENGI_TRANSFER_TOPIC` to the mesh.
+- Tests: net_actor verify/project/dedup/reject-forgery (p2p) + `resolve_did_pubkey`
+  round-trip, green.
 
-1. **outbound publish at transfer creation** — an XRPC endpoint / `EngiChain`
-   integration that, when this node records a spend/receive, gossips the
-   countersigned transfer on `ENGI_TRANSFER_TOPIC` via the generic publish
-   channel. (Inbound projection + subscribe already landed in R1.)
-2. **validator deployment** — a neighborhood node syncs a peer's chain via the
-   existing bitswap `want_since`, runs `audit_peer_chain`, and gossips
-   `mutual_credit_warrant`s on violations.
-3. **boot replay** — on startup, load the node's tracked chains and call
-   `Engi::rebuild_from_transfers` so the cache derives from the chains.
-4. **fold fees onto transfers** — make `charge` / `batch_credit` countersigned
-   transfers so the chain is the *sole* source of EN movement (today those legacy
-   paths still mutate the cache directly).
-5. **DID → pubkey resolution** — wire `audit_peer_chain`'s `resolve` to the live
-   DID-document / `did:key` path instead of a test resolver.
+**Deferred (need new subsystems — not faked):**
+
+1. **durable transfer store + boot replay** — there is no durable, queryable log
+   of transfers yet (the balance JSON is a derived cache, not the canonical
+   record). Persisting `ChainContent::Transfer` entries (journal / QuadStore) is
+   the prerequisite; once present, boot calls `Engi::rebuild_from_transfers`.
+2. **full neighborhood validator deployment** — sync a peer's *whole* Source
+   Chain (bitswap `want_since`), run `audit_peer_chain` over it, and gossip
+   `mutual_credit_warrant`s. Needs the peer-chain sync + a per-agent chain store
+   (the R2 boundary check verifies single transfers, not full-chain solvency).
+3. **fold fees onto transfers** — making `charge` / `batch_credit` countersigned
+   transfers is a write-path + economics change (the operator must co-sign every
+   write fee, and the writer's signature must enter the fee path); deferred as a
+   deliberate protocol change, not a mechanical edit.


### PR DESCRIPTION
ADR-engi-mutual-credit-on-chain **R2**。EN が mesh を**双方向**に流れ、gossip 境界で forged transfer を弾く。

## 変更
- **`engi::resolve_did_pubkey(did)`** — `did:key` → Ed25519 pubkey（`kotoba_auth::parse_ed25519_did_key`）。受信検証 + `audit_peer_chain` の resolver。
- **`net_actor::handle_engi_transfer`** — 射影前に両 DID 解決＋**両 countersignature を検証**。forged / 片署名 / 非 did:key は gossip 境界で reject（射影に入れない）。
- **`xrpc::econ_transfer`（`NSID_ENGI_TRANSFER` = `engi.transfer`）** — countersigned transfer を受け、両署名検証→ローカル射影→ `engi/transfer` に CBOR で gossip 送出。**self-authorizing**（2署名が認可なので operator gate なし）。

## テスト（green）
- `net_actor::tests::handle_engi_transfer_verifies_projects_dedups_and_rejects`（`--features p2p`）— 正規 transfer は射影 / dup は drop / eve の forged countersig は reject
- `engi::tests::resolve_did_pubkey_roundtrips_did_key_and_rejects_others`
- `cargo fmt --check` + `RUSTDOCFLAGS=-D warnings cargo doc --features p2p` 確認済み

## スコープと残り（ADR §Deferred を更新）
5項目のうち本 PR で **outbound publish + DID 解決 + 受信検証境界**（item 1・5・2の境界）を実装。残り3つは**新サブシステムを要するため fake せず明示**:
1. **durable transfer store + boot replay** — transfer の durable な正準ログが未存在（balance JSON は派生 cache）。`ChainContent::Transfer` の永続化が前提。
2. **full neighborhood validator deployment** — peer の chain 全体を sync（bitswap `want_since`）して `audit_peer_chain` → warrant gossip。peer-chain store が必要。
3. **fold fees onto transfers** — `charge`/`batch_credit` の countersigned 化は write-path + economics 変更（operator co-sign が必要）。

> `net_actor` は `#[cfg(feature = "p2p")]` 配下 → **all-features gate** で検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)