### PR TITLE
feat(kotoba-clj): media-decode/encode capability + effect plumbing (ADR-2606272200 §3)

### DIFF
--- a/crates/kotoba-clj/src/ast.rs
+++ b/crates/kotoba-clj/src/ast.rs
@@ -152,6 +152,16 @@ pub enum Builtin {
     /// object-cbor), or `0` on err. Read with `kqe-count` /
     /// `kqe-quad-{graph,subject,predicate,object}`.
     KqeQuery,
+    /// `(media-decode codec packet)` — host call into the `kotoba:kais` `media`
+    /// interface (`decode: func(string, list<u8>) -> result<list<u8>, string>`).
+    /// Same core ABI as [`Builtin::LlmInfer`]: a codec-name string handle + a
+    /// packet `list<u8>` (a `(ptr,len)` pair) → the decoded frame bytes as a
+    /// string handle on `ok`, or `0` on `err`. The **capability-gated native codec
+    /// boundary** (ADR-2606272200 §3) — gated by `:media-decode`.
+    MediaDecode,
+    /// `(media-encode codec frame)` — `encode`, the twin of
+    /// [`Builtin::MediaDecode`]; gated by `:media-encode`.
+    MediaEncode,
     /// `(bit-and a b …)` — bitwise AND of all arguments (Clojure `bit-and`).
     /// Maps to WASM `i64.and` folded left over the arg list.
     BitAnd,
@@ -202,6 +212,8 @@ impl Builtin {
             Builtin::KqeRetract => Some(HostImport::KqeRetractQuad),
             Builtin::KqeGetObjects => Some(HostImport::KqeGetObjects),
             Builtin::KqeQuery => Some(HostImport::KqeQuery),
+            Builtin::MediaDecode => Some(HostImport::MediaDecode),
+            Builtin::MediaEncode => Some(HostImport::MediaEncode),
             _ => None,
         }
     }
@@ -234,6 +246,12 @@ pub enum HostImport {
     /// string>`. Indirect result (12-byte return area, same variant layout as
     /// `llm.infer`).
     KqeQuery,
+    /// `kotoba:kais/media@0.1.0` → `decode: func(string, list<u8>) ->
+    /// result<list<u8>, string>`. Identical indirect return-area ABI to
+    /// `llm.infer`. Capability class [`crate::policy::CapClass::MediaDecode`].
+    MediaDecode,
+    /// `kotoba:kais/media@0.1.0` → `encode` — twin of [`HostImport::MediaDecode`].
+    MediaEncode,
 }
 
 /// Whether a list head names an **inert form** — one whose body is data or is
@@ -255,13 +273,15 @@ impl HostImport {
     /// from this rather than hardcoding it, so the audit cannot drift as the
     /// host world grows. Kept in sync with the enum by the
     /// `host_import_all_is_complete` test.
-    pub const ALL: [HostImport; 6] = [
+    pub const ALL: [HostImport; 8] = [
         HostImport::HasCapability,
         HostImport::LlmInfer,
         HostImport::KqeAssertQuad,
         HostImport::KqeRetractQuad,
         HostImport::KqeGetObjects,
         HostImport::KqeQuery,
+        HostImport::MediaDecode,
+        HostImport::MediaEncode,
     ];
 
     /// The wasm import `(module, field)` the Component encoder matches against
@@ -274,6 +294,8 @@ impl HostImport {
             HostImport::KqeRetractQuad => ("kotoba:kais/kqe@0.1.0", "retract-quad"),
             HostImport::KqeGetObjects => ("kotoba:kais/kqe@0.1.0", "get-objects"),
             HostImport::KqeQuery => ("kotoba:kais/kqe@0.1.0", "query"),
+            HostImport::MediaDecode => ("kotoba:kais/media@0.1.0", "decode"),
+            HostImport::MediaEncode => ("kotoba:kais/media@0.1.0", "encode"),
         }
     }
 }
@@ -293,6 +315,8 @@ mod host_import_meta_tests {
             HostImport::KqeRetractQuad => 3,
             HostImport::KqeGetObjects => 4,
             HostImport::KqeQuery => 5,
+            HostImport::MediaDecode => 6,
+            HostImport::MediaEncode => 7,
         }
     }
 
@@ -303,7 +327,7 @@ mod host_import_meta_tests {
         tags.dedup();
         assert_eq!(
             tags,
-            (0..tag(HostImport::KqeQuery) + 1).collect::<Vec<u8>>(),
+            (0..tag(HostImport::MediaEncode) + 1).collect::<Vec<u8>>(),
             "HostImport::ALL is missing a variant — capability auditing would not see it"
         );
     }
