### PR TITLE
feat(engi): mutual-credit insolvency 監査（R4、validator の overspend 検出）

### DIFF
--- a/crates/kotoba-dht/src/engi_chain.rs
+++ b/crates/kotoba-dht/src/engi_chain.rs
@@ -559,6 +559,68 @@ pub fn detect_fork(a: &ChainEntry, b: &ChainEntry) -> bool {
     a.agent == b.agent && a.seq == b.seq && a.cid != b.cid
 }
 
+/// A solvency violation found by [`audit_transfers`]: spending agent `did`'s
+/// running balance fell to `balance_after` — below `−credit_limit` — at the
+/// transfer identified by `transfer_id`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InsolvencyFinding {
+    /// The overspending agent (the transfer's spender).
+    pub did: String,
+    /// CID of the offending transfer (its `transfer_id`, the audit evidence).
+    pub transfer_id: KotobaCid,
+    /// The spender's running balance after this debit (more negative than allowed).
+    pub balance_after: i64,
+    /// The spender's effective credit limit (max negative) it breached.
+    pub credit_limit: i64,
+}
+
+/// Audit a flat, time-ordered list of countersigned transfers for **insolvency**:
+/// replay every agent's running balance in arrival order and report each spend
+/// that drives the spender below `−credit_limit(spender)`.
+///
+/// Unlike the chain-entry path ([`validate_chain_transfers`]) this needs no
+/// `prev`/`seq` — it audits the transfer *record* (e.g. the Engi durable transfer
+/// log), which is exactly what the unconditional projection accumulates. It
+/// therefore catches **overspend / double-spend-by-accumulation** (an agent that
+/// gossiped more spending than its credit allows) but NOT chain *forks* (those
+/// need per-DID `ChainEntry`s — see [`detect_fork`] / [`audit_peer_chain`]).
+///
+/// The over-limit debit is still applied to the running balance (mirroring the
+/// projection, which applies unconditionally), so every subsequent over-limit
+/// spend by the same agent is also reported. An empty result = solvent.
+pub fn audit_transfers<F>(
+    transfers: &[MutualCreditTransfer],
+    credit_limit: F,
+) -> Vec<InsolvencyFinding>
+where
+    F: Fn(&str) -> i64,
+{
+    let mut bal: std::collections::HashMap<&str, i64> = std::collections::HashMap::new();
+    let mut out = Vec::new();
+    for t in transfers {
+        if t.body.amount <= 0 || t.body.spender == t.body.receiver {
+            continue;
+        }
+        // Receiver is credited (you can always receive).
+        let rb = bal.entry(t.body.receiver.as_str()).or_insert(0);
+        *rb = rb.saturating_add(t.body.amount);
+        // Spender is debited; flag if the debit breaches its credit limit.
+        let limit = credit_limit(&t.body.spender);
+        let sb = bal.entry(t.body.spender.as_str()).or_insert(0);
+        let after = sb.saturating_sub(t.body.amount);
+        if after < -limit {
+            out.push(InsolvencyFinding {
+                did: t.body.spender.clone(),
+                transfer_id: t.body.transfer_id(),
+                balance_after: after,
+                credit_limit: limit,
+            });
+        }
+        *sb = after;
+    }
+    out
+}
+
 /// Bounded dedup guard for gossiped transfers, keyed by
 /// [`TransferBody::transfer_id`]. Mirrors the firehose seen-guard: a transfer
 /// re-gossiped around the mesh is projected at most once per node. Ring-buffer
