### PR TITLE
feat(kotoba-runtime): real codec injection hook for media.* (ADR-2606272200 §3)

### DIFF
--- a/crates/kotoba-runtime/src/executor.rs
+++ b/crates/kotoba-runtime/src/executor.rs
@@ -3,7 +3,7 @@ use tracing::instrument;
 use wasmtime::component::Func;
 
 use crate::error::RuntimeError;
-use crate::host::{HostState, InferenceFn, KotobaEngine, PendingQuad, WitQuad};
+use crate::host::{CodecFn, HostState, InferenceFn, KotobaEngine, PendingQuad, WitQuad};
 use crate::program::ProgramStore;
 
 /// InvokeContext is CBOR-decoded from the Invoke ChainEntry input field.
@@ -66,6 +66,7 @@ pub struct WasmExecutor {
     programs: ProgramStore,
     gas_limit: u64,
     inference_engine: Option<InferenceFn>,
+    codec_fn: Option<CodecFn>,
 }
 
 impl WasmExecutor {
@@ -81,6 +82,7 @@ impl WasmExecutor {
             programs,
             gas_limit,
             inference_engine: None,
+            codec_fn: None,
         })
     }
 
@@ -92,6 +94,15 @@ impl WasmExecutor {
         let mut s = Self::new(gas_limit)?;
         s.inference_engine = Some(engine);
         Ok(s)
+    }
+
+    /// Wire in a real native codec, forwarded into every `HostState` at execute time
+    /// so `media.decode`/`media.encode` calls in guest WASM transform real bytes
+    /// (ADR-2606272200 §3). Chainable: `WasmExecutor::new(gas)?.with_codec(codec_fn)`.
+    /// When unset, `media.*` is opaque passthrough.
+    pub fn with_codec(mut self, codec_fn: CodecFn) -> Self {
+        self.codec_fn = Some(codec_fn);
+        self
     }
 
     #[instrument(
