### PR TITLE
feat(engi): warrant gossip + K/2 eviction tally（R8、validator ループを閉じる）

### DIFF
--- a/crates/kotoba-dht/src/engi_chain.rs
+++ b/crates/kotoba-dht/src/engi_chain.rs
@@ -39,13 +39,14 @@
 //! the scarce, irreversibly-settled asset lives across the boundary (USDC on Base
 //! L2). This layer is internal contribution accounting only.
 
+use crate::neighborhood::K;
 use crate::source_chain::{ChainContent, ChainEntry, ChainError, SourceChain};
 use crate::warrant::{warrant_signing_bytes, ValidationRule, Warrant};
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use kotoba_core::cid::KotobaCid;
 use kotoba_vault::agent_identity::AgentIdentity;
 use serde::{Deserialize, Serialize};
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 /// GossipSub **KSE-topic name** carrying countersigned EN transfers across the
 /// mesh. This is the bare name (like `firehose` / `rekey/revoke`); the net layer
@@ -645,7 +646,6 @@ pub struct TransferFork {
 /// only spenders can fork. Output is sorted by `(spender, prev-bytes)` for a
 /// deterministic, replica-independent verdict.
 pub fn detect_transfer_forks(transfers: &[MutualCreditTransfer]) -> Vec<TransferFork> {
-    use std::collections::HashMap;
     // (spender, spender_prev) → distinct transfer_ids (first-seen order).
     let mut groups: HashMap<(String, Option<KotobaCid>), Vec<KotobaCid>> = HashMap::new();
     for t in transfers {
@@ -679,6 +679,96 @@ pub fn detect_transfer_forks(transfers: &[MutualCreditTransfer]) -> Vec<Transfer
         })
     });
     out
+}
+
+/// GossipSub **KSE-topic name** carrying signed `mutual_credit_warrant`s — the
+/// bare name (wire = `kotoba/engi/warrant`). A validator publishes a warrant here
+/// when it detects a violating spender; peers verify and tally it
+/// ([`WarrantTally`]) toward neighborhood eviction.
+pub const ENGI_WARRANT_TOPIC: &str = "engi/warrant";
+
+/// Distinct validators that must warrant one accused before it is **evicted** —
+/// `K/2` (the neighborhood replication factor over two), the same quorum the rest
+/// of KDHT uses for Byzantine eviction. Floored at 1.
+pub const WARRANT_EVICTION_THRESHOLD: usize = if K / 2 > 0 { K / 2 } else { 1 };
+
+/// Verify a `mutual_credit_warrant`: recompute [`warrant_signing_bytes`] and check
+/// `w.sig` against `w.validator` (which for an EN mutual-credit warrant IS the
+/// validating node's 32-byte Ed25519 pubkey). Returns `false` for a malformed
+/// validator key / signature or a signature that does not match — so a forged
+/// warrant is rejected at the gossip edge before it can be tallied.
+pub fn verify_warrant(w: &Warrant) -> bool {
+    let Ok(pk): Result<[u8; 32], _> = w.validator.as_slice().try_into() else {
+        return false;
+    };
+    let Ok(vk) = VerifyingKey::from_bytes(&pk) else {
+        return false;
+    };
+    let Ok(sig_arr): Result<[u8; 64], _> = w.sig.as_slice().try_into() else {
+        return false;
+    };
+    vk.verify(&warrant_signing_bytes(w), &Signature::from_bytes(&sig_arr))
+        .is_ok()
+}
+
+/// Tally of warrants per accused toward neighborhood eviction. A node receiving
+/// gossiped `mutual_credit_warrant`s records each `(accused, validator)` pair;
+/// once **`threshold` distinct validators** have warranted one accused, it is
+/// *evicted* (the offender's future transfers should be refused). Counting
+/// *distinct validators* (not raw warrants) stops one node inflating the tally by
+/// re-gossiping; mirrors the `K/2` Byzantine-eviction rule used across KDHT.
+#[derive(Debug)]
+pub struct WarrantTally {
+    threshold: usize,
+    by_accused: HashMap<Vec<u8>, HashSet<Vec<u8>>>,
+    evicted: HashSet<Vec<u8>>,
+}
+
+impl WarrantTally {
+    /// New tally requiring `threshold` distinct validators to evict (min 1).
+    pub fn with_threshold(threshold: usize) -> Self {
+        Self {
+            threshold: threshold.max(1),
+            by_accused: HashMap::new(),
+            evicted: HashSet::new(),
+        }
+    }
+
+    /// Record one validator's warrant against `accused`. Returns `true` iff this
+    /// warrant *just* pushed the accused over the threshold (a newly-decided
+    /// eviction) — so the caller acts exactly once. A duplicate `(accused,
+    /// validator)` or a warrant against an already-evicted accused returns `false`.
+    pub fn record(&mut self, accused: Vec<u8>, validator: Vec<u8>) -> bool {
+        let already = self.evicted.contains(&accused);
+        let set = self.by_accused.entry(accused.clone()).or_default();
+        set.insert(validator);
+        if !already && set.len() >= self.threshold {
+            self.evicted.insert(accused);
+            return true;
+        }
+        false
+    }
+
+    /// Whether `accused` has reached the eviction threshold.
+    pub fn is_evicted(&self, accused: &[u8]) -> bool {
+        self.evicted.contains(accused)
+    }
+
+    /// Number of distinct validators currently warranting `accused`.
+    pub fn validator_count(&self, accused: &[u8]) -> usize {
+        self.by_accused.get(accused).map(|s| s.len()).unwrap_or(0)
+    }
+
+    /// Number of evicted accuseds.
+    pub fn evicted_len(&self) -> usize {
+        self.evicted.len()
+    }
+}
+
+impl Default for WarrantTally {
+    fn default() -> Self {
+        Self::with_threshold(WARRANT_EVICTION_THRESHOLD)
+    }
 }
 
 /// Bounded dedup guard for gossiped transfers, keyed by
