### PR TITLE
feat(kotoba-runtime): media WIT interface + bind_media host word (ADR-2606272200 §3)

### DIFF
--- a/crates/kotoba-runtime/src/host.rs
+++ b/crates/kotoba-runtime/src/host.rs
@@ -319,6 +319,7 @@ impl KotobaLinker {
         bind_chain(&mut self.0)?;
         bind_evm(&mut self.0)?;
         bind_btc(&mut self.0)?;
+        bind_media(&mut self.0)?;
         bind_http(&mut self.0)?;
         Ok(())
     }
@@ -634,6 +635,43 @@ fn bind_llm(linker: &mut Linker<HostState>) -> Result<()> {
                 .pending_lora_loads
                 .push((base_model_cid, lora_cid));
             Ok((Ok(()),))
+        },
+    )?;
+
+    Ok(())
+}
+
+// ── kotoba:kais/media ──────────────────────────────────────────────────────
+
+/// Bind the media codec boundary (ADR-2606272200 §3, utsushi R1). `decode`/`encode`
+/// share `llm.infer`'s `(string, list<u8>) -> result<list<u8>, string>` ABI and
+/// CALL_FOREIGN-class gas (1000). **R0: opaque passthrough** — the bytes are returned
+/// unchanged; the real native decoders (a pure-Rust codec crate or a `kotoba-llm` WGSL
+/// pipeline) swap in here later via a `HostState::with_codec_fn` hook, mirroring how
+/// `llm.infer` dispatches to `inference_engine`. The capability/effect gate already lives
+/// in `kotoba-clj` (only a policy-granted guest emits these imports), so this host fn is
+/// reached solely by authorized guests.
+fn bind_media(linker: &mut Linker<HostState>) -> Result<()> {
+    let mut inst = linker.instance("kotoba:kais/media@0.1.0")?;
+
+    inst.func_wrap(
+        "decode",
+        |mut ctx: wasmtime::StoreContextMut<HostState>,
+         (_codec, packet): (String, Vec<u8>)|
+         -> Result<(Result<Vec<u8>, String>,)> {
+            ctx.data_mut().charge_gas(1000)?;
+            // R0: opaque passthrough — real decode is the deferred native host word.
+            Ok((Ok(packet),))
+        },
+    )?;
+
+    inst.func_wrap(
+        "encode",
+        |mut ctx: wasmtime::StoreContextMut<HostState>,
+         (_codec, frame): (String, Vec<u8>)|
+         -> Result<(Result<Vec<u8>, String>,)> {
+            ctx.data_mut().charge_gas(1000)?;
+            Ok((Ok(frame),))
         },
     )?;
 

--- a/crates/kotoba-runtime/wit/world.wit
+++ b/crates/kotoba-runtime/wit/world.wit
@@ -252,6 +252,19 @@ interface egress {
     ) -> result<tuple<u16, list<u8>>, string>;
 }
 
+/// Media — capability-gated native codec boundary (ADR-2606272200 §3, utsushi R1).
+/// `decode`/`encode` take a codec name + bytes and return transformed bytes; same
+/// `(string, list<u8>) -> result<list<u8>, string>` ABI as `llm.infer`. CALL_FOREIGN
+/// gas. The safe-clj `media-decode`/`media-encode` builtins (CapClass::MediaDecode/
+/// MediaEncode) lower to these imports. R0 host binding is opaque passthrough; real
+/// decoders (pure-Rust / WGSL) swap in behind this boundary later.
+interface media {
+    /// Decode a coded packet for `codec` (e.g. "h264") into frame bytes.
+    decode: func(codec: string, packet: list<u8>) -> result<list<u8>, string>;
+    /// Encode frame bytes with `codec` (e.g. "h265").
+    encode: func(codec: string, frame: list<u8>) -> result<list<u8>, string>;
+}
+
 /// KOTOBA world — imported by every WASM guest node program
 ///
 /// Guest exports `run` to be called by the KotobaRuntime executor.
@@ -265,6 +278,7 @@ world kotoba-node {
     import evm;
     import btc;
     import egress;
+    import media;
     // `egress` was renamed from `http` (2026-05-31, ADR-2605312355): a guest importing
     // an interface literally named `http` died at instantiation with `ImportError:
     // outgoing_handler` — verified with wasi:http BOTH present and absent and with/without
@@ -296,6 +310,7 @@ world kotoba-component {
     import evm;
     import btc;
     import egress;
+    import media;
     import wasi:http/outgoing-handler@0.2.0;
 
     /// Generic invoke (same as kotoba-node).
@@ -318,6 +333,7 @@ world kotoba-cron {
     import evm;
     import btc;
     import egress;
+    import media;
     import wasi:http/outgoing-handler@0.2.0;
 
     /// Generic invoke (same as kotoba-node).
@@ -339,6 +355,7 @@ world kotoba-kse {
     import evm;
     import btc;
     import egress;
+    import media;
     import wasi:http/outgoing-handler@0.2.0;
 
     /// Generic invoke (same as kotoba-node).
@@ -361,6 +378,7 @@ world kotoba-mesh {
     import evm;
     import btc;
     import egress;
+    import media;
     import wasi:http/outgoing-handler@0.2.0;
 
     /// Generic invoke (same as kotoba-node).


### PR DESCRIPTION
kotoba-clj の `media-decode`/`media-encode` capability（[#234](https://github.com/com-junkawasaki/kotoba/pull/234)）に**実行サーフェス**を与える。`media` を使う safe-clj guest が instantiate → 実行できるようになる。

## 変更
- **`wit/world.wit`**: `interface media { decode/encode: func(string, list<u8>) -> result<list<u8>, string> }`（`llm.infer` と同一 ABI）+ node 系 5 world（node/component/cron/kse/mesh）に `import media`
- **`src/host.rs`**: `bind_media`（CALL_FOREIGN gas = 1000）を `bind_kotoba_interfaces` に登録。**R0 は opaque passthrough**（bytes をそのまま返す）

## 設計
`kotoba-clj` の `HostImport::MediaDecode/MediaEncode`（`kotoba:kais/media@0.1.0` decode/encode）がこのインターフェースに lower される。capability/effect ゲートは **#234 で言語側に既に存在** — policy で grant された guest だけがこのインポートを emit するので、本 host fn は**認可済み guest からのみ**到達する。

実 native codec（pure-Rust decoder か `kotoba-llm` WGSL）は `llm.infer` の `inference_engine` と同じく `HostState` フック経由で opaque 実装を差し替える形で後段導入。

## 検証
`cargo build -p kotoba-runtime` green（WIT bindgen + 5 world + bind_media のクロージャ型）。capability/effect の網羅テストは #234（`tests/media_caps.rs` 8 tests）で済。

## 次段（このPR外）
- 実 native codec の接続（`HostState::with_codec_fn`）
- e2e invoke テスト（media-decode guest を `WasmExecutor` で実行 → opaque passthrough 確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)