@@ -1100,5 +1162,62 @@ mod tests {
         assert!(seen.contains(&id2) && seen.contains(&id3));
         // id1 re-seen after eviction counts as new again (harmless, idempotent proj).
         assert!(seen.insert(id1));
+    }
+
+    // ── transfer-record solvency audit (audit_transfers) ──────────────────────
+
+    /// A transfer with arbitrary parties/amount (sigs irrelevant to the audit).
+    fn flat(spender: &str, receiver: &str, amount: i64, nonce: u64) -> MutualCreditTransfer {
+        MutualCreditTransfer {
+            body: TransferBody {
+                spender: spender.to_string(),
+                receiver: receiver.to_string(),
+                amount,
+                spender_prev: None,
+                receiver_prev: None,
+                nonce,
+                ts: 0,
+            },
+            spender_sig: Vec::new(),
+            receiver_sig: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn audit_transfers_flags_overspend_against_per_agent_limit() {
+        // a spends 100 three times; under a 150 limit the 2nd and 3rd breach it.
+        let transfers = vec![
+            flat("a", "b", 100, 1),
+            flat("a", "b", 100, 2),
+            flat("a", "b", 100, 3),
+        ];
+        let findings = audit_transfers(&transfers, |did| if did == "a" { 150 } else { 1_000_000 });
+        assert_eq!(findings.len(), 2, "2nd and 3rd debits overspend");
+        assert!(findings.iter().all(|f| f.did == "a"));
+        assert_eq!(findings[0].balance_after, -200);
+        assert_eq!(findings[0].credit_limit, 150);
+        // A generous limit makes the same record solvent.
+        assert!(audit_transfers(&transfers, |_| 1_000_000).is_empty());
+    }
+
+    #[test]
+    fn audit_transfers_never_flags_a_pure_receiver() {
+        // b only ever receives — even at credit limit 0 it is never insolvent
+        // (a has headroom to fund the transfer).
+        let transfers = vec![flat("a", "b", 500, 1)];
+        assert!(audit_transfers(&transfers, |did| if did == "b" { 0 } else { 1_000 }).is_empty());
+        // Received EN funds a later spend: b receives 500 then spends 400 at
+        // limit 0 — solvent because the received credit covers it.
+        let chain = vec![flat("a", "b", 500, 1), flat("b", "c", 400, 2)];
+        assert!(
+            audit_transfers(&chain, |did| if did == "a" { 1_000 } else { 0 }).is_empty(),
+            "spending within received funds is solvent even at limit 0"
+        );
+        // But b spending 600 (more than the 500 it received) at limit 0 is insolvent.
+        let over = vec![flat("a", "b", 500, 1), flat("b", "c", 600, 2)];
+        let f = audit_transfers(&over, |did| if did == "a" { 1_000 } else { 0 });
+        assert_eq!(f.len(), 1);
+        assert_eq!(f[0].did, "b");
+        assert_eq!(f[0].balance_after, -100);
     }
 }

--- a/crates/kotoba-dht/src/lib.rs
+++ b/crates/kotoba-dht/src/lib.rs
@@ -32,9 +32,10 @@ pub use audit::{
 pub use commit_chain::CommitChain;
 pub use dna::{DnaManifest, ValidationRuleRef};
 pub use engi_chain::{
-    audit_peer_chain, detect_fork, mutual_credit_warrant, replay_balance, validate_chain_transfers,
-    EngiChain, EngiChainError, MutualCreditTransfer, SeenTransfers, TransferAccusation,
-    TransferBody, TransferViolation, ENGI_TRANSFER_TOPIC, SEEN_TRANSFERS_CAP,
+    audit_peer_chain, audit_transfers, detect_fork, mutual_credit_warrant, replay_balance,
+    validate_chain_transfers, EngiChain, EngiChainError, InsolvencyFinding, MutualCreditTransfer,
+    SeenTransfers, TransferAccusation, TransferBody, TransferViolation, ENGI_TRANSFER_TOPIC,
+    SEEN_TRANSFERS_CAP,
 };
 pub use governance::{
     ratify, verify_and_ratify, ActiveParams, Attestation, ParamVersion, Ratification,

--- a/crates/kotoba-server/src/engi.rs
+++ b/crates/kotoba-server/src/engi.rs
@@ -495,6 +495,19 @@ impl Engi {
         self.inner.read().await.transfers.len()
     }
 
+    /// Audit the durable transfer record for **insolvency** — any agent whose
+    /// accumulated gossiped transfers drove its balance below its credit limit.
+    /// Because `project_transfer` applies transfers unconditionally (it mirrors
+    /// committed facts), a peer that overspends is only caught here, by replaying
+    /// the record against each agent's effective limit. An empty result means the
+    /// projected ledger is solvent. (Chain forks are out of scope — they need
+    /// per-DID `ChainEntry`s, not the flat transfer record.)
+    pub async fn audit_solvency(&self) -> Vec<kotoba_dht::InsolvencyFinding> {
+        let g = self.inner.read().await;
+        let transfers = g.transfers.clone();
+        kotoba_dht::audit_transfers(&transfers, |did| self.limit_for(&g, did))
+    }
+
     /// Rebuild the entire balance cache by replaying `transfers` from an empty
     /// map — the boot-time projection of the EN mutual-credit ledger from the
     /// Source Chains. `transfers` must be the *complete* set of EN movements
@@ -972,6 +985,29 @@ mod tests {
         assert_eq!(e2.balance("did:key:a").await, -10);
         assert!(e2.ledger().await.is_balanced());
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn audit_solvency_flags_overspend_in_the_projected_record() {
+        // `engi()` uses default_credit_limit = 1000. Two 700-EN spends drive a to
+        // -1400, past the limit — the projection applied them unconditionally, so
+        // the audit is what catches it.
+        let e = engi(10, "did:key:op");
+        e.project_transfer(&mk_transfer("did:key:a", "did:key:b", 700))
+            .await;
+        e.project_transfer(&mk_transfer("did:key:a", "did:key:b", 700))
+            .await;
+        let findings = e.audit_solvency().await;
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].did, "did:key:a");
+        assert_eq!(findings[0].balance_after, -1400);
+        assert_eq!(findings[0].credit_limit, 1000);
+
+        // A within-limit record audits clean.
+        let e2 = engi(10, "did:key:op");
+        e2.project_transfer(&mk_transfer("did:key:a", "did:key:b", 500))
+            .await;
+        assert!(e2.audit_solvency().await.is_empty());
     }
 
     #[tokio::test]

--- a/crates/kotoba-server/src/lib.rs
+++ b/crates/kotoba-server/src/lib.rs
@@ -1263,6 +1263,10 @@ pub fn build_router(state: Arc<KotobaState>) -> Router {
             post(xrpc::econ_transfer),
         )
         .route(
+            &format!("/xrpc/{}", xrpc::NSID_ENGI_AUDIT),
+            post(xrpc::econ_audit),
+        )
+        .route(
             &format!("/xrpc/{}", xrpc::NSID_ECON_BALANCE),
             post(xrpc::econ_balance),
         )

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -95,6 +95,10 @@ pub const NSID_ENGI_CREDIT: &str = "com.etzhayyim.apps.kotoba.engi.credit";
 /// `engi/transfer` (ADR-engi-mutual-credit-on-chain R2). Self-authorizing — the
 /// two signatures ARE the authorization, so there is no operator gate.
 pub const NSID_ENGI_TRANSFER: &str = "com.etzhayyim.apps.kotoba.engi.transfer";
+/// Audit the durable transfer record for **insolvency** (any agent whose
+/// accumulated transfers breached its credit limit). Operator-gated read
+/// (ADR-engi-mutual-credit-on-chain R4).
+pub const NSID_ENGI_AUDIT: &str = "com.etzhayyim.apps.kotoba.engi.audit";
 /// Deprecated aliases (pre-ENGI-rename); prefer `NSID_ENGI_*`.
 pub const NSID_ECON_BALANCE: &str = "com.etzhayyim.apps.kotoba.econ.balance";
 pub const NSID_ECON_CREDIT: &str = "com.etzhayyim.apps.kotoba.econ.credit";
@@ -989,6 +993,37 @@ pub async fn econ_transfer(
         "spender_balance_en": state.engi.balance(&t.body.spender).await,
         "receiver_balance_en": state.engi.balance(&t.body.receiver).await,
         "gossiped": gossiped,
+    })))
+}
+
+/// `engi.audit` — operator-gated insolvency audit of the durable transfer record.
+///
+/// Replays every projected countersigned transfer against each agent's credit
+/// limit and reports any agent that overspent (the projection applies transfers
+/// unconditionally, so insolvency surfaces only here). `insolvent: false` with an
+/// empty `findings` array means the projected ledger is solvent.
+pub async fn econ_audit(
+    State(state): State<Arc<KotobaState>>,
+    headers: axum::http::HeaderMap,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    crate::graph_auth::require_operator_auth(&headers, &state.operator_did)?;
+    let findings = state.engi.audit_solvency().await;
+    let findings_json: Vec<_> = findings
+        .iter()
+        .map(|f| {
+            serde_json::json!({
+                "did": f.did,
+                "transfer_id": f.transfer_id.to_multibase(),
+                "balance_after_en": f.balance_after,
+                "credit_limit_en": f.credit_limit,
+            })
+        })
+        .collect();
+    Ok(Json(serde_json::json!({
+        "unit": "EN",
+        "transfer_count": state.engi.transfer_count().await,
+        "insolvent": !findings.is_empty(),
+        "findings": findings_json,
     })))
 }
 

