### PR TITLE
feat(engi): 違反検出 → 署名付き warrant 生成（R7、validator ループを accusation まで）

### DIFF
--- a/crates/kotoba-server/src/engi.rs
+++ b/crates/kotoba-server/src/engi.rs
@@ -598,6 +598,51 @@ impl Engi {
         kotoba_dht::detect_transfer_forks(&g.transfers)
     }
 
+    /// Turn every current violation (insolvency + double-spend fork) into a
+    /// **signed, gossip-ready** `kotoba_dht::Warrant`, closing the validator loop:
+    /// detection → an evidence-bearing accusation the neighborhood can act on
+    /// (`ValidationRule::DoubleSpend`, K/2 warrants → eviction). `signing_key` is
+    /// the validating node's key; `validator_id` its NodeId/pubkey bytes. The
+    /// accused is each offender's resolved `did:key` pubkey; the evidence is the
+    /// offending `transfer_id`. Offenders whose DID does not resolve are skipped
+    /// (can't name an accused). Pure over a snapshot — no side effects.
+    pub async fn pending_warrants(
+        &self,
+        signing_key: &ed25519_dalek::SigningKey,
+        validator_id: Vec<u8>,
+        ts: u64,
+    ) -> Vec<kotoba_dht::Warrant> {
+        use kotoba_dht::{mutual_credit_warrant, ValidationRule};
+        let mut out = Vec::new();
+        for f in self.audit_solvency().await {
+            if let Some(pk) = resolve_did_pubkey(&f.did) {
+                out.push(mutual_credit_warrant(
+                    pk.to_vec(),
+                    f.transfer_id,
+                    ValidationRule::DoubleSpend,
+                    validator_id.clone(),
+                    ts,
+                    signing_key,
+                ));
+            }
+        }
+        for fork in self.detect_forks().await {
+            if let (Some(pk), Some(evidence)) =
+                (resolve_did_pubkey(&fork.spender), fork.transfer_ids.first())
+            {
+                out.push(mutual_credit_warrant(
+                    pk.to_vec(),
+                    evidence.clone(),
+                    ValidationRule::DoubleSpend,
+                    validator_id.clone(),
+                    ts,
+                    signing_key,
+                ));
+            }
+        }
+        out
+    }
+
     /// Rebuild the entire balance cache by replaying `transfers` from an empty
     /// map — the boot-time projection of the EN mutual-credit ledger from the
     /// Source Chains. `transfers` must be the *complete* set of EN movements
@@ -1169,6 +1214,50 @@ mod tests {
         e2.project_transfer(&t).await;
         e2.project_transfer(&t).await; // identical id → deduped, no fork
         assert!(e2.detect_forks().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn pending_warrants_signs_a_verifiable_warrant_for_a_fork() {
+        use ed25519_dalek::{Signature, Verifier};
+        let a = kotoba_vault::AgentIdentity::generate_ephemeral();
+        let b = kotoba_vault::AgentIdentity::generate_ephemeral();
+        let c = kotoba_vault::AgentIdentity::generate_ephemeral();
+        let validator = kotoba_vault::AgentIdentity::generate_ephemeral();
+        let e = engi(10, "did:key:op");
+
+        // `a` (a real did:key) double-spends from genesis: two distinct transfers
+        // both pinning prev = None → a fork.
+        e.project_transfer(&mk_transfer(&a.did, &b.did, 100)).await;
+        e.project_transfer(&mk_transfer(&a.did, &c.did, 100)).await;
+        assert_eq!(e.detect_forks().await.len(), 1);
+
+        let validator_id = validator.verifying_key().to_bytes().to_vec();
+        let warrants = e
+            .pending_warrants(&validator.signing_key, validator_id.clone(), 42)
+            .await;
+        assert_eq!(warrants.len(), 1, "one warrant for the fork");
+        let w = &warrants[0];
+        assert_eq!(w.rule_id, kotoba_dht::ValidationRule::DoubleSpend as u8);
+        // accused = a's pubkey, resolved from its did:key.
+        assert_eq!(w.accused, a.verifying_key().to_bytes().to_vec());
+        assert_eq!(w.validator, validator_id);
+        // The signature verifies under the validator's key.
+        let sig: [u8; 64] = w.sig.as_slice().try_into().unwrap();
+        assert!(validator
+            .verifying_key()
+            .verify(
+                &kotoba_dht::warrant_signing_bytes(w),
+                &Signature::from_bytes(&sig)
+            )
+            .is_ok());
+
+        // A clean record (no violation) emits no warrants.
+        let e2 = engi(10, "did:key:op");
+        e2.project_transfer(&mk_transfer(&a.did, &b.did, 100)).await;
+        assert!(e2
+            .pending_warrants(&validator.signing_key, validator_id, 0)
+            .await
+            .is_empty());
     }
 
     #[tokio::test]

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -1030,6 +1030,32 @@ pub async fn econ_audit(
             })
         })
         .collect();