@@ -365,6 +389,8 @@ impl Builtin {
             "kqe-retract!" => Builtin::KqeRetract,
             "kqe-get-objects" => Builtin::KqeGetObjects,
             "kqe-query" => Builtin::KqeQuery,
+            "media-decode" => Builtin::MediaDecode,
+            "media-encode" => Builtin::MediaEncode,
             "bit-and" => Builtin::BitAnd,
             "bit-or" => Builtin::BitOr,
             "bit-xor" => Builtin::BitXor,
@@ -2472,6 +2498,7 @@ fn check_builtin_arity(op: Builtin, n: usize) -> Result<(), CljError> {
         Builtin::BytesAlloc | Builtin::BytesLen | Builtin::BytesFinish => n == 1,
         Builtin::Alloc | Builtin::Load64 | Builtin::Load32 => n == 1,
         Builtin::Store64 | Builtin::Store32 | Builtin::HasCapability | Builtin::LlmInfer => n == 2,
+        Builtin::MediaDecode | Builtin::MediaEncode => n == 2,
         Builtin::Sub => n >= 1, // unary negate or n-ary subtract
         Builtin::Min | Builtin::Max => n >= 1,
         Builtin::Add | Builtin::Mul | Builtin::And | Builtin::Or => n >= 1,

--- a/crates/kotoba-clj/src/codegen.rs
+++ b/crates/kotoba-clj/src/codegen.rs
@@ -491,6 +491,10 @@ fn host_import_sig(imp: HostImport) -> (Vec<ValType>, Vec<ValType>) {
         //   - indirect 12-byte return area `[tag:u8 @0, ptr @4, len @8]` (the
         //     same variant layout as `llm.infer`).
         HostImport::KqeQuery => (vec![ValType::I32; 3], vec![]),
+        // `decode`/`encode: func(string, list<u8>) -> result<list<u8>, string>`:
+        // identical core ABI to `llm.infer` — `string` + `list<u8>` flatten to
+        // 4 i32 params, the indirect result adds a 5th return-area pointer.
+        HostImport::MediaDecode | HostImport::MediaEncode => (vec![ValType::I32; 5], vec![]),
     }
 }
 
@@ -1609,7 +1613,15 @@ fn compile_builtin(cg: &mut FnCtx, op: Builtin, args: &[Expr]) -> Result<(), Clj
         Builtin::Store32 => compile_store(cg, &args[0], &args[1], /*word32=*/ true),
 
         Builtin::HasCapability => compile_host_call(cg, HostImport::HasCapability, args),
-        Builtin::LlmInfer => compile_llm_infer(cg, &args[0], &args[1]),
+        Builtin::LlmInfer => {
+            compile_indirect_bytes_call(cg, HostImport::LlmInfer, &args[0], &args[1])
+        }
+        Builtin::MediaDecode => {
+            compile_indirect_bytes_call(cg, HostImport::MediaDecode, &args[0], &args[1])
+        }
+        Builtin::MediaEncode => {
+            compile_indirect_bytes_call(cg, HostImport::MediaEncode, &args[0], &args[1])
+        }
         Builtin::KqeAssert => compile_kqe_mutate(cg, HostImport::KqeAssertQuad, args),
         Builtin::KqeRetract => compile_kqe_mutate(cg, HostImport::KqeRetractQuad, args),
         Builtin::KqeGetObjects => compile_kqe_get_objects(cg, args),
@@ -1753,18 +1765,25 @@ fn compile_kqe_query(cg: &mut FnCtx, filter: &Expr) -> Result<(), CljError> {
     Ok(())
 }
 
-/// Lower `(llm-infer model-cid prompt)` — a host import whose
+/// Lower a 2-arg host import whose signature is `(string, list<u8>) ->
+/// result<list<u8>, string>` — shared by `llm-infer` and `media-decode` /
+/// `media-encode`, which have identical Canonical-ABI shapes. The
 /// `result<list<u8>, string>` return uses the indirect **return-area** ABI:
 ///   1. `cabi_realloc` a 12-byte area (align 4),
-///   2. push `model (ptr,len)`, `prompt (ptr,len)`, then the area pointer,
+///   2. push `a (ptr,len)`, `b (ptr,len)`, then the area pointer,
 ///   3. `call` the import (no core result),
 ///   4. read `tag = mem[area]`; on `ok` (tag 0) rebuild the output string handle
 ///      `(mem[area+4] << 32) | mem[area+8]`, on `err` yield `0`.
-fn compile_llm_infer(cg: &mut FnCtx, model: &Expr, prompt: &Expr) -> Result<(), CljError> {
+fn compile_indirect_bytes_call(
+    cg: &mut FnCtx,
+    imp: HostImport,
+    a: &Expr,
+    b: &Expr,
+) -> Result<(), CljError> {
     let idx = *cg
         .import_index
-        .get(&HostImport::LlmInfer)
-        .ok_or_else(|| CljError::Codegen("host import LlmInfer not registered".into()))?;
+        .get(&imp)
+        .ok_or_else(|| CljError::Codegen(format!("host import {imp:?} not registered")))?;
     let realloc = cg.realloc_index;
     let area = cg.alloc_local(); // i64 local holding the area pointer (extended)
 
@@ -1777,9 +1796,9 @@ fn compile_llm_infer(cg: &mut FnCtx, model: &Expr, prompt: &Expr) -> Result<(), 
     cg.emit(Instruction::I64ExtendI32U);
     cg.emit(Instruction::LocalSet(area));
 
-    // model (ptr,len), prompt (ptr,len)
-    lower_string_arg_to_ptr_len(cg, model)?;
-    lower_string_arg_to_ptr_len(cg, prompt)?;
+    // a (ptr,len), b (ptr,len)
+    lower_string_arg_to_ptr_len(cg, a)?;
+    lower_string_arg_to_ptr_len(cg, b)?;
     // return-area pointer (i32)
     cg.emit(Instruction::LocalGet(area));
     cg.emit(Instruction::I32WrapI64);
@@ -2508,7 +2527,9 @@ fn eval_const_builtin(op: Builtin, v: &[i64]) -> Result<i64, CljError> {
         | Builtin::KqeAssert
         | Builtin::KqeRetract
         | Builtin::KqeGetObjects
-        | Builtin::KqeQuery => {
+        | Builtin::KqeQuery
+        | Builtin::MediaDecode
+        | Builtin::MediaEncode => {
             return Err(CljError::Codegen(
                 "host calls are not allowed in a `def` initialiser".into(),
             ))

--- a/crates/kotoba-clj/src/effects.rs
+++ b/crates/kotoba-clj/src/effects.rs
@@ -40,7 +40,14 @@ use kotoba_edn::EdnValue;
 use crate::CljError;
 
 /// The effect vocabulary. One-to-one with the host-induced capability classes.
-const KNOWN_EFFECTS: &[&str] = &["graph-read", "graph-write", "infer", "auth"];
+const KNOWN_EFFECTS: &[&str] = &[
+    "graph-read",
+    "graph-write",
+    "infer",
+    "auth",
+    "media-decode",
+    "media-encode",
+];
 
 /// The effect an effectful builtin induces, or `None` for pure builtins. Kept
 /// in sync with `ast::Builtin::host_import` / `policy::CapClass::of`.
@@ -49,6 +56,8 @@ fn effect_of_call(name: &str) -> Option<&'static str> {
         "kqe-assert!" | "kqe-retract!" => "graph-write",
         "kqe-get-objects" | "kqe-query" => "graph-read",
         "llm-infer" => "infer",
+        "media-decode" => "media-decode",
+        "media-encode" => "media-encode",
         "has-capability?" => "auth",
         _ => return None,
     })

--- a/crates/kotoba-clj/src/policy.rs
+++ b/crates/kotoba-clj/src/policy.rs
@@ -57,6 +57,12 @@ pub enum CapClass {
     /// Introspect the caller's own CACAO: `auth.has-capability`. Granted by
     /// `:auth`.
     Auth,
+    /// Decode media: `media.decode`. Granted by `:media-decode`. The native
+    /// codec boundary (ADR-2606272200 §3) — split from [`CapClass::MediaEncode`]
+    /// so decode-only code never gains encode authority.
+    MediaDecode,
+    /// Encode media: `media.encode`. Granted by `:media-encode`.
+    MediaEncode,
 }
 
 impl CapClass {
@@ -67,6 +73,8 @@ impl CapClass {
             HostImport::KqeAssertQuad | HostImport::KqeRetractQuad => CapClass::GraphWrite,
             HostImport::LlmInfer => CapClass::Infer,
             HostImport::HasCapability => CapClass::Auth,
+            HostImport::MediaDecode => CapClass::MediaDecode,
+            HostImport::MediaEncode => CapClass::MediaEncode,
         }
     }
 
@@ -77,6 +85,8 @@ impl CapClass {
             CapClass::GraphWrite => "graph-write",
             CapClass::Infer => "infer",
             CapClass::Auth => "auth",
+            CapClass::MediaDecode => "media-decode",
+            CapClass::MediaEncode => "media-encode",
         }
     }
 }
@@ -127,6 +137,11 @@ pub struct Policy {
     pub graph_write: BTreeSet<String>,
     /// Model cids the module may run inference against.
     pub infer: BTreeSet<String>,
+    /// Codecs the module may decode (`media.decode`), e.g. `"h264"`. Keyed by
+    /// codec name (the first string-literal arg of `media-decode`).
+    pub media_decode: BTreeSet<String>,
+    /// Codecs the module may encode (`media.encode`).
+    pub media_encode: BTreeSet<String>,
     /// Whether the module may introspect its own CACAO (`has-capability?`).
     pub auth: bool,
     /// Whether the module may observe wall-clock (timing-channel surface).
@@ -151,6 +166,8 @@ impl Policy {
             graph_read: BTreeSet::new(),
             graph_write: BTreeSet::new(),
             infer: BTreeSet::new(),
+            media_decode: BTreeSet::new(),
+            media_encode: BTreeSet::new(),
             auth: false,
             clock: false,
             random: false,
@@ -190,6 +207,26 @@ impl Policy {
         self
     }
 
+    /// Builder: grant decode of the given codecs (e.g. `"h264"`).
+    pub fn grant_media_decode<I, S>(mut self, codecs: I) -> Policy
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.media_decode.extend(codecs.into_iter().map(Into::into));
+        self
+    }
+
+    /// Builder: grant encode of the given codecs.
+    pub fn grant_media_encode<I, S>(mut self, codecs: I) -> Policy
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.media_encode.extend(codecs.into_iter().map(Into::into));
+        self
+    }
+
     /// Builder: allow CACAO self-introspection (`has-capability?`).
     pub fn grant_auth(mut self) -> Policy {
         self.auth = true;
@@ -209,6 +246,8 @@ impl Policy {
             CapClass::GraphWrite => !self.graph_write.is_empty(),
             CapClass::Infer => !self.infer.is_empty(),
             CapClass::Auth => self.auth,
+            CapClass::MediaDecode => !self.media_decode.is_empty(),
+            CapClass::MediaEncode => !self.media_encode.is_empty(),
         }
     }
 
@@ -260,6 +299,8 @@ impl Policy {
             "kqe-assert!" | "kqe-retract!" => Some(("graph-write", &self.graph_write)),
             "kqe-get-objects" => Some(("graph-read", &self.graph_read)),
             "llm-infer" => Some(("infer", &self.infer)),
+            "media-decode" => Some(("media-decode", &self.media_decode)),
+            "media-encode" => Some(("media-encode", &self.media_encode)),
             _ => None,
         }
     }
@@ -347,6 +388,8 @@ impl Policy {
             (EdnValue::kw_bare("graph-read"), strs(&self.graph_read)),
             (EdnValue::kw_bare("graph-write"), strs(&self.graph_write)),
             (EdnValue::kw_bare("infer"), strs(&self.infer)),
+            (EdnValue::kw_bare("media-decode"), strs(&self.media_decode)),
+            (EdnValue::kw_bare("media-encode"), strs(&self.media_encode)),
             (EdnValue::kw_bare("auth"), EdnValue::bool(self.auth)),
             (EdnValue::kw_bare("egress"), strs(&self.egress)),
             (EdnValue::kw_bare("secrets"), strs(&self.secrets)),
@@ -404,6 +447,12 @@ impl Policy {
             }
             if let Some(v) = imports.get(&EdnValue::kw_bare("infer")) {
                 policy.infer = str_set(v, ":imports :infer")?;
+            }
+            if let Some(v) = imports.get(&EdnValue::kw_bare("media-decode")) {
+                policy.media_decode = str_set(v, ":imports :media-decode")?;
+            }
+            if let Some(v) = imports.get(&EdnValue::kw_bare("media-encode")) {
+                policy.media_encode = str_set(v, ":imports :media-encode")?;
             }
             if let Some(v) = imports.get(&EdnValue::kw_bare("egress")) {
                 policy.egress = str_set(v, ":imports :egress")?;
@@ -474,6 +523,18 @@ impl Policy {
         );
         diff_class(&mut out, "graph-read", &self.graph_read, &needed.graph_read);
         diff_class(&mut out, "infer", &self.infer, &needed.infer);
+        diff_class(
+            &mut out,
+            "media-decode",
+            &self.media_decode,
+            &needed.media_decode,
+        );
+        diff_class(
+            &mut out,
+            "media-encode",
+            &self.media_encode,
+            &needed.media_encode,
+        );
         if self.auth && !needed.auth {
             out.push("auth: granted but `has-capability?` is never used".to_string());
         }
@@ -543,6 +604,8 @@ pub fn infer_minimal(forms: &[EdnValue]) -> Policy {
     p.graph_write = resolve(acc.write_dynamic, acc.write);
     p.graph_read = resolve(acc.read_dynamic, acc.read);
     p.infer = resolve(acc.infer_dynamic, acc.infer);
+    p.media_decode = resolve(acc.media_decode_dynamic, acc.media_decode);
+    p.media_encode = resolve(acc.media_encode_dynamic, acc.media_encode);
     p.auth = acc.auth;
     p
 }
@@ -557,6 +620,10 @@ struct MinAcc {
     read_dynamic: bool,
     infer: BTreeSet<String>,
     infer_dynamic: bool,
+    media_decode: BTreeSet<String>,
+    media_decode_dynamic: bool,
+    media_encode: BTreeSet<String>,
+    media_encode_dynamic: bool,
     auth: bool,
 }
 
@@ -594,6 +661,18 @@ fn collect_min(v: &EdnValue, acc: &mut MinAcc) {
                             acc.infer.insert(s);
                         }
                         None => acc.infer_dynamic = true,
+                    },
+                    "media-decode" => match literal {
+                        Some(s) => {
+                            acc.media_decode.insert(s);
+                        }
+                        None => acc.media_decode_dynamic = true,
+                    },
+                    "media-encode" => match literal {
+                        Some(s) => {
+                            acc.media_encode.insert(s);
+                        }
+                        None => acc.media_encode_dynamic = true,
                     },
                     "has-capability?" => acc.auth = true,
                     _ => {}

--- a/crates/kotoba-clj/tests/media_caps.rs
+++ b/crates/kotoba-clj/tests/media_caps.rs
@@ -1,0 +1,84 @@
+//! Media capability + effect plumbing (R1, ADR-2606272200 §3).
+//!
+//! `media-decode` / `media-encode` are the capability-gated native codec
+//! boundary: each is a deny-by-default [`CapClass`] + a declared effect. These
+//! tests assert, from both sides, that
+//!   - a `media-*` call needs its grant (deny-by-default),
+//!   - the decode/encode split is real (one does not confer the other),
+//!   - per-codec (instance-level) grants are honoured (S4),
+//!   - effect soundness (T2) rejects an under-declared `:effects` row,
+//!   - a matching declaration + grant compiles to real wasm.
+
+use kotoba_clj::policy::CapClass;
+use kotoba_clj::{compile_safe_clj, CljError, Policy};
+
+fn is_wasm(b: &[u8]) -> bool {
+    b.starts_with(b"\0asm")
+}
+
+fn assert_policy_denied(res: Result<Vec<u8>, CljError>) {
+    match res {
+        Err(CljError::Policy(_)) => {}
+        other => panic!("expected CljError::Policy denial, got {other:?}"),
+    }
+}
+
+const DECODE: &str = r#"(defn run [pkt] (media-decode "h264" pkt))"#;
+const ENCODE: &str = r#"(defn run [frame] (media-encode "h265" frame))"#;
+
+#[test]
+fn media_decode_denied_without_grant() {
+    assert_policy_denied(compile_safe_clj(DECODE, &Policy::deny_all()));
+}
+
+#[test]
+fn media_decode_allowed_with_grant() {
+    let policy = Policy::deny_all().grant_media_decode(["h264"]);
+    let wasm = compile_safe_clj(DECODE, &policy).expect("granted media-decode must compile");
+    assert!(is_wasm(&wasm));
+}
+
+#[test]
+fn decode_grant_does_not_confer_encode() {
+    // The decode/encode split is the point: decode authority must not encode.
+    let policy = Policy::deny_all().grant_media_decode(["h264"]);
+    assert_policy_denied(compile_safe_clj(ENCODE, &policy));
+}
+
+#[test]
+fn encode_grant_does_not_confer_decode() {
+    let policy = Policy::deny_all().grant_media_encode(["h265"]);
+    assert_policy_denied(compile_safe_clj(DECODE, &policy));
+}
+
+#[test]
+fn per_codec_grant_is_instance_scoped() {
+    // S4: granting "av1" does not authorize decoding "h264".
+    let policy = Policy::deny_all().grant_media_decode(["av1"]);
+    assert_policy_denied(compile_safe_clj(DECODE, &policy));
+}
+
+#[test]
+fn effect_soundness_rejects_under_declared_media() {
+    // Declares pure but decodes → T2 under-declaration. Fires regardless of the
+    // (here granted) capability — the effect gate runs first.
+    let src = r#"(defn run {:effects #{}} [pkt] (media-decode "h264" pkt))"#;
+    let policy = Policy::deny_all().grant_media_decode(["h264"]);
+    match compile_safe_clj(src, &policy) {
+        Err(CljError::Effect(_)) => {}
+        other => panic!("expected CljError::Effect under-declaration, got {other:?}"),
+    }
+}
+
+#[test]
+fn declared_and_granted_media_compiles() {
+    let src = r#"(defn run {:effects #{:media-decode}} [pkt] (media-decode "h264" pkt))"#;
+    let policy = Policy::deny_all().grant_media_decode(["h264"]);
+    let wasm = compile_safe_clj(src, &policy).expect("declared+used+granted must compile");
+    assert!(is_wasm(&wasm));
+}
+
+#[test]
+fn capclass_decode_and_encode_are_distinct() {
+    assert_ne!(CapClass::MediaDecode, CapClass::MediaEncode);
+}


### PR DESCRIPTION
[utsushi](https://github.com/com-junkawasaki/utsushi) の **R1 native codec 境界**を kotoba-clj に通す。`media-decode` / `media-encode` を **HostImport + CapClass(deny-by-default) + 宣言効果(effect soundness T2)** として追加。EVM/BTC の read+verify surface と同じ「言語側の capability/effect ゲートを先に確定する」パターン。

> 本PRは**言語側の plumbing のみ**。実コーデックは kotoba-runtime の `media` WIT interface + native host word（pure-Rust / WGSL）が次段。`compile_safe_clj` が emit / 拒否する surface をここで確定する。

## 変更
| ファイル | 内容 |
|---|---|
| `ast.rs` | `Builtin::MediaDecode/MediaEncode` + `HostImport::MediaDecode/MediaEncode`（`kotoba:kais/media@0.1.0` `decode`/`encode`, **`llm-infer` と同一 ABI**）, `ALL`/`module_field`/`from_name`/arity + 完全性テスト |
| `codegen.rs` | `compile_llm_infer` を `compile_indirect_bytes_call(imp, ..)` に汎用化して media に再利用、`host_import_sig` に media（5×i32 = string + list<u8> + return-area）、`def`-initialiser ban に追加 |
| `effects.rs` | `KNOWN_EFFECTS` と `effect_of_call` に `:media-decode`/`:media-encode` |
| `policy.rs` | `CapClass::MediaDecode/MediaEncode` + `Policy.media_decode/media_encode` allowlist + grants + `class_granted` + `resource_target_of`（S4 per-codec）+ EDN round-trip + `infer_minimal`/`unused_grants` |
| `tests/media_caps.rs` | 8 tests |

## 検証（`cargo test -p kotoba-clj` green）
`tests/media_caps.rs`（8）:
- **deny-by-default**: 無権限の `media-decode` は `CljError::Policy` で拒否
- **decode↔encode split**: decode 権限は encode を与えない（逆も）
- **per-codec S4**: `"av1"` 付与は `"h264"` decode を許可しない
- **effect soundness(T2)**: `{:effects #{}}` 宣言下の `media-decode` は `CljError::Effect`（under-declaration）
- **declared+granted compiles**: `{:effects #{:media-decode}}` + grant で実 wasm 生成

既存の host-import 完全性テスト（`ALL` 網羅）・`safe_policy`・`safe_effects`・lib unit も green。

## 次段（このPR外）
kotoba-runtime の `wit/world.wit` に `media` interface + `bind_media`（native host word: pure-Rust decoder か `kotoba-llm` WGSL）。utsushi の cljc façade（`utsushi.codec`）をこの実 native に接続。

🤖 Generated with [Claude Code](https://claude.com/claude-code)