### PR TITLE
feat(engi): double-spend fork 検出（R5、gossip 蓄積 record だけで完結）

### DIFF
--- a/crates/kotoba-dht/src/engi_chain.rs
+++ b/crates/kotoba-dht/src/engi_chain.rs
@@ -621,6 +621,66 @@ where
     out
 }
 
+/// A **double-spend fork** found in a transfer record: a spender signed two or
+/// more *distinct* transfers that all pin the same `spender_prev` — i.e. it spent
+/// from one chain position more than once. This is the transfer-level analog of
+/// [`detect_fork`] (which compares `ChainEntry` `seq`), detectable from the flat
+/// gossip-accumulated record alone (no per-DID chain sync needed, because every
+/// transfer carries the spender's pinned head). Any `transfer_id` in the group is
+/// warrant evidence ([`ValidationRule::DoubleSpend`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransferFork {
+    /// The double-spending agent.
+    pub spender: String,
+    /// The reused chain position (the `spender_prev` all conflicting transfers pin).
+    pub spender_prev: Option<KotobaCid>,
+    /// The ≥2 distinct conflicting transfer ids, in first-seen order.
+    pub transfer_ids: Vec<KotobaCid>,
+}
+
+/// Detect double-spend forks in a transfer record: group spend-transfers by
+/// `(spender, spender_prev)` and report every position from which the spender
+/// signed two or more **distinct** transfers (the same transfer gossiped twice is
+/// deduped by `transfer_id`, not a fork). Receivers never pin `spender_prev`, so
+/// only spenders can fork. Output is sorted by `(spender, prev-bytes)` for a
+/// deterministic, replica-independent verdict.
+pub fn detect_transfer_forks(transfers: &[MutualCreditTransfer]) -> Vec<TransferFork> {
+    use std::collections::HashMap;
+    // (spender, spender_prev) → distinct transfer_ids (first-seen order).
+    let mut groups: HashMap<(String, Option<KotobaCid>), Vec<KotobaCid>> = HashMap::new();
+    for t in transfers {
+        if t.body.amount <= 0 || t.body.spender == t.body.receiver {
+            continue;
+        }
+        let id = t.body.transfer_id();
+        let ids = groups
+            .entry((t.body.spender.clone(), t.body.spender_prev.clone()))
+            .or_default();
+        if !ids.contains(&id) {
+            ids.push(id);
+        }
+    }
+    let mut out: Vec<TransferFork> = groups
+        .into_iter()
+        .filter(|(_, ids)| ids.len() >= 2)
+        .map(|((spender, spender_prev), transfer_ids)| TransferFork {
+            spender,
+            spender_prev,
+            transfer_ids,
+        })
+        .collect();
+    // Deterministic order: by spender, then by the pinned position's bytes.
+    out.sort_by(|a, b| {
+        a.spender.cmp(&b.spender).then_with(|| {
+            a.spender_prev
+                .as_ref()
+                .map(|c| c.0)
+                .cmp(&b.spender_prev.as_ref().map(|c| c.0))
+        })
+    });
+    out
+}
+
 /// Bounded dedup guard for gossiped transfers, keyed by
 /// [`TransferBody::transfer_id`]. Mirrors the firehose seen-guard: a transfer
 /// re-gossiped around the mesh is projected at most once per node. Ring-buffer
@@ -1219,5 +1279,44 @@ mod tests {
         assert_eq!(f.len(), 1);
         assert_eq!(f[0].did, "b");
         assert_eq!(f[0].balance_after, -100);
+    }
+
+    // ── double-spend fork detection (detect_transfer_forks) ───────────────────
+
+    fn with_prev(mut t: MutualCreditTransfer, prev: Option<KotobaCid>) -> MutualCreditTransfer {
+        t.body.spender_prev = prev;
+        t
+    }
+
+    #[test]
+    fn detect_transfer_forks_finds_double_spend_from_one_position() {
+        // a signs two DISTINCT transfers both pinning prev = None → it spent the
+        // same (genesis) position twice = a fork.
+        let t1 = flat("a", "b", 100, 1);
+        let t2 = flat("a", "c", 100, 2); // distinct receiver → distinct transfer_id
+        let forks = detect_transfer_forks(&[t1.clone(), t2.clone()]);
+        assert_eq!(forks.len(), 1);
+        assert_eq!(forks[0].spender, "a");
+        assert_eq!(forks[0].spender_prev, None);
+        assert_eq!(forks[0].transfer_ids.len(), 2);
+        assert!(forks[0].transfer_ids.contains(&t1.body.transfer_id()));
+        assert!(forks[0].transfer_ids.contains(&t2.body.transfer_id()));
+    }
+
+    #[test]
+    fn detect_transfer_forks_ignores_dups_and_advancing_positions() {
+        let t1 = flat("a", "b", 100, 1);
+        // The same transfer gossiped twice is deduped by id — not a fork.
+        assert!(detect_transfer_forks(&[t1.clone(), t1.clone()]).is_empty());
+        // A second spend that pins a DIFFERENT (advanced) position is well-formed.
+        let t_next = with_prev(flat("a", "b", 100, 2), Some(KotobaCid::from_bytes(b"pos1")));
+        assert!(
+            detect_transfer_forks(&[t1.clone(), t_next]).is_empty(),
+            "advancing spender_prev is a normal chain, not a fork"
+        );
+        // A pure receiver never forks (only the spender pins spender_prev).
+        let r1 = flat("x", "a", 10, 1);
+        let r2 = flat("y", "a", 20, 2);
+        assert!(detect_transfer_forks(&[r1, r2]).is_empty());
     }
 }