+    // Turn every violation into a signed, gossip-ready warrant (this node is the
+    // validator). `warrant_b64` is the CBOR a peer would publish on the warrant
+    // gossip; the JSON view is for human/operator inspection.
+    let validator_id = crate::engi::resolve_did_pubkey(&state.operator_did)
+        .map(|p| p.to_vec())
+        .unwrap_or_default();
+    let signing_key = state.ipns_signing_key();
+    let ts = now_ms_epoch();
+    let warrants = state
+        .engi
+        .pending_warrants(&signing_key, validator_id, ts)
+        .await;
+    let warrants_json: Vec<_> = warrants
+        .iter()
+        .map(|w| {
+            let mut cbor = Vec::new();
+            let _ = ciborium::into_writer(w, &mut cbor);
+            serde_json::json!({
+                "rule_id": w.rule_id,
+                "evidence": w.evidence.to_multibase(),
+                "accused_hex": hex::encode(&w.accused),
+                "validator_hex": hex::encode(&w.validator),
+                "warrant_b64": B64.encode(&cbor),
+            })
+        })
+        .collect();
     Ok(Json(serde_json::json!({
         "unit": "EN",
         "transfer_count": state.engi.transfer_count().await,
@@ -1037,7 +1063,18 @@ pub async fn econ_audit(
         "findings": findings_json,
         "forked": !forks.is_empty(),
         "forks": forks_json,
+        "warrant_count": warrants.len(),
+        "warrants": warrants_json,
     })))
+}
+
+/// Unix-epoch milliseconds (warrant timestamp). A clock read is fine here — this
+/// is a normal server handler, not a deterministic workflow context.
+fn now_ms_epoch() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
 }
 
 fn map_delegation_error(e: kotoba_auth::DelegationError) -> (StatusCode, String) {

--- a/docs/ADR-engi-mutual-credit-on-chain.md
+++ b/docs/ADR-engi-mutual-credit-on-chain.md
@@ -1,6 +1,6 @@
 # ADR — ENGI mutual-credit on the Source Chain (mesh-distributed EN)
 
-Status: **accepted (R0 core · R1 net receive · R2 verified outbound · R3 durable log/boot replay · R4 insolvency audit · R5 fork detection · R6 durable fees — landed)**
+Status: **accepted (R0 core · R1 net receive · R2 verified outbound · R3 durable log/boot replay · R4 insolvency audit · R5 fork detection · R6 durable fees · R7 signed warrants — landed)**
 Supersedes the node-local-only ledger posture of `engi.rs` (ADR-2606013400).
 
 ## Context
@@ -172,14 +172,25 @@ an Ed25519 transfer signature) — a separate log from the peer-countersigned
 transfer record, not masquerading as one. 2 server tests (fee-only recovery +
 combined transfer+fee recovery), green.
 
-**Deferred (need new subsystems / a design decision — not faked):**
+**Landed (R7, signed warrant production):** `Engi::pending_warrants(signing_key,
+validator_id, ts)` turns **every** current violation (insolvency + fork) into a
+signed, gossip-ready `kotoba_dht::Warrant` — accused = the offender's resolved
+`did:key` pubkey, evidence = the offending `transfer_id`, rule
+`DoubleSpend`, signed by the validating node. The operator-gated `engi.audit` XRPC
+now returns these (`warrants` with `warrant_b64` = the CBOR a peer would publish +
+a JSON view). This closes detection → *signed accusation*; the warrant is the same
+shape the neighborhood already evicts on (K/2). 1 server test (fork → verifiable
+warrant; clean record → none), green.
 
-1. **auto-emit warrants on detection** — `audit_solvency` / `detect_forks` are
-   pull-only (via `engi.audit`). Wiring them to *push* a signed
-   `mutual_credit_warrant` onto the warrant gossip on detection (so the
-   neighborhood evicts the offender automatically) is the remaining validator
-   step. Catching forks across **non-EN** chain content (full `SourceChain` with
-   `seq`-based entries) still needs the per-DID chain sync (bitswap `want_since`).
+**Deferred (need new subsystems — not faked):**
+
+1. **push warrants onto gossip + neighborhood eviction-apply** — R7 *produces*
+   signed warrants (pulled via `engi.audit`). Auto-*pushing* them on the warrant
+   gossip topic and having peers **apply** them (count K/2 → evict the offender)
+   is the remaining net/DHT wiring — it needs a warrant gossip subscribe/receive
+   arm in `net_actor` and the eviction tally. Catching forks across **non-EN**
+   chain content (full `SourceChain` with `seq`-based entries) still needs the
+   per-DID chain sync (bitswap `want_since`).
 2. **peer-countersigned fees** — turning a write fee into a true 2-party
    countersigned transfer needs the payer's Ed25519 signature in the synchronous
    write path (a countersigning handshake). A deliberate protocol change, not a


### PR DESCRIPTION
ADR-engi-mutual-credit-on-chain **R7**。`audit_solvency` / `detect_forks` は pull 検出のみだった。本 PR で検出した全違反を**署名付き gossip-ready Warrant** に変換する。

## 変更（`engi.rs` + `xrpc.rs`、server-only）
- **`Engi::pending_warrants(signing_key, validator_id, ts) -> Vec<Warrant>`** — insolvency + fork の各違反を `mutual_credit_warrant` 化（accused = 違反者の `did:key` pubkey、evidence = 違反 `transfer_id`、rule = `DoubleSpend`、検証ノードが署名）。
- **`engi.audit`** が `warrants`（`warrant_b64` = peer が gossip する CBOR + JSON view）を返す。ノード identity（`ipns_signing_key` + `operator_did`→pubkey）で署名。

検出 → **署名済み accusation** まで閉じた（warrant は neighborhood が既に K/2 で evict する形状と同一）。`net_actor`/`swarm.rs` には触れない server-only 変更。

## テスト
- server engi **28** green（+1: fork → 検証可能 warrant / clean → なし）
- `cargo fmt --check` + `RUSTDOCFLAGS=-D warnings cargo doc` 確認済み

## 残り（ADR §Deferred）
1. **warrant を gossip に push + peer 側で apply（K/2 eviction）** — R7 は warrant を*生成*（`engi.audit` で pull）。自動*push* + peer の適用集計は net/DHT 配線（`net_actor` の warrant 受信 arm + eviction tally）。非EN chain content の fork は full `SourceChain` sync が必要。
2. **peer-countersigned fee** — write-path handshake（別プロトコル）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)