--- a/docs/ADR-engi-mutual-credit-on-chain.md
+++ b/docs/ADR-engi-mutual-credit-on-chain.md
@@ -1,6 +1,6 @@
 # ADR — ENGI mutual-credit on the Source Chain (mesh-distributed EN)
 
-Status: **accepted (R0 core + R1 net receive + R2 verified outbound + R3 durable transfer log/boot replay landed)**
+Status: **accepted (R0 core · R1 net receive · R2 verified outbound · R3 durable log/boot replay · R4 insolvency audit — landed)**
 Supersedes the node-local-only ledger posture of `engi.rs` (ADR-2606013400).
 
 ## Context
@@ -141,14 +141,23 @@ mid-append) is skipped, never fatal. 3 unit tests (restart round-trip / rebuild
 from log when cache lost / torn-line tolerance), green. (Fee balances are not yet
 in the log — recovering those is item 2 below.)
 
+**Landed (R4, insolvency audit):** `kotoba_dht::audit_transfers(transfers,
+credit_limit_fn) -> Vec<InsolvencyFinding>` replays a flat transfer record per
+agent and flags every spend that breaches the spender's credit limit — the
+solvency check the *unconditional* projection needs (it applies transfers without
+re-judging them). `Engi::audit_solvency()` runs it over the R3 durable record with
+each agent's effective limit; the operator-gated `engi.audit` XRPC exposes the
+findings (`insolvent` + per-finding did/transfer_id/balance/limit). Catches
+overspend / double-spend-by-accumulation; chain *forks* remain out of scope (they
+need per-DID `ChainEntry`s). 2 dht + 1 server unit tests, green.
+
 **Deferred (need new subsystems — not faked):**
 