--- a/crates/kotoba-dht/src/lib.rs
+++ b/crates/kotoba-dht/src/lib.rs
@@ -32,10 +32,10 @@ pub use audit::{
 pub use commit_chain::CommitChain;
 pub use dna::{DnaManifest, ValidationRuleRef};
 pub use engi_chain::{
-    audit_peer_chain, audit_transfers, detect_fork, mutual_credit_warrant, replay_balance,
-    validate_chain_transfers, EngiChain, EngiChainError, InsolvencyFinding, MutualCreditTransfer,
-    SeenTransfers, TransferAccusation, TransferBody, TransferViolation, ENGI_TRANSFER_TOPIC,
-    SEEN_TRANSFERS_CAP,
+    audit_peer_chain, audit_transfers, detect_fork, detect_transfer_forks, mutual_credit_warrant,
+    replay_balance, validate_chain_transfers, EngiChain, EngiChainError, InsolvencyFinding,
+    MutualCreditTransfer, SeenTransfers, TransferAccusation, TransferBody, TransferFork,
+    TransferViolation, ENGI_TRANSFER_TOPIC, SEEN_TRANSFERS_CAP,
 };
 pub use governance::{
     ratify, verify_and_ratify, ActiveParams, Attestation, ParamVersion, Ratification,

--- a/crates/kotoba-server/src/engi.rs
+++ b/crates/kotoba-server/src/engi.rs
@@ -508,6 +508,16 @@ impl Engi {
         kotoba_dht::audit_transfers(&transfers, |did| self.limit_for(&g, did))
     }
 
+    /// Detect **double-spend forks** in the durable transfer record — any agent
+    /// that signed two distinct transfers pinning the same chain position
+    /// (`spender_prev`). Works over the gossip-accumulated record, so it catches a
+    /// peer's double-spend without a separate per-DID chain sync. Empty = no fork
+    /// seen.
+    pub async fn detect_forks(&self) -> Vec<kotoba_dht::TransferFork> {
+        let g = self.inner.read().await;
+        kotoba_dht::detect_transfer_forks(&g.transfers)
+    }
+
     /// Rebuild the entire balance cache by replaying `transfers` from an empty
     /// map — the boot-time projection of the EN mutual-credit ledger from the
     /// Source Chains. `transfers` must be the *complete* set of EN movements
@@ -1008,6 +1018,29 @@ mod tests {
         e2.project_transfer(&mk_transfer("did:key:a", "did:key:b", 500))
             .await;
         assert!(e2.audit_solvency().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn detect_forks_catches_double_spend_in_projected_record() {
+        // a projects two DISTINCT transfers both from the genesis position
+        // (mk_transfer pins prev = None) → a double-spend fork.
+        let e = engi(10, "did:key:op");
+        e.project_transfer(&mk_transfer("did:key:a", "did:key:b", 100))
+            .await;
+        e.project_transfer(&mk_transfer("did:key:a", "did:key:c", 100))
+            .await;
+        let forks = e.detect_forks().await;
+        assert_eq!(forks.len(), 1);
+        assert_eq!(forks[0].spender, "did:key:a");
+        assert_eq!(forks[0].transfer_ids.len(), 2);
+
+        // A single spender→one-receiver record (even repeated identical gossip)
+        // is not a fork.
+        let e2 = engi(10, "did:key:op");
+        let t = mk_transfer("did:key:a", "did:key:b", 100);
+        e2.project_transfer(&t).await;
+        e2.project_transfer(&t).await; // identical id → deduped, no fork
+        assert!(e2.detect_forks().await.is_empty());
     }
 
     #[tokio::test]

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -1019,11 +1019,24 @@ pub async fn econ_audit(
             })
         })
         .collect();
+    let forks = state.engi.detect_forks().await;
+    let forks_json: Vec<_> = forks
+        .iter()
+        .map(|f| {
+            serde_json::json!({
+                "spender": f.spender,
+                "spender_prev": f.spender_prev.as_ref().map(|c| c.to_multibase()),
+                "transfer_ids": f.transfer_ids.iter().map(|c| c.to_multibase()).collect::<Vec<_>>(),
+            })
+        })
+        .collect();
     Ok(Json(serde_json::json!({
         "unit": "EN",
         "transfer_count": state.engi.transfer_count().await,
         "insolvent": !findings.is_empty(),
         "findings": findings_json,
+        "forked": !forks.is_empty(),
+        "forks": forks_json,
     })))
 }
 

