### PR TITLE
feat(kotoba-server): webrtc feature → kotoba-net/webrtc (buildable fleet binary)

### DIFF
--- a/crates/kotoba-server/Cargo.toml
+++ b/crates/kotoba-server/Cargo.toml
@@ -13,6 +13,11 @@ wasm-runtime = ["dep:kotoba-runtime", "dep:kotoba-vm"]
 # Run real kotoba:kge WASM components as room sims (ADR-2606060001 room swap).
 realtime-wasm = ["kotoba-rt/wasm-component"]
 p2p = ["dep:kotoba-net", "dep:kotoba-lattice", "wasm-runtime"]
+# Browser-dialable WebRTC on the Live plane: builds the kotoba-net webrtc-direct
+# transport so a node started with KOTOBA_WEBRTC=<port> listens for browser peers
+# (root ADR-2606271800). Implies p2p. The fleet binary is built `--features
+# p2p,realtime-wasm,webrtc` (murakumo bin/BUILD.edn :features).
+webrtc = ["p2p", "kotoba-net/webrtc"]
 cc-parquet = ["kotoba-ingest/cc-parquet"]
 # Compile/run `.kotoba` (Clojure-subset) source over XRPC (mesh.compile / mesh.run).
 # Off by default: pulls kotoba-clj + wasmtime into the server build.


### PR DESCRIPTION
## What

Closes the last build gap for browser WebRTC (root ADR-2606271800). The
`KOTOBA_WEBRTC` `/webrtc-direct` listen (kotoba#229) is behind kotoba-net's `webrtc`
feature, but **kotoba-server had no feature to enable it** — so the fleet binary
couldn't serve browser-live peers even with the env set.

`webrtc = ["p2p", "kotoba-net/webrtc"]` — building the resident node
`--features p2p,realtime-wasm,webrtc` (the features murakumo's `bin/BUILD.edn` already
declares) now compiles the webrtc-direct transport into `kotoba-server`.

## Verification

```
cargo check -p kotoba-server --features webrtc → Finished, 0 errors
```

After this, the operator path is: build `kotoba-server --features p2p,realtime-wasm,webrtc`
→ `bb murakumo pin <release>` → `bb murakumo provision` (renders KOTOBA_WEBRTC) → browsers
dial the fleet on the Live plane (connect.edn `:native :live` already includes `:webrtc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)