-1. **full neighborhood validator deployment** — the R3 transfer log gives a node
-   the *data* (`Engi::transfers()`), but `audit_peer_chain` validates a per-DID
-   `SourceChain` (`ChainEntry`s), not a flat transfer list. Reconstructing
-   per-agent chains from transfers + syncing a *peer's* chain (bitswap
-   `want_since`) and gossiping `mutual_credit_warrant`s is the remaining work.
-   (The R2 boundary check already verifies single transfers' countersignatures.)
+1. **fork detection over synced peer chains** — the R2 boundary verifies single
+   transfers' countersignatures and R4 audits accumulated solvency, but catching a
+   *fork* (same agent re-spending one chain position) needs per-DID `ChainEntry`s:
+   reconstruct per-agent chains, sync a *peer's* chain (bitswap `want_since`), run
+   `audit_peer_chain` / `detect_fork`, and gossip `mutual_credit_warrant`s.
 2. **fold fees onto transfers** — making `charge` / `batch_credit` countersigned
    transfers is a write-path + economics change (the operator must co-sign every
    write fee, and the writer's signature must enter the fee path); deferred as a


### PR DESCRIPTION
ADR-engi-mutual-credit-on-chain **R4**。`project_transfer` は committed fact を**無条件適用**するため、署名検証(R2)があっても**累積 transfer の solvency は未検証**だった——ここが実リスク。R3 の durable record を replay して overspend を検出する validator を実装。

## 変更
- **`kotoba_dht::audit_transfers(transfers, credit_limit_fn) -> Vec<InsolvencyFinding>`** — flat な transfer 列を agent ごとに走行残高 replay し、与信枠 `−limit` を割る spend を全件報告。fork は `ChainEntry` 必要なので対象外（正直に）。
- **`Engi::audit_solvency()`** — durable record + 各 agent の effective limit で監査。
- **`xrpc::econ_audit`（`engi.audit`、operator-gated）** — `insolvent` + 各 finding（did / transfer_id / balance_after / credit_limit）を返す。

## テスト
- dht **207** green（+2: overspend 検出 / pure-receiver は非検出 + 受領分内 spend は solvent）
- server engi **24** green（+1: 射影済み record の overspend を audit が検出）
- `cargo fmt --check` + `RUSTDOCFLAGS=-D warnings cargo doc` 確認済み

## 残り（ADR §Deferred）
1. **synced peer chain 上の fork 検出** — R2 が単一 transfer の署名、R4 が累積 solvency を見るが、*fork*（同一 agent が1つの chain 位置を再 spend）は per-DID `ChainEntry` が必要：per-agent chain 復元 + peer chain sync（`want_since`）+ `audit_peer_chain`/`detect_fork` + warrant gossip。
2. **fold fees onto transfers** — `charge`/`batch_credit` の countersigned 化（write-path + economics 変更）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)