--- a/docs/ADR-engi-mutual-credit-on-chain.md
+++ b/docs/ADR-engi-mutual-credit-on-chain.md
@@ -1,6 +1,6 @@
 # ADR — ENGI mutual-credit on the Source Chain (mesh-distributed EN)
 
-Status: **accepted (R0 core · R1 net receive · R2 verified outbound · R3 durable log/boot replay · R4 insolvency audit — landed)**
+Status: **accepted (R0 core · R1 net receive · R2 verified outbound · R3 durable log/boot replay · R4 insolvency audit · R5 fork detection — landed)**
 Supersedes the node-local-only ledger posture of `engi.rs` (ADR-2606013400).
 
 ## Context
@@ -148,16 +148,28 @@ solvency check the *unconditional* projection needs (it applies transfers withou
 re-judging them). `Engi::audit_solvency()` runs it over the R3 durable record with
 each agent's effective limit; the operator-gated `engi.audit` XRPC exposes the
 findings (`insolvent` + per-finding did/transfer_id/balance/limit). Catches
-overspend / double-spend-by-accumulation; chain *forks* remain out of scope (they
-need per-DID `ChainEntry`s). 2 dht + 1 server unit tests, green.
+overspend / double-spend-by-accumulation. 2 dht + 1 server unit tests, green.
 
-**Deferred (need new subsystems — not faked):**
+**Landed (R5, double-spend fork detection):**
+`kotoba_dht::detect_transfer_forks(transfers) -> Vec<TransferFork>` groups spend
+transfers by `(spender, spender_prev)` and reports any position from which a
+spender signed two *distinct* transfers — the double-spend fingerprint, detectable
+from the **gossip-accumulated transfer record alone** (every transfer carries the
+spender's pinned head, so no separate per-DID chain sync is needed). It is the
+transfer-level analog of `detect_fork` (which compares `ChainEntry` `seq`).
+`Engi::detect_forks()` runs it over the durable record and `engi.audit` now also
+returns `forked` + per-fork `{spender, spender_prev, transfer_ids}`. Dups
+(same `transfer_id`) and advancing positions are not forks. 2 dht + 1 server
+tests, green.
 
-1. **fork detection over synced peer chains** — the R2 boundary verifies single
-   transfers' countersignatures and R4 audits accumulated solvency, but catching a
-   *fork* (same agent re-spending one chain position) needs per-DID `ChainEntry`s:
-   reconstruct per-agent chains, sync a *peer's* chain (bitswap `want_since`), run
-   `audit_peer_chain` / `detect_fork`, and gossip `mutual_credit_warrant`s.
+**Deferred (need new subsystems / a design decision — not faked):**
+
+1. **auto-emit warrants on detection** — `audit_solvency` / `detect_forks` are
+   pull-only (via `engi.audit`). Wiring them to *push* a signed
+   `mutual_credit_warrant` onto the warrant gossip on detection (so the
+   neighborhood evicts the offender automatically) is the remaining validator
+   step. Catching forks across **non-EN** chain content (full `SourceChain` with
+   `seq`-based entries) still needs the per-DID chain sync (bitswap `want_since`).
 2. **fold fees onto transfers** — making `charge` / `batch_credit` countersigned
    transfers is a write-path + economics change (the operator must co-sign every
    write fee, and the writer's signature must enter the fee path); deferred as a


### PR DESCRIPTION
ADR-engi-mutual-credit-on-chain **R5**。重要な気づき：transfer は gossip で各ノードの durable record に蓄積されるため、`spender_prev` の衝突（同一 spender が同じ chain 位置から2つの異なる transfer を署名＝二重支払い）は **record だけで検出できる**。別途 peer chain sync を作らずに fork 検出を完成。

## 変更
- **`kotoba_dht::detect_transfer_forks(transfers) -> Vec<TransferFork>`** — spend を `(spender, spender_prev)` でグループ化し、distinct transfer が2つ以上の位置を報告。dup（同一 `transfer_id`）は除外、prev 前進は fork でない。`ChainEntry` の `seq` を見る `detect_fork` の transfer 版。
- **`Engi::detect_forks()`** — durable record 上で検出。
- **`engi.audit`** に `forked` + 各 fork（`spender`/`spender_prev`/`transfer_ids`）を追加（insolvency と合わせた validator 読み出し）。

## テスト
- dht **209** green（+2: fork 検出 / dup・prev 前進は非 fork）
- server engi **25** green（+1: 射影済み record の二重支払いを検出）
- `cargo fmt --check` + `RUSTDOCFLAGS=-D warnings cargo doc` 確認済み

## 残り（ADR §Deferred）
1. **検出時の warrant auto-emit** — 現状 `engi.audit` の pull のみ。検出時に署名付き `mutual_credit_warrant` を warrant gossip へ push（neighborhood が自動 evict）する wiring が残る。非EN chain content の fork は full `SourceChain` sync が必要。
2. **fold fees onto transfers** — economics 判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)