@@ -1318,5 +1408,62 @@ mod tests {
         let r1 = flat("x", "a", 10, 1);
         let r2 = flat("y", "a", 20, 2);
         assert!(detect_transfer_forks(&[r1, r2]).is_empty());
+    }
+
+    // ── warrant verification + eviction tally ─────────────────────────────────
+
+    #[test]
+    fn verify_warrant_accepts_signed_rejects_tampered_or_malformed() {
+        let validator = ident();
+        let accused = ident();
+        let vk = SigningKey::from_bytes(&validator.signing_key.to_bytes());
+        let w = mutual_credit_warrant(
+            accused.verifying_key().to_bytes().to_vec(),
+            KotobaCid::from_bytes(b"bad-transfer"),
+            ValidationRule::DoubleSpend,
+            validator.verifying_key().to_bytes().to_vec(),
+            42,
+            &vk,
+        );
+        assert!(verify_warrant(&w));
+        // Tampering the accused after signing breaks the signature.
+        let mut tampered = w.clone();
+        tampered.accused = ident().verifying_key().to_bytes().to_vec();
+        assert!(!verify_warrant(&tampered));
+        // A validator field that is not a 32-byte pubkey fails cleanly.
+        let mut malformed = w.clone();
+        malformed.validator = vec![1, 2, 3];
+        assert!(!verify_warrant(&malformed));
+    }
+
+    #[test]
+    fn warrant_tally_evicts_at_threshold_on_distinct_validators() {
+        let mut t = WarrantTally::with_threshold(3);
+        let accused = vec![0xAAu8; 32];
+        let v = |n: u8| vec![n; 32];
+        assert!(!t.record(accused.clone(), v(1)));
+        assert!(
+            !t.record(accused.clone(), v(1)),
+            "dup validator makes no progress"
+        );
+        assert_eq!(t.validator_count(&accused), 1);
+        assert!(!t.record(accused.clone(), v(2)));
+        assert!(
+            t.record(accused.clone(), v(3)),
+            "3rd distinct validator crosses the threshold"
+        );
+        assert!(t.is_evicted(&accused));
+        // Further warrants against an already-evicted accused don't re-fire.
+        assert!(!t.record(accused.clone(), v(4)));
+        assert_eq!(t.evicted_len(), 1);
+        // A different accused tallies independently.
+        let other = vec![0xBBu8; 32];
+        assert!(!t.record(other.clone(), v(1)));
+        assert!(!t.is_evicted(&other));
+    }
+
+    #[test]
+    fn warrant_eviction_threshold_is_k_over_2() {
+        assert_eq!(WARRANT_EVICTION_THRESHOLD, (K / 2).max(1));
     }
 }