@@ -215,7 +226,7 @@ impl WasmExecutor {
             .get_or_compile(program_cid, wasm_bytes)
             .map_err(RuntimeError::CompileFailed)?;
 
-        let state = match &self.inference_engine {
+        let mut state = match &self.inference_engine {
             Some(e) => HostState::with_inference_and_snapshot(
                 agent_did,
                 self.gas_limit,
@@ -227,6 +238,9 @@ impl WasmExecutor {
                 .with_snapshot(quad_snapshot)
                 .with_head_commits(head_commits),
         };
+        if let Some(c) = &self.codec_fn {
+            state = state.with_codec_fn(c.clone());
+        }
         let mut store = self.engine.new_store(state);
 
         let mut linker = self.engine.new_linker();

--- a/crates/kotoba-runtime/src/host.rs
+++ b/crates/kotoba-runtime/src/host.rs
@@ -31,6 +31,27 @@ pub type InferenceFn = Arc<dyn Fn(&str, usize) -> anyhow::Result<String> + Send 
 /// Type-erased to avoid kotoba-runtime → kotoba-ingest dependency.
 pub type EmbedFn = Arc<dyn Fn(&str) -> anyhow::Result<Vec<f32>> + Send + Sync>;
 
+/// The operation a [`CodecFn`] performs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MediaOp {
+    /// Coded packet → frame bytes.
+    Decode,
+    /// Frame bytes → coded packet.
+    Encode,
+}
+
+/// Type alias for a synchronous native codec function (ADR-2606272200 §3, utsushi R1).
+///
+/// Signature: `(op, codec, bytes) -> Result<Vec<u8>>` — `op` selects decode/encode,
+/// `codec` is the codec name (e.g. `"h264"`), `bytes` is the packet (decode) or frame
+/// (encode); the result is the transformed bytes.
+///
+/// The concrete decoder/encoder (a pure-Rust codec crate or a `kotoba-llm` WGSL
+/// pipeline) is injected by the caller and **type-erased here so kotoba-runtime carries
+/// no codec dependency** — exactly as [`InferenceFn`] keeps it independent of
+/// kotoba-llm. When unset, `media.decode`/`media.encode` fall back to opaque passthrough.
+pub type CodecFn = Arc<dyn Fn(MediaOp, &str, &[u8]) -> anyhow::Result<Vec<u8>> + Send + Sync>;
+
 /// WIT record type for kotoba:kais/kqe.quad.
 ///
 /// `func_wrap` requires an exact Rust type that mirrors the WIT record layout.
@@ -89,6 +110,9 @@ pub struct HostState {
     /// Dense embedding function — routes to HttpEmbedClient when configured.
     /// Type-erased to avoid kotoba-runtime → kotoba-ingest dependency.
     pub embed_fn: Option<EmbedFn>,
+    /// Native codec function for `media.decode`/`media.encode`. `None` → opaque
+    /// passthrough. Type-erased so kotoba-runtime carries no codec dependency.
+    pub codec_fn: Option<CodecFn>,
     /// WASI HTTP context for wasi:http egress.
     pub wasi_http_ctx: WasiHttpCtx,
     /// Optional allow-list for outbound HTTP host glob patterns (None = allow all).
@@ -132,6 +156,7 @@ impl HostState {
             kse_inbox: Vec::new(),
             source_chain_head: None,
             embed_fn: None,
+            codec_fn: None,
             wasi_http_ctx: WasiHttpCtx::new(),
             http_egress_allow: allow_list,
         }
@@ -146,6 +171,13 @@ impl HostState {
     /// Wire in a real embedding function (e.g. from HttpEmbedClient).
     pub fn with_embed_fn(mut self, f: EmbedFn) -> Self {
         self.embed_fn = Some(f);
+        self
+    }
+
+    /// Wire in a real native codec (decode/encode) for `media.*`. When unset,
+    /// `media.decode`/`media.encode` fall back to opaque passthrough (R0).
+    pub fn with_codec_fn(mut self, f: CodecFn) -> Self {
+        self.codec_fn = Some(f);
         self
     }
 
@@ -645,33 +677,40 @@ fn bind_llm(linker: &mut Linker<HostState>) -> Result<()> {
 
 /// Bind the media codec boundary (ADR-2606272200 §3, utsushi R1). `decode`/`encode`
 /// share `llm.infer`'s `(string, list<u8>) -> result<list<u8>, string>` ABI and
-/// CALL_FOREIGN-class gas (1000). **R0: opaque passthrough** — the bytes are returned
-/// unchanged; the real native decoders (a pure-Rust codec crate or a `kotoba-llm` WGSL
-/// pipeline) swap in here later via a `HostState::with_codec_fn` hook, mirroring how
-/// `llm.infer` dispatches to `inference_engine`. The capability/effect gate already lives
-/// in `kotoba-clj` (only a policy-granted guest emits these imports), so this host fn is
-/// reached solely by authorized guests.
+/// CALL_FOREIGN-class gas (1000). Each dispatches to the injected
+/// [`HostState::codec_fn`] (a real pure-Rust decoder or a `kotoba-llm` WGSL pipeline,
+/// wired by `kotoba-server` — mirroring how `llm.infer` dispatches to
+/// `inference_engine`). When no codec is configured it falls back to **opaque
+/// passthrough** (R0). The capability/effect gate already lives in `kotoba-clj` (only a
+/// policy-granted guest emits these imports), so this host fn is reached solely by
+/// authorized guests.
 fn bind_media(linker: &mut Linker<HostState>) -> Result<()> {
     let mut inst = linker.instance("kotoba:kais/media@0.1.0")?;
 
     inst.func_wrap(
         "decode",
         |mut ctx: wasmtime::StoreContextMut<HostState>,
-         (_codec, packet): (String, Vec<u8>)|
+         (codec, packet): (String, Vec<u8>)|
          -> Result<(Result<Vec<u8>, String>,)> {
             ctx.data_mut().charge_gas(1000)?;
-            // R0: opaque passthrough — real decode is the deferred native host word.
-            Ok((Ok(packet),))
+            // Clone the Arc so the closure doesn't hold a borrow on ctx.
+            match ctx.data().codec_fn.clone() {
+                Some(f) => Ok((f(MediaOp::Decode, &codec, &packet).map_err(|e| e.to_string()),)),
+                None => Ok((Ok(packet),)), // R0 opaque passthrough
+            }
         },
     )?;
 
     inst.func_wrap(
         "encode",
         |mut ctx: wasmtime::StoreContextMut<HostState>,
-         (_codec, frame): (String, Vec<u8>)|
+         (codec, frame): (String, Vec<u8>)|
          -> Result<(Result<Vec<u8>, String>,)> {
             ctx.data_mut().charge_gas(1000)?;
-            Ok((Ok(frame),))
+            match ctx.data().codec_fn.clone() {
+                Some(f) => Ok((f(MediaOp::Encode, &codec, &frame).map_err(|e| e.to_string()),)),
+                None => Ok((Ok(frame),)),
+            }
         },
     )?;
 

--- a/crates/kotoba-runtime/src/lib.rs
+++ b/crates/kotoba-runtime/src/lib.rs
@@ -368,6 +368,67 @@ mod tests {
         );
     }
 
+    /// HostState defaults to no codec (media.* is opaque passthrough until injected).
+    #[test]
+    fn test_host_state_codec_fn_default_is_none() {
+        let state = crate::host::HostState::new("did:test:000", 10_000_000);
+        assert!(
+            state.codec_fn.is_none(),
+            "HostState::new() must leave codec_fn as None (opaque passthrough)"
+        );
+    }
+
+    /// A real injected codec (RLE) round-trips through the `with_codec_fn` hook — the
+    /// boundary `media.decode`/`media.encode` dispatch into (ADR-2606272200 §3).
+    #[test]
+    fn test_host_state_codec_fn_real_codec_round_trips() {
+        use crate::host::MediaOp;
+        use std::sync::Arc;
+
+        // Minimal but real run-length codec: encode → [run, byte]*, decode reverses it.
+        fn rle_encode(input: &[u8]) -> Vec<u8> {
+            let mut out = Vec::new();
+            let mut i = 0;
+            while i < input.len() {
+                let b = input[i];
+                let mut run = 1usize;
+                while i + run < input.len() && input[i + run] == b && run < 255 {
+                    run += 1;
+                }
+                out.push(run as u8);
+                out.push(b);
+                i += run;
+            }
+            out
+        }
+        fn rle_decode(input: &[u8]) -> Vec<u8> {
+            let mut out = Vec::new();
+            let mut i = 0;
+            while i + 1 < input.len() {
+                out.extend(std::iter::repeat_n(input[i + 1], input[i] as usize));
+                i += 2;
+            }
+            out
+        }
+
+        let codec: crate::host::CodecFn = Arc::new(|op, _codec, bytes| match op {
+            MediaOp::Encode => Ok(rle_encode(bytes)),
+            MediaOp::Decode => Ok(rle_decode(bytes)),
+        });
+        let state = crate::host::HostState::new("did:test:codec", 10_000_000).with_codec_fn(codec);
+
+        let f = state.codec_fn.clone().expect("codec_fn must be set");
+        let frame = b"aaaaabbbc".to_vec();
+        let coded = f(MediaOp::Encode, "rle", &frame).unwrap();
+        // A real transform: repetitive input compresses (not opaque passthrough).
+        assert!(
+            coded.len() < frame.len(),
+            "RLE must shrink repetitive input"
+        );
+        let back = f(MediaOp::Decode, "rle", &coded).unwrap();
+        assert_eq!(back, frame, "decode(encode(x)) must round-trip");
+    }
+
     #[test]
     fn runtime_error_program_not_found_display() {
         let e = crate::error::RuntimeError::ProgramNotFound("cid-abc".to_string());


### PR DESCRIPTION
[#235](https://github.com/com-junkawasaki/kotoba/pull/235) の `bind_media` opaque passthrough を、**注入された実コーデックへ dispatch** する形に拡張。これで `media` を grant された `.kotoba` guest が実コーデック変換を実行できる。

`inference_engine` / `embed_fn` と**同じ型消去フックパターン** — kotoba-runtime は特定 codec への依存を持たず、実 decoder（pure-Rust crate / `kotoba-llm` WGSL）は `kotoba-server` が注入する。

## 変更
| ファイル | 内容 |
|---|---|
| `host.rs` | `enum MediaOp{Decode,Encode}` + `type CodecFn = Arc<dyn Fn(MediaOp,&str,&[u8])->Result<Vec<u8>>>` + `HostState.codec_fn` + `with_codec_fn`。`bind_media` の decode/encode が `codec_fn` へ dispatch、**未設定時は opaque passthrough** |
| `executor.rs` | `WasmExecutor.codec_fn` + `with_codec`（chainable）+ `execute` で `HostState` へ注入（全 execute 経路は単一の state 構築点を共有） |
| `lib.rs` | `codec_fn` デフォルト None テスト + **実 RLE codec の round-trip テスト**（hook が実バイト変換を通す＝opaque ではないことを確認） |

## 設計（kotoba の依存規律に整合）
```
guest media.decode → bind_media → HostState.codec_fn(Decode, codec, bytes)
                                     ├ Some(f) → 実コーデック変換
                                     └ None    → opaque passthrough (R0)
```
`InferenceFn` が kotoba-runtime → kotoba-llm 依存を断つのと同様、`CodecFn` で codec crate 依存を断つ。production は `WasmExecutor::new(gas)?.with_codec(codec_fn)` で実 decoder を注入。

## 検証
`cargo test -p kotoba-runtime --lib codec` → **2 passed**（デフォルト None + 実 RLE round-trip）。capability/effect ゲートは #234、WIT interface/import は #235 で確定済み。

## 次段（このPR外）
- `kotoba-server` で実 video decoder（pure-Rust / WGSL）を `with_codec` 注入
- guest 経由 e2e invoke テスト（media-decode guest → `WasmExecutor.with_codec(rle)` → 変換確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)