### PR TITLE
feat(engi): eviction enforcement（R9、判定を実際の拒否に繋いでループを閉じる）

### DIFF
--- a/crates/kotoba-server/src/engi.rs
+++ b/crates/kotoba-server/src/engi.rs
@@ -66,7 +66,7 @@
 //! protocol change, deliberately not done here.)
 
 use kotoba_dht::MutualCreditTransfer;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -159,6 +159,12 @@ struct Inner {
     /// they are not countersigned transfers (folding them in is a deferred ADR
     /// follow-up).
     transfers: Vec<MutualCreditTransfer>,
+    /// Ed25519 pubkeys of agents the neighborhood has **evicted** (reached the
+    /// `K/2` mutual-credit warrant threshold). [`Engi::project_transfer`] refuses
+    /// any transfer whose spender resolves to one of these — the enforcement that
+    /// makes an eviction bite. Live state (rebuilt as warrants re-arrive), not
+    /// persisted.
+    evicted: HashSet<Vec<u8>>,
 }
 
 pub struct Engi {
@@ -275,6 +281,7 @@ impl Engi {
             balances,
             limits,
             transfers,
+            evicted: HashSet::new(),
         }
     }
 
@@ -547,12 +554,26 @@ impl Engi {
     /// must mirror it rather than re-judge it. This is the entry point the gossip
     /// / chain-replay path calls per observed transfer. A non-positive amount or a
     /// self-transfer is a no-op. Persisted so the cache survives restart.
-    pub async fn project_transfer(&self, t: &MutualCreditTransfer) {
+    pub async fn project_transfer(&self, t: &MutualCreditTransfer) -> bool {
         let amount = t.body.amount;
         if amount <= 0 || t.body.spender == t.body.receiver {
-            return;
+            return false;
         }
         let mut g = self.inner.write().await;
+        // Eviction enforcement: refuse a transfer whose spender the neighborhood
+        // has evicted (K/2 mutual-credit warrants). Resolution is only attempted
+        // when some agent is actually evicted, so the common path pays nothing.
+        if !g.evicted.is_empty() {
+            if let Some(pk) = resolve_did_pubkey(&t.body.spender) {
+                if g.evicted.contains(pk.as_slice()) {
+                    tracing::warn!(
+                        spender = %t.body.spender,
+                        "engi: refusing transfer from an evicted spender (K/2 warranted)"
+                    );
+                    return false;
+                }
+            }
+        }
         Self::apply_transfer(&mut g, &t.body.spender, &t.body.receiver, amount);
         // Append to the durable record (in-memory + on-disk log) so the transfer
         // survives a lost balance cache and is auditable / replayable.
@@ -561,6 +582,20 @@ impl Engi {
         drop(g);
         self.persist(snapshot);
         self.append_transfer_log(t);
+        true
+    }
+
+    /// Mark `pubkey` (an Ed25519 agent pubkey) as **evicted** — the neighborhood
+    /// reached the `K/2` warrant threshold against it. After this, every transfer
+    /// whose spender resolves to `pubkey` is refused by [`Engi::project_transfer`].
+    /// Called by the warrant-gossip receive path on a newly-decided eviction.
+    pub async fn mark_evicted(&self, pubkey: Vec<u8>) {
+        self.inner.write().await.evicted.insert(pubkey);
+    }
+
+    /// Whether `pubkey` is currently evicted.
+    pub async fn is_evicted(&self, pubkey: &[u8]) -> bool {
+        self.inner.read().await.evicted.contains(pubkey)
     }
 
     /// Snapshot of the durable transfer record (every countersigned transfer
@@ -1258,6 +1293,58 @@ mod tests {
             .pending_warrants(&validator.signing_key, validator_id, 0)
             .await
             .is_empty());
+    }
+
+    #[tokio::test]
+    async fn project_transfer_refuses_an_evicted_spender() {
+        let a = kotoba_vault::AgentIdentity::generate_ephemeral();
+        let b = kotoba_vault::AgentIdentity::generate_ephemeral();
+        let mk = |amount: i64, nonce: u64| {
+            MutualCreditTransfer::countersign(
+                a.did.clone(),
+                b.did.clone(),
+                amount,
+                None,
+                None,
+                nonce,
+                0,
+                &a.signing_key,
+                &b.signing_key,
+            )
+            .unwrap()
+        };
+        let e = engi(10, "did:key:op");
+        // Before eviction the spender's transfer applies.
+        assert!(e.project_transfer(&mk(100, 1)).await);
+        assert_eq!(e.balance(&a.did).await, -100);
+
+        // Evict `a`; a further transfer from it is refused (balance unchanged).
+        e.mark_evicted(a.verifying_key().to_bytes().to_vec()).await;
+        assert!(e.is_evicted(&a.verifying_key().to_bytes()).await);
+        assert!(
+            !e.project_transfer(&mk(50, 2)).await,
+            "evicted spender must be refused"
+        );
+        assert_eq!(
+            e.balance(&a.did).await,
+            -100,
+            "refused transfer not applied"
+        );
+
+        // A non-evicted spender (b) is unaffected.
+        let t_b = MutualCreditTransfer::countersign(
+            b.did.clone(),
+            a.did.clone(),
+            30,
+            None,
+            None,
+            1,
+            0,
+            &b.signing_key,
+            &a.signing_key,
+        )
+        .unwrap();
+        assert!(e.project_transfer(&t_b).await);
     }
 
     #[tokio::test]

--- a/crates/kotoba-server/src/net_actor.rs
+++ b/crates/kotoba-server/src/net_actor.rs
@@ -318,7 +318,11 @@ async fn handle_engi_transfer(
 /// (the K/2 threshold was reached) — logged so an operator sees the decision.
 /// Counting distinct validators in the tally means one node re-gossiping cannot
 /// inflate the count.
-fn handle_engi_warrant(data: &[u8], tally: &mut kotoba_dht::WarrantTally) -> bool {
+async fn handle_engi_warrant(
+    data: &[u8],
+    tally: &mut kotoba_dht::WarrantTally,
+    engi: &crate::engi::Engi,
+) -> bool {
     let w: kotoba_dht::Warrant = match ciborium::from_reader(data) {
         Ok(w) => w,
         Err(e) => {
@@ -334,8 +338,10 @@ fn handle_engi_warrant(data: &[u8], tally: &mut kotoba_dht::WarrantTally) -> boo
     if evicted {
         tracing::warn!(
             accused = %hex::encode(&w.accused),
-            "engi/warrant: accused reached the K/2 eviction threshold — its future transfers should be refused"
+            "engi/warrant: accused reached the K/2 eviction threshold — refusing its future transfers"
         );
+        // Enforce: the ledger now refuses transfers from this evicted spender.
+        engi.mark_evicted(w.accused.clone()).await;
     }
     evicted
 }
@@ -748,8 +754,9 @@ pub async fn run(
                                 handle_engi_transfer(&data, &mut engi_seen, &engi).await;
                             } else if kse_name == kotoba_dht::ENGI_WARRANT_TOPIC {
                                 // Mutual-credit warrant: verify the validator's
-                                // signature, then tally toward K/2 eviction.
-                                handle_engi_warrant(&data, &mut engi_warrants);
+                                // signature, tally toward K/2, and on eviction mark
+                                // the ledger to refuse the offender's transfers.
+                                handle_engi_warrant(&data, &mut engi_warrants, &engi).await;
                             } else {
                                 let maybe_quad_op = if kse_name == "quad/assert" {
                                     serde_json::from_slice::<Quad>(&data).ok().map(|quad| (quad, true))
@@ -849,8 +856,8 @@ mod tests {
         buf
     }
 
-    #[test]
-    fn handle_engi_warrant_verifies_tallies_and_evicts() {
+    #[tokio::test]
+    async fn handle_engi_warrant_verifies_tallies_evicts_and_enforces() {
         let accused = kotoba_vault::AgentIdentity::generate_ephemeral();
         let accused_id = accused.verifying_key().to_bytes().to_vec();
         // A signed warrant against `accused` by `validator`, CBOR-encoded.
@@ -870,16 +877,43 @@ mod tests {
         let v1 = kotoba_vault::AgentIdentity::generate_ephemeral();
         let v2 = kotoba_vault::AgentIdentity::generate_ephemeral();
         let mut tally = kotoba_dht::WarrantTally::with_threshold(2);
+        let engi = crate::engi::Engi::from_env("did:key:op".to_string());
 
         // First validator tallies but doesn't reach the threshold.
-        assert!(!handle_engi_warrant(&warrant_bytes(&v1), &mut tally));
+        assert!(!handle_engi_warrant(&warrant_bytes(&v1), &mut tally, &engi).await);
+        assert!(!engi.is_evicted(&accused_id).await);
         // Re-gossip of the SAME validator's warrant makes no progress.
-        assert!(!handle_engi_warrant(&warrant_bytes(&v1), &mut tally));
-        // A second distinct validator crosses threshold 2 → eviction fires once.
-        assert!(handle_engi_warrant(&warrant_bytes(&v2), &mut tally));
+        assert!(!handle_engi_warrant(&warrant_bytes(&v1), &mut tally, &engi).await);
+        // A second distinct validator crosses threshold 2 → eviction fires once,
+        // and the ledger is marked to enforce it.
+        assert!(handle_engi_warrant(&warrant_bytes(&v2), &mut tally, &engi).await);
         assert!(tally.is_evicted(&accused_id));
+        assert!(
+            engi.is_evicted(&accused_id).await,
+            "ledger now enforces the eviction"
+        );
+
+        // Enforcement bites: a transfer from the evicted spender is refused.
+        let receiver = kotoba_vault::AgentIdentity::generate_ephemeral();
+        let t = kotoba_dht::MutualCreditTransfer::countersign(
+            accused.did.clone(),
+            receiver.did.clone(),
+            100,
+            None,
+            None,
+            0,
+            0,
+            &accused.signing_key,
+            &receiver.signing_key,
+        )
+        .unwrap();
+        assert!(
+            !engi.project_transfer(&t).await,
+            "evicted spender's transfer must be refused"
+        );
+
         // Garbage bytes are dropped without panic or tally.
-        assert!(!handle_engi_warrant(b"not a warrant", &mut tally));
+        assert!(!handle_engi_warrant(b"not a warrant", &mut tally, &engi).await);
     }
 
     #[tokio::test]

--- a/docs/ADR-engi-mutual-credit-on-chain.md
+++ b/docs/ADR-engi-mutual-credit-on-chain.md
@@ -1,6 +1,6 @@
 # ADR — ENGI mutual-credit on the Source Chain (mesh-distributed EN)
 
-Status: **accepted (R0 core · R1 net receive · R2 verified outbound · R3 durable log/boot replay · R4 insolvency audit · R5 fork detection · R6 durable fees · R7 signed warrants · R8 warrant gossip/K-2 eviction — landed)**
+Status: **accepted (R0 core · R1 net receive · R2 verified outbound · R3 durable log/boot replay · R4 insolvency audit · R5 fork detection · R6 durable fees · R7 signed warrants · R8 warrant gossip/K-2 eviction · R9 eviction enforcement — landed)**
 Supersedes the node-local-only ledger posture of `engi.rs` (ADR-2606013400).
 
 ## Context
@@ -196,13 +196,23 @@ warrant; clean record → none), green.
 - 3 dht tests (verify accept/reject, tally eviction, threshold = K/2) + 1 net
   handler test (verify/tally/evict/garbage), green.
 
+**Landed (R9, eviction enforcement):** an eviction now *bites*. `Engi` holds the
+set of evicted agent pubkeys; `mark_evicted(pubkey)` adds to it, and
+`project_transfer` **refuses** (returns `false`, applies nothing) any transfer
+whose spender resolves to an evicted pubkey — on both the inbound-gossip and the
+`engi.transfer` paths. The warrant-receive path
+(`handle_engi_warrant`) calls `mark_evicted` the moment the K/2 threshold is
+crossed. Resolution is skipped when no one is evicted (the common path pays
+nothing). Eviction is live state (rebuilt as warrants re-arrive), not persisted.
+1 server test (evict → refused, balance unchanged, non-evicted unaffected) + the
+net handler test extended to assert the refusal end-to-end, green.
+
 **Deferred (need new subsystems / a design decision — not faked):**
 
-1. **enforce eviction + non-EN fork sync** — R8 *decides* eviction (the tally
-   fires at K/2); making `project_transfer` **refuse** an evicted spender's future
-   transfers (thread the tally into the ledger) is the enforcement step. Catching
-   forks across **non-EN** chain content (full `SourceChain` with `seq`-based
-   entries) still needs the per-DID chain sync (bitswap `want_since`).
+1. **non-EN fork sync** — EN double-spend forks are caught from the gossip record
+   (R5/R8). Catching forks across **non-EN** chain content (a full `SourceChain`
+   with `seq`-based entries) still needs the per-DID chain sync (bitswap
+   `want_since`) + `audit_peer_chain` over it.
 2. **peer-countersigned fees** — turning a write fee into a true 2-party
    countersigned transfer needs the payer's Ed25519 signature in the synchronous
    write path (a countersigning handshake). A deliberate protocol change, not a


### PR DESCRIPTION
ADR-engi-mutual-credit-on-chain **R9**。R8 は eviction を*判定*するのみだった。本 PR で eviction を実際に **enforce** し、validator ループを完全に閉じる。

## 変更（`engi.rs` + `net_actor.rs`、server-only）
- `Engi` が `evicted`（agent pubkey の集合）を保持。`mark_evicted(pubkey)` で追加。
- **`project_transfer`** が spender を解決して evicted pubkey なら**拒否**（`false` を返し何も適用しない）。inbound-gossip / `engi.transfer` 両経路に効く。誰も evicted でない場合は解決をスキップ（common path コストゼロ）。
- `net_actor::handle_engi_warrant` が **K/2 到達の瞬間に `engi.mark_evicted`** を呼ぶ。
- eviction は live state（warrant 再到着で再構築）、非永続。

## テスト
- server engi **1**（evict → 拒否、残高不変、非 evicted は影響なし）
- net handler test を拡張し **end-to-end の拒否**まで検証（p2p: verify→tally→evict→`project_transfer` 拒否）
- `cargo fmt --check` + `RUSTDOCFLAGS=-D warnings cargo doc --features p2p` 確認済み

これで **検出 → 署名 → gossip → 検証 → 集計 → eviction → 拒否** まで完全に閉じた。

## 残り（ADR §Deferred）
1. **非EN chain content の fork sync** — EN の fork は gossip record から検出済み（R5/R8）。非EN の chain content は full `SourceChain` sync（`want_since`）が必要
2. **peer-countersigned fee** — write-path handshake（別プロトコル）

🤖 Generated with [Claude Code](https://claude.com/claude-code)