--- a/crates/kotoba-dht/src/lib.rs
+++ b/crates/kotoba-dht/src/lib.rs
@@ -33,9 +33,10 @@ pub use commit_chain::CommitChain;
 pub use dna::{DnaManifest, ValidationRuleRef};
 pub use engi_chain::{
     audit_peer_chain, audit_transfers, detect_fork, detect_transfer_forks, mutual_credit_warrant,
-    replay_balance, validate_chain_transfers, EngiChain, EngiChainError, InsolvencyFinding,
-    MutualCreditTransfer, SeenTransfers, TransferAccusation, TransferBody, TransferFork,
-    TransferViolation, ENGI_TRANSFER_TOPIC, SEEN_TRANSFERS_CAP,
+    replay_balance, validate_chain_transfers, verify_warrant, EngiChain, EngiChainError,
+    InsolvencyFinding, MutualCreditTransfer, SeenTransfers, TransferAccusation, TransferBody,
+    TransferFork, TransferViolation, WarrantTally, ENGI_TRANSFER_TOPIC, ENGI_WARRANT_TOPIC,
+    SEEN_TRANSFERS_CAP, WARRANT_EVICTION_THRESHOLD,
 };
 pub use governance::{
     ratify, verify_and_ratify, ActiveParams, Attestation, ParamVersion, Ratification,

--- a/crates/kotoba-server/src/net_actor.rs
+++ b/crates/kotoba-server/src/net_actor.rs
@@ -312,6 +312,34 @@ async fn handle_engi_transfer(
     true
 }
 
+/// Apply a gossiped mutual-credit `Warrant`: decode it, **verify the validator's
+/// signature** (a forged warrant is dropped at the edge), then record it in the
+/// eviction `tally`. Returns `true` iff this warrant *just* evicted its accused
+/// (the K/2 threshold was reached) — logged so an operator sees the decision.
+/// Counting distinct validators in the tally means one node re-gossiping cannot
+/// inflate the count.
+fn handle_engi_warrant(data: &[u8], tally: &mut kotoba_dht::WarrantTally) -> bool {
+    let w: kotoba_dht::Warrant = match ciborium::from_reader(data) {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::warn!(err = %e, "engi/warrant: bad Warrant envelope — skipped");
+            return false;
+        }
+    };
+    if !kotoba_dht::verify_warrant(&w) {
+        tracing::warn!("engi/warrant: invalid validator signature — rejected");
+        return false;
+    }
+    let evicted = tally.record(w.accused.clone(), w.validator.clone());
+    if evicted {
+        tracing::warn!(
+            accused = %hex::encode(&w.accused),
+            "engi/warrant: accused reached the K/2 eviction threshold — its future transfers should be refused"
+        );
+    }
+    evicted
+}
+
 pub async fn run(
     mut swarm: KotobaSwarm,
     mut publish_rx: tokio::sync::mpsc::Receiver<(String, Vec<u8>)>,
@@ -338,10 +366,13 @@ pub async fn run(
     swarm.subscribe("quad/retract").ok();
     swarm.subscribe(REKEY_REVOKE_TOPIC).ok();
     swarm.subscribe(kotoba_dht::ENGI_TRANSFER_TOPIC).ok();
+    swarm.subscribe(kotoba_dht::ENGI_WARRANT_TOPIC).ok();
     swarm.subscribe_pregel().ok();
 
     // Dedup guard for gossiped EN transfers (project each at most once per node).
     let mut engi_seen = kotoba_dht::SeenTransfers::default();
+    // Tally of gossiped mutual-credit warrants toward neighborhood eviction.
+    let mut engi_warrants = kotoba_dht::WarrantTally::default();
 
     // Full gossip topic string as published by KotobaSwarm (has "kotoba/" prefix)
     let pregel_full_topic = format!("kotoba/{PREGEL_GOSSIP_TOPIC}");
@@ -715,6 +746,10 @@ pub async fn run(
                                 // on both parties' Source Chains, so projection is
                                 // an unconditional net-zero mirror.
                                 handle_engi_transfer(&data, &mut engi_seen, &engi).await;
+                            } else if kse_name == kotoba_dht::ENGI_WARRANT_TOPIC {
+                                // Mutual-credit warrant: verify the validator's
+                                // signature, then tally toward K/2 eviction.
+                                handle_engi_warrant(&data, &mut engi_warrants);
                             } else {
                                 let maybe_quad_op = if kse_name == "quad/assert" {
                                     serde_json::from_slice::<Quad>(&data).ok().map(|quad| (quad, true))
@@ -812,6 +847,39 @@ mod tests {
         let mut buf = Vec::new();
         ciborium::into_writer(&t, &mut buf).unwrap();
         buf
+    }
+
+    #[test]
+    fn handle_engi_warrant_verifies_tallies_and_evicts() {
+        let accused = kotoba_vault::AgentIdentity::generate_ephemeral();
+        let accused_id = accused.verifying_key().to_bytes().to_vec();
+        // A signed warrant against `accused` by `validator`, CBOR-encoded.
+        let warrant_bytes = |validator: &kotoba_vault::AgentIdentity| -> Vec<u8> {
+            let w = kotoba_dht::mutual_credit_warrant(
+                accused_id.clone(),
+                KotobaCid::from_bytes(b"evidence"),
+                kotoba_dht::ValidationRule::DoubleSpend,
+                validator.verifying_key().to_bytes().to_vec(),
+                0,
+                &validator.signing_key,
+            );
+            let mut buf = Vec::new();
+            ciborium::into_writer(&w, &mut buf).unwrap();
+            buf
+        };
+        let v1 = kotoba_vault::AgentIdentity::generate_ephemeral();
+        let v2 = kotoba_vault::AgentIdentity::generate_ephemeral();
+        let mut tally = kotoba_dht::WarrantTally::with_threshold(2);
+
+        // First validator tallies but doesn't reach the threshold.
+        assert!(!handle_engi_warrant(&warrant_bytes(&v1), &mut tally));
+        // Re-gossip of the SAME validator's warrant makes no progress.
+        assert!(!handle_engi_warrant(&warrant_bytes(&v1), &mut tally));
+        // A second distinct validator crosses threshold 2 → eviction fires once.
+        assert!(handle_engi_warrant(&warrant_bytes(&v2), &mut tally));
+        assert!(tally.is_evicted(&accused_id));
+        // Garbage bytes are dropped without panic or tally.
+        assert!(!handle_engi_warrant(b"not a warrant", &mut tally));
     }
 
     #[tokio::test]

--- a/crates/kotoba-server/src/xrpc.rs
+++ b/crates/kotoba-server/src/xrpc.rs
@@ -984,6 +984,36 @@ pub async fn econ_transfer(
         false
     };
 
+    // Auto-emit: if this transfer just made its spender a violator (overspend or
+    // a fork from the same chain position), gossip a signed warrant about THIS
+    // spender so peers tally it toward K/2 eviction. Targeted to the spender; a
+    // clean transfer emits none.
+    let warrants_emitted = if let Some(tx) = &state.gossip_tx {
+        let validator_id = crate::engi::resolve_did_pubkey(&state.operator_did)
+            .map(|p| p.to_vec())
+            .unwrap_or_default();
+        let signing_key = state.ipns_signing_key();
+        let accused = spk.to_vec();
+        let warrants = state
+            .engi
+            .pending_warrants(&signing_key, validator_id, now_ms_epoch())
+            .await;
+        let mut n = 0u32;
+        for w in warrants.iter().filter(|w| w.accused == accused) {
+            let mut buf = Vec::new();
+            if ciborium::into_writer(w, &mut buf).is_ok()
+                && tx
+                    .try_send((kotoba_dht::ENGI_WARRANT_TOPIC.to_string(), buf))
+                    .is_ok()
+            {
+                n += 1;
+            }
+        }
+        n
+    } else {
+        0
+    };
+
     Ok(Json(serde_json::json!({
         "transfer_id": t.body.transfer_id().to_multibase(),
         "unit": "EN",
@@ -993,6 +1023,7 @@ pub async fn econ_transfer(
         "spender_balance_en": state.engi.balance(&t.body.spender).await,
         "receiver_balance_en": state.engi.balance(&t.body.receiver).await,
         "gossiped": gossiped,
+        "warrants_emitted": warrants_emitted,
     })))
 }
 

--- a/docs/ADR-engi-mutual-credit-on-chain.md
+++ b/docs/ADR-engi-mutual-credit-on-chain.md
@@ -1,6 +1,6 @@
 # ADR — ENGI mutual-credit on the Source Chain (mesh-distributed EN)
 
-Status: **accepted (R0 core · R1 net receive · R2 verified outbound · R3 durable log/boot replay · R4 insolvency audit · R5 fork detection · R6 durable fees · R7 signed warrants — landed)**
+Status: **accepted (R0 core · R1 net receive · R2 verified outbound · R3 durable log/boot replay · R4 insolvency audit · R5 fork detection · R6 durable fees · R7 signed warrants · R8 warrant gossip/K-2 eviction — landed)**
 Supersedes the node-local-only ledger posture of `engi.rs` (ADR-2606013400).
 
 ## Context
@@ -182,15 +182,27 @@ a JSON view). This closes detection → *signed accusation*; the warrant is the 
 shape the neighborhood already evicts on (K/2). 1 server test (fork → verifiable
 warrant; clean record → none), green.
 
-**Deferred (need new subsystems — not faked):**
+**Landed (R8, warrant gossip + K/2 eviction tally):**
+- `ENGI_WARRANT_TOPIC` (`engi/warrant`) carries signed warrants; `verify_warrant`
+  checks a warrant's signature against its `validator` pubkey (forged warrants
+  dropped at the edge); `WarrantTally` counts **distinct validators** per accused
+  and evicts at `WARRANT_EVICTION_THRESHOLD = K/2` (= 3 for K=7).
+- **Push**: the `engi.transfer` XRPC, after projecting a transfer, gossips a signed
+  warrant about *that spender* iff the transfer made it a violator (targeted; clean
+  transfers emit none) — returns `warrants_emitted`.
+- **Receive + apply**: `net_actor` (feature `p2p`) subscribes the topic and runs
+  `handle_engi_warrant` → verify → `WarrantTally::record`; reaching K/2 logs the
+  eviction decision (the offender's future transfers should be refused).
+- 3 dht tests (verify accept/reject, tally eviction, threshold = K/2) + 1 net
+  handler test (verify/tally/evict/garbage), green.
 
-1. **push warrants onto gossip + neighborhood eviction-apply** — R7 *produces*
-   signed warrants (pulled via `engi.audit`). Auto-*pushing* them on the warrant
-   gossip topic and having peers **apply** them (count K/2 → evict the offender)
-   is the remaining net/DHT wiring — it needs a warrant gossip subscribe/receive
-   arm in `net_actor` and the eviction tally. Catching forks across **non-EN**
-   chain content (full `SourceChain` with `seq`-based entries) still needs the
-   per-DID chain sync (bitswap `want_since`).
+**Deferred (need new subsystems / a design decision — not faked):**
+
+1. **enforce eviction + non-EN fork sync** — R8 *decides* eviction (the tally
+   fires at K/2); making `project_transfer` **refuse** an evicted spender's future
+   transfers (thread the tally into the ledger) is the enforcement step. Catching
+   forks across **non-EN** chain content (full `SourceChain` with `seq`-based
+   entries) still needs the per-DID chain sync (bitswap `want_since`).
 2. **peer-countersigned fees** — turning a write fee into a true 2-party
    countersigned transfer needs the payer's Ed25519 signature in the synchronous
    write path (a countersigning handshake). A deliberate protocol change, not a


### PR DESCRIPTION
ADR-engi-mutual-credit-on-chain **R8**。R7 は warrant を*生成*（pull）のみだった。本 PR で warrant を実際に **gossip** し、peer 側で**検証・集計して K/2 で eviction 判定**する——validator ループを閉じる。

## 変更
**`kotoba-dht`**
- `ENGI_WARRANT_TOPIC`（`engi/warrant`）+ **`verify_warrant`**（warrant の `validator` pubkey で署名検証、forged を edge で drop）+ **`WarrantTally`**（accused ごとに *distinct validator* を数え、`WARRANT_EVICTION_THRESHOLD = K/2 = 3` で evict）

**`server`**
- **push**: `engi.transfer` が射影後、その spender が違反者になった場合のみ署名 warrant を gossip（targeted、clean transfer は出さない）。`warrants_emitted` を返す
- **receive+apply**: `net_actor`（feature `p2p`）が topic を subscribe し `handle_engi_warrant` → 検証 → `WarrantTally::record`。K/2 到達で eviction 判定を log

## テスト
- dht **212** green（+3: verify accept/reject, tally eviction, threshold=K/2）
- net_actor handler **1** green（p2p: verify/tally/evict/garbage）
- `cargo fmt --check` + `RUSTDOCFLAGS=-D warnings cargo doc --features p2p` 確認済み

> `net_actor` は `#[cfg(feature = "p2p")]` → all-features gate で検証。`swarm.rs` は未編集（既存 subscribe/publish API のみ使用）。

## 残り（ADR §Deferred）
1. **eviction の enforcement** — R8 は eviction を*判定*（K/2 で fire）。`project_transfer` が evicted spender の transfer を*拒否*する enforcement + 非EN chain content の fork sync（`want_since`）
2. **peer-countersigned fee** — write-path handshake（別プロトコル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)