### PR TITLE
feat(kotoba-rad): add sovereign repo layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4779,6 +4779,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "kotoba-rad"
+version = "0.1.0"
+dependencies = [
+ "ciborium",
+ "kotoba-core",
+ "kotoba-datomic",
+ "kotoba-git",
+ "kotoba-store",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "kotoba-rt"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
     "crates/kotoba-vc",
     "crates/kotoba-didcomm",
     "crates/kotoba-git",
+    "crates/kotoba-rad",
     "crates/kotoba-evm",
     "crates/kotoba-word",
     "examples/ashiba-bmc",
@@ -183,6 +184,7 @@ kotoba-datomic = { path = "crates/kotoba-datomic" }
 kotoba-vc      = { path = "crates/kotoba-vc" }
 kotoba-didcomm = { path = "crates/kotoba-didcomm" }
 kotoba-git     = { path = "crates/kotoba-git" }
+kotoba-rad     = { path = "crates/kotoba-rad" }
 kotoba-word    = { path = "crates/kotoba-word" }
 kotoba-lattice = { path = "crates/kotoba-lattice" }
 

--- a/crates/kotoba-git/README.md
+++ b/crates/kotoba-git/README.md
@@ -1,0 +1,59 @@
+# kotoba-git
+
+`kotoba-git` is the byte-exact Git object bridge for kotoba.
+
+Git is already a content-addressed DAG keyed by SHA-1 over framed object bytes.
+kotoba stores blocks by CID. This crate keeps both identities:
+
+- `git oid = sha1("<type> <size>\0<body>")`
+- `kotoba cid = cid(framed-bytes)`
+
+The SHA-1 side preserves Git compatibility. The CID side lets kotoba replicate,
+query, encrypt, and cache objects using the same block substrate as the rest of
+the system.
+
+## Implemented
+
+- blob/tree/commit/tag framed object codec
+- byte-exact parse/materialize round trip
+- Git tree entry parsing
+- commit/tag header projection
+- `:git/oid` to `:git.object/cid` Datom schema
+- commit parents, tree entries, tags, refs projected to Datoms
+- loose object import/export
+- pack v2 / idx v2 import with OFS/REF delta resolution
+- snapshot manifest and rehydrate of the queryable projection
+- bounded zlib inflation and bounded delta depth for hostile repos
+
+## Boundary
+
+This crate does not decide repository authority. It only answers:
+
+- what bytes does this Git object have?
+- what Git oid do those bytes hash to?
+- what CID stores those bytes?
+- what refs are currently projected?
+- what commit/tree/tag facts are queryable?
+
+Repository identity, delegate authorization, private grants, and peer
+accountability belong to the `kotoba-rad` layer described in
+`docs/ADR-kotoba-rad-git-sovereign-repo.md`.
+
+## Maturity
+
+| Stage | Scope | Status |
+|---|---|---|
+| R0 | byte-exact Git object bridge | implemented |
+| R1 | signed repo identity and ref authorization | `kotoba-rad` design target |
+| R2 | encrypted private Git object blocks | `kotoba-rad` / `kotoba-crypto` design target |
+| R3 | p2p warrants and reputation | `kotoba-dht` integration target |
+| R4 | hybrid post-quantum envelopes and signatures | future |
+
+## Privacy Rule
+
+Do not treat Git refs or peer allow-lists as a secrecy boundary. For private
+repositories, the future `kotoba-rad` layer must encrypt Git framed bytes before
+untrusted replication and publish only ciphertext CIDs to non-recipient peers.
+
+`kotoba-git` remains the plaintext fidelity core: after decryption, it verifies
+that the framed bytes recompute to the expected Git oid and CID.

--- a/crates/kotoba-rad/Cargo.toml
+++ b/crates/kotoba-rad/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "kotoba-rad"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Kotoba sovereign repository layer: RID, identity journal, delegate/ref validation over kotoba-git"
+
+[dependencies]
+kotoba-core = { workspace = true }
+kotoba-datomic = { workspace = true }
+kotoba-git = { workspace = true }
+ciborium = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+kotoba-store = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/kotoba-rad/src/lib.rs
+++ b/crates/kotoba-rad/src/lib.rs
@@ -1,0 +1,618 @@
+//! kotoba-rad: sovereign repository identity and ref authorization over
+//! [`kotoba-git`].
+//!
+//! This crate is the R1 layer from `docs/ADR-kotoba-rad-git-sovereign-repo.md`.
+//! It deliberately does **not** reimplement Git storage. `kotoba-git` remains
+//! the byte-exact object bridge; `kotoba-rad` validates who may move refs and
+//! how repository identity evolves.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kotoba_core::cid::KotobaCid;
+use kotoba_git::{commit_parents, log, object_cid, resolve_ref, GitOid, GitStore};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum RadError {
+    #[error("delegate not found or inactive: {0}")]
+    DelegateNotFound(String),
+    #[error("delegate {actor} lacks capability {capability}")]
+    MissingCapability {
+        actor: String,
+        capability: Capability,
+    },
+    #[error("event prev mismatch")]
+    PrevMismatch,
+    #[error("event sequence mismatch: expected {expected}, got {got}")]
+    SeqMismatch { expected: u64, got: u64 },
+    #[error("invalid oid: {0}")]
+    InvalidOid(String),
+    #[error("target object not found: {0}")]
+    ObjectNotFound(String),
+    #[error("ref update is not fast-forward: {name}")]
+    NonFastForward { name: String },
+    #[error("force update not allowed for ref: {0}")]
+    ForceUpdateDenied(String),
+    #[error("private object publish requires ciphertext cid")]
+    PrivatePublishWithoutCiphertext,
+    #[error("cbor encode error: {0}")]
+    Cbor(String),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Capability {
+    IdentityUpdate,
+    RefCreate,
+    RefUpdate,
+    RefDelete,
+    RefForceUpdate,
+    ObjectPublish,
+    GrantWrite,
+    GrantRevoke,
+}
+
+impl std::fmt::Display for Capability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RepoVisibility {
+    Public,
+    Private,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Delegate {
+    pub did: String,
+    pub role: String,
+    pub can: BTreeSet<Capability>,
+}
+
+impl Delegate {
+    pub fn new(
+        did: impl Into<String>,
+        role: impl Into<String>,
+        can: impl IntoIterator<Item = Capability>,
+    ) -> Self {
+        Self {
+            did: did.into(),
+            role: role.into(),
+            can: can.into_iter().collect(),
+        }
+    }
+
+    pub fn can(&self, capability: Capability) -> bool {
+        self.can.contains(&capability)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoIdentity {
+    pub version: u32,
+    pub name: String,
+    pub description: Option<String>,
+    pub visibility: RepoVisibility,
+    pub default_branch: String,
+    pub git_hash_suite: String,
+    pub block_hash_suite: String,
+    pub delegates: Vec<Delegate>,
+    pub created_at: u64,
+}
+
+impl RepoIdentity {
+    pub fn new(
+        name: impl Into<String>,
+        visibility: RepoVisibility,
+        default_branch: impl Into<String>,
+        delegates: Vec<Delegate>,
+        created_at: u64,
+    ) -> Self {
+        Self {
+            version: 1,
+            name: name.into(),
+            description: None,
+            visibility,
+            default_branch: default_branch.into(),
+            git_hash_suite: "git.sha1".to_string(),
+            block_hash_suite: "cidv1.dag-cbor.sha2-256".to_string(),
+            delegates,
+            created_at,
+        }
+    }
+
+    pub fn rid(&self) -> Result<RepoRid, RadError> {
+        canonical_cid(self).map(RepoRid)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RepoRid(pub KotobaCid);
+
+impl RepoRid {
+    pub fn to_multibase(&self) -> String {
+        self.0.to_multibase()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RefUpdate {
+    pub name: String,
+    pub old: Option<String>,
+    pub new: String,
+    #[serde(default)]
+    pub allow_non_fast_forward: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ObjectPublish {
+    pub git_oid: String,
+    pub plaintext_cid: Option<KotobaCid>,
+    pub ciphertext_cid: Option<KotobaCid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RecipientGrant {
+    pub epoch: u64,
+    pub recipient: String,
+    pub kem: Vec<String>,
+    pub aead: String,
+    pub wrapped_key_cid: KotobaCid,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "body", rename_all = "kebab-case")]
+pub enum RepoEventKind {
+    IdentityUpdate { identity: RepoIdentity },
+    RefCreate { update: RefUpdate },
+    RefUpdate { update: RefUpdate },
+    RefDelete { name: String, old: String },
+    ObjectPublish { publish: ObjectPublish },
+    GrantAdd { grant: RecipientGrant },
+    GrantRevoke { epoch: u64, recipient: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RepoEvent {
+    pub rid: RepoRid,
+    pub seq: u64,
+    pub prev: Option<KotobaCid>,
+    pub actor: String,
+    pub ts: u64,
+    pub kind: RepoEventKind,
+    /// Signature bytes are carried by the wire format, but signature verification
+    /// is a later integration with `kotoba-auth`. R1 fixes the canonical bytes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sig: Vec<u8>,
+}
+
+impl RepoEvent {
+    pub fn signing_bytes(&self) -> Result<Vec<u8>, RadError> {
+        #[derive(Serialize)]
+        struct SigningPayload<'a> {
+            rid: &'a RepoRid,
+            seq: u64,
+            prev: &'a Option<KotobaCid>,
+            actor: &'a str,
+            ts: u64,
+            kind: &'a RepoEventKind,
+        }
+        let payload = SigningPayload {
+            rid: &self.rid,
+            seq: self.seq,
+            prev: &self.prev,
+            actor: &self.actor,
+            ts: self.ts,
+            kind: &self.kind,
+        };
+        canonical_bytes(&payload)
+    }
+
+    pub fn cid(&self) -> Result<KotobaCid, RadError> {
+        Ok(KotobaCid::from_bytes(&self.signing_bytes()?))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RepoState {
+    pub identity: RepoIdentity,
+    pub rid: RepoRid,
+    pub journal_head: Option<KotobaCid>,
+    pub next_seq: u64,
+    pub refs: BTreeMap<String, String>,
+}
+
+impl RepoState {
+    pub fn new(identity: RepoIdentity) -> Result<Self, RadError> {
+        let rid = identity.rid()?;
+        Ok(Self {
+            identity,
+            rid,
+            journal_head: None,
+            next_seq: 0,
+            refs: BTreeMap::new(),
+        })
+    }
+
+    pub fn delegate(&self, did: &str) -> Option<&Delegate> {
+        self.identity.delegates.iter().find(|d| d.did == did)
+    }
+
+    pub fn require(&self, actor: &str, capability: Capability) -> Result<(), RadError> {
+        let delegate = self
+            .delegate(actor)
+            .ok_or_else(|| RadError::DelegateNotFound(actor.to_string()))?;
+        if !delegate.can(capability) {
+            return Err(RadError::MissingCapability {
+                actor: actor.to_string(),
+                capability,
+            });
+        }
+        Ok(())
+    }
+}
+
+pub struct RadRepo<'a, 'b> {
+    git: &'a GitStore<'b>,
+}
+
+impl<'a, 'b> RadRepo<'a, 'b> {
+    pub fn new(git: &'a GitStore<'b>) -> Self {
+        Self { git }
+    }
+
+    pub fn authorize_event(&self, state: &RepoState, event: &RepoEvent) -> Result<(), RadError> {
+        if event.seq != state.next_seq {
+            return Err(RadError::SeqMismatch {
+                expected: state.next_seq,
+                got: event.seq,
+            });
+        }
+        if event.prev != state.journal_head {
+            return Err(RadError::PrevMismatch);
+        }
+
+        match &event.kind {
+            RepoEventKind::IdentityUpdate { .. } => {
+                state.require(&event.actor, Capability::IdentityUpdate)
+            }
+            RepoEventKind::RefCreate { update } => {
+                state.require(&event.actor, Capability::RefCreate)?;
+                self.validate_ref_update(state, update, false, false)
+            }
+            RepoEventKind::RefUpdate { update } => {
+                state.require(&event.actor, Capability::RefUpdate)?;
+                let force_allowed = if update.allow_non_fast_forward {
+                    state.require(&event.actor, Capability::RefForceUpdate)?;
+                    true
+                } else {
+                    false
+                };
+                self.validate_ref_update(state, update, true, force_allowed)
+            }
+            RepoEventKind::RefDelete { .. } => state.require(&event.actor, Capability::RefDelete),
+            RepoEventKind::ObjectPublish { publish } => {
+                state.require(&event.actor, Capability::ObjectPublish)?;
+                self.validate_object_publish(state, publish)
+            }
+            RepoEventKind::GrantAdd { .. } => state.require(&event.actor, Capability::GrantWrite),
+            RepoEventKind::GrantRevoke { .. } => {
+                state.require(&event.actor, Capability::GrantRevoke)
+            }
+        }
+    }
+
+    pub fn apply_event(
+        &self,
+        state: &mut RepoState,
+        event: RepoEvent,
+    ) -> Result<KotobaCid, RadError> {
+        self.authorize_event(state, &event)?;
+        let cid = event.cid()?;
+        match event.kind {
+            RepoEventKind::IdentityUpdate { identity } => {
+                state.identity = identity;
+                state.rid = state.identity.rid()?;
+            }
+            RepoEventKind::RefCreate { update } | RepoEventKind::RefUpdate { update } => {
+                state.refs.insert(update.name, update.new);
+            }
+            RepoEventKind::RefDelete { name, .. } => {
+                state.refs.remove(&name);
+            }
+            RepoEventKind::ObjectPublish { .. }
+            | RepoEventKind::GrantAdd { .. }
+            | RepoEventKind::GrantRevoke { .. } => {}
+        }
+        state.journal_head = Some(cid.clone());
+        state.next_seq += 1;
+        Ok(cid)
+    }
+
+    fn validate_object_publish(
+        &self,
+        state: &RepoState,
+        publish: &ObjectPublish,
+    ) -> Result<(), RadError> {
+        let oid = parse_oid(&publish.git_oid)?;
+        object_cid(&self.git.db(), oid)
+            .map_err(|_| RadError::ObjectNotFound(publish.git_oid.clone()))?;
+        if state.identity.visibility == RepoVisibility::Private && publish.ciphertext_cid.is_none()
+        {
+            return Err(RadError::PrivatePublishWithoutCiphertext);
+        }
+        Ok(())
+    }
+
+    fn validate_ref_update(
+        &self,
+        state: &RepoState,
+        update: &RefUpdate,
+        existing_ref_required: bool,
+        force_allowed: bool,
+    ) -> Result<(), RadError> {
+        let new_oid = parse_oid(&update.new)?;
+        object_cid(&self.git.db(), new_oid)
+            .map_err(|_| RadError::ObjectNotFound(update.new.clone()))?;
+
+        let current = state
+            .refs
+            .get(&update.name)
+            .and_then(|s| GitOid::from_hex(s).ok())
+            .or_else(|| resolve_ref(&self.git.db(), &update.name));
+
+        if existing_ref_required && current.is_none() {
+            return Err(RadError::ObjectNotFound(update.name.clone()));
+        }
+
+        if let Some(old) = &update.old {
+            let old_oid = parse_oid(old)?;
+            if Some(old_oid) != current {
+                return Err(RadError::NonFastForward {
+                    name: update.name.clone(),
+                });
+            }
+        }
+
+        if let Some(old_oid) = current {
+            if !update.allow_non_fast_forward && !is_ancestor(&self.git.db(), old_oid, new_oid) {
+                return Err(RadError::NonFastForward {
+                    name: update.name.clone(),
+                });
+            }
+        } else if existing_ref_required {
+            return Err(RadError::ObjectNotFound(update.name.clone()));
+        }
+
+        if update.allow_non_fast_forward && !force_allowed {
+            return Err(RadError::ForceUpdateDenied(update.name.clone()));
+        }
+
+        Ok(())
+    }
+}
+
+fn is_ancestor(db: &kotoba_datomic::Db, ancestor: GitOid, head: GitOid) -> bool {
+    if ancestor == head {
+        return true;
+    }
+    log(db, head).contains(&ancestor) || commit_parents(db, head).contains(&ancestor)
+}
+
+fn parse_oid(value: &str) -> Result<GitOid, RadError> {
+    GitOid::from_hex(value).map_err(|_| RadError::InvalidOid(value.to_string()))
+}
+
+fn canonical_cid<T: Serialize>(value: &T) -> Result<KotobaCid, RadError> {
+    Ok(KotobaCid::from_bytes(&canonical_bytes(value)?))
+}
+
+fn canonical_bytes<T: Serialize>(value: &T) -> Result<Vec<u8>, RadError> {
+    let mut buf = Vec::new();
+    ciborium::into_writer(value, &mut buf).map_err(|e| RadError::Cbor(e.to_string()))?;
+    Ok(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kotoba_datomic::Connection;
+    use kotoba_git::{GitObject, GitObjectKind};
+    use kotoba_store::MemoryBlockStore;
+
+    async fn fixture() -> (Connection, MemoryBlockStore, String, String, GitOid, GitOid) {
+        let conn = Connection::new();
+        let store = MemoryBlockStore::new();
+        let git = GitStore::new(&conn, &store);
+        git.install_schema().await.unwrap();
+
+        let tree = GitObject::new(GitObjectKind::Tree, Vec::new());
+        let (tree_oid, _) = git.put_object(&tree).await.unwrap();
+
+        let c1 = GitObject::new(
+            GitObjectKind::Commit,
+            format!(
+                "tree {}\nauthor t <t@t> 1700000000 +0000\ncommitter t <t@t> 1700000000 +0000\n\nfirst\n",
+                tree_oid.to_hex()
+            )
+            .into_bytes(),
+        );
+        let (c1_oid, _) = git.put_object(&c1).await.unwrap();
+
+        let c2 = GitObject::new(
+            GitObjectKind::Commit,
+            format!(
+                "tree {}\nparent {}\nauthor t <t@t> 1700000001 +0000\ncommitter t <t@t> 1700000001 +0000\n\nsecond\n",
+                tree_oid.to_hex(),
+                c1_oid.to_hex()
+            )
+            .into_bytes(),
+        );
+        let (c2_oid, _) = git.put_object(&c2).await.unwrap();
+
+        git.put_ref("refs/heads/main", c1_oid).await.unwrap();
+        let maintainer = "did:key:zmaintainer".to_string();
+        let observer = "did:key:zobserver".to_string();
+        (conn, store, maintainer, observer, c1_oid, c2_oid)
+    }
+
+    fn identity(maintainer: String, observer: String) -> RepoIdentity {
+        RepoIdentity::new(
+            "test/repo",
+            RepoVisibility::Private,
+            "refs/heads/main",
+            vec![
+                Delegate::new(
+                    maintainer,
+                    "maintainer",
+                    [
+                        Capability::RefCreate,
+                        Capability::RefUpdate,
+                        Capability::RefForceUpdate,
+                        Capability::ObjectPublish,
+                        Capability::GrantWrite,
+                        Capability::GrantRevoke,
+                    ],
+                ),
+                Delegate::new(observer, "observer", []),
+            ],
+            1,
+        )
+    }
+
+    #[tokio::test]
+    async fn rid_is_stable_for_same_identity() {
+        let (_conn, _store, maintainer, observer, _c1, _c2) = fixture().await;
+        let id = identity(maintainer, observer);
+        assert_eq!(id.rid().unwrap(), id.rid().unwrap());
+    }
+
+    #[tokio::test]
+    async fn applies_fast_forward_ref_update() {
+        let (conn, store, maintainer, observer, c1, c2) = fixture().await;
+        let git = GitStore::new(&conn, &store);
+        let rad = RadRepo::new(&git);
+        let mut state = RepoState::new(identity(maintainer.clone(), observer)).unwrap();
+        state
+            .refs
+            .insert("refs/heads/main".to_string(), c1.to_hex());
+
+        let event = RepoEvent {
+            rid: state.rid.clone(),
+            seq: 0,
+            prev: None,
+            actor: maintainer,
+            ts: 2,
+            kind: RepoEventKind::RefUpdate {
+                update: RefUpdate {
+                    name: "refs/heads/main".to_string(),
+                    old: Some(c1.to_hex()),
+                    new: c2.to_hex(),
+                    allow_non_fast_forward: false,
+                },
+            },
+            sig: Vec::new(),
+        };
+
+        rad.apply_event(&mut state, event).unwrap();
+        assert_eq!(state.refs["refs/heads/main"], c2.to_hex());
+        assert_eq!(state.next_seq, 1);
+        assert!(state.journal_head.is_some());
+    }
+
+    #[tokio::test]
+    async fn rejects_delegate_without_capability() {
+        let (conn, store, _maintainer, observer, c1, c2) = fixture().await;
+        let git = GitStore::new(&conn, &store);
+        let rad = RadRepo::new(&git);
+        let mut state = RepoState::new(identity(
+            "did:key:zmaintainer".to_string(),
+            observer.clone(),
+        ))
+        .unwrap();
+        state
+            .refs
+            .insert("refs/heads/main".to_string(), c1.to_hex());
+
+        let event = RepoEvent {
+            rid: state.rid.clone(),
+            seq: 0,
+            prev: None,
+            actor: observer,
+            ts: 2,
+            kind: RepoEventKind::RefUpdate {
+                update: RefUpdate {
+                    name: "refs/heads/main".to_string(),
+                    old: Some(c1.to_hex()),
+                    new: c2.to_hex(),
+                    allow_non_fast_forward: false,
+                },
+            },
+            sig: Vec::new(),
+        };
+
+        assert!(matches!(
+            rad.apply_event(&mut state, event),
+            Err(RadError::MissingCapability { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn private_object_publish_requires_ciphertext_cid() {
+        let (conn, store, maintainer, observer, c1, _c2) = fixture().await;
+        let git = GitStore::new(&conn, &store);
+        let rad = RadRepo::new(&git);
+        let mut state = RepoState::new(identity(maintainer.clone(), observer)).unwrap();
+
+        let event = RepoEvent {
+            rid: state.rid.clone(),
+            seq: 0,
+            prev: None,
+            actor: maintainer,
+            ts: 2,
+            kind: RepoEventKind::ObjectPublish {
+                publish: ObjectPublish {
+                    git_oid: c1.to_hex(),
+                    plaintext_cid: None,
+                    ciphertext_cid: None,
+                },
+            },
+            sig: Vec::new(),
+        };
+
+        assert!(matches!(
+            rad.apply_event(&mut state, event),
+            Err(RadError::PrivatePublishWithoutCiphertext)
+        ));
+    }
+
+    #[tokio::test]
+    async fn signing_bytes_exclude_signature() {
+        let (_conn, _store, maintainer, observer, _c1, c2) = fixture().await;
+        let state = RepoState::new(identity(maintainer.clone(), observer)).unwrap();
+        let mut event = RepoEvent {
+            rid: state.rid,
+            seq: 0,
+            prev: None,
+            actor: maintainer,
+            ts: 2,
+            kind: RepoEventKind::RefCreate {
+                update: RefUpdate {
+                    name: "refs/heads/dev".to_string(),
+                    old: None,
+                    new: c2.to_hex(),
+                    allow_non_fast_forward: false,
+                },
+            },
+            sig: vec![1, 2, 3],
+        };
+        let a = event.signing_bytes().unwrap();
+        event.sig = vec![9, 9, 9];
+        let b = event.signing_bytes().unwrap();
+        assert_eq!(a, b);
+    }
+}

--- a/docs/ADR-kotoba-rad-git-sovereign-repo.md
+++ b/docs/ADR-kotoba-rad-git-sovereign-repo.md
@@ -1,0 +1,222 @@
+# ADR: kotoba-rad / kotoba-git sovereign repository layer
+
+**Status**: proposed
+**Date**: 2026-06-28
+**Deciders**: Jun Kawasaki
+
+## Context
+
+`kotoba-git` already gives kotoba a byte-exact Git object bridge:
+
+- Git framed object bytes (`<type> <size>\0<body>`) are stored as CID blocks.
+- `:git/oid` and `:git.object/cid` form the SHA-1 to CID bridge.
+- commits, trees, tags, refs are projected into Datom attributes.
+- loose and packed repos can be imported, and snapshot manifests can rehydrate the Datom projection.
+
+The missing layer is what Radicle provides around Git: repository identity, delegate authority,
+ref authorization, selective replication, source-chain auditability, and peer accountability.
+This ADR names that layer **kotoba-rad** and defines how it composes with `kotoba-git`,
+`kotoba-dht`, `kotoba-auth`, and `kotoba-crypto`.
+
+This is **not** a Radicle protocol implementation. It is a kotoba-native sovereign repository
+layer that fills the same role with CID, Datom, DID, Source Chain, Warrant, and object encryption.
+
+## Decision
+
+### Layer Split
+
+| Layer | Crate / module | Responsibility | Trust boundary |
+|---|---|---|---|
+| Git object fidelity | `kotoba-git` | byte-exact Git object codec, SHA-1 to CID bridge, pack/loose import, refs projection | verifies Git object bytes |
+| Repository identity | `kotoba-rad` design layer | repo id, delegate set, visibility, policies, epoch keys | signed identity journal |
+| Authority / auth | `kotoba-auth` | DID key parsing, CACAO grants, signature verification | signer authority |
+| Source chain / warrants | `kotoba-dht` | append-only per-DID journal, warrants for invalid updates | peer accountability |
+| Object encryption | `kotoba-crypto` | envelope encryption, HPKE now, hybrid PQ later | confidentiality |
+| Distribution | `kotoba-net` / read plane | CID-over-HTTP, gossipsub, bitswap-style replication | transport untrusted |
+
+### Repository ID
+
+`kotoba-rad` defines a repository identity as the CID of the genesis identity document:
+
+```edn
+{:kotoba.rad/type :repo.identity
+ :kotoba.rad/version 1
+ :repo/name "com-junkawasaki/kotoba"
+ :repo/description "kotoba substrate"
+ :repo/visibility :private        ; :public | :private
+ :repo/default-branch "refs/heads/main"
+ :repo/git-hash-suite :git.sha1    ; Git compatibility anchor
+ :repo/block-hash-suite :cid.sha2-256.dag-cbor
+ :repo/delegates [{:did "did:key:z6Mk..."
+                   :role :maintainer
+                   :can [:ref/update :ref/create :object/publish :identity/update]}]
+ :repo/created-at 1782600000000}
+```
+
+`rid = cid(canonical-cbor(identity-doc))`.
+
+The RID is immutable. Mutable repository state is a signed journal of updates that points back
+to the RID.
+
+### Identity Journal
+
+`kotoba-rad` state is an append-only identity journal. Each event is a Source Chain entry signed
+by a current delegate:
+
+```edn
+{:kotoba.rad/type :repo.event
+ :repo/rid "bafy..."
+ :event/seq 12
+ :event/prev "bafy..."
+ :event/kind :ref.update
+ :event/body {:ref/name "refs/heads/main"
+              :ref/old "ef01..."
+              :ref/new "a41b..."
+              :git/manifest-cid "bafy..."}
+ :event/actor "did:key:z6Mk..."
+ :event/sig {:alg :ed25519
+             :bytes "..."}}
+```
+
+Event kinds:
+
+| Event | Purpose | Required authority |
+|---|---|---|
+| `:identity.update` | delegate set, repo policy, crypto suite | `:identity/update` |
+| `:ref.create` | create ref | `:ref/create` |
+| `:ref.update` | fast-forward or allowed non-fast-forward | `:ref/update` |
+| `:ref.delete` | delete ref | `:ref/delete` |
+| `:object.publish` | announce object or manifest availability | `:object/publish` |
+| `:grant.add` | add recipient envelope for private content | `:grant/write` |
+| `:grant.revoke` | revoke future access via epoch rotation | `:grant/revoke` |
+| `:warrant.issue` | publish signed evidence of invalid event | validator authority |
+
+The journal is also projected to Datoms under `:rad.*` so Datalog can answer:
+
+- who can update this ref?
+- what is the current head of `refs/heads/main`?
+- what events led to this head?
+- which recipients can decrypt epoch `N`?
+- which warrants accuse a peer or delegate?
+
+### Ref Authorization
+
+`kotoba-git` stores refs as facts. `kotoba-rad` decides whether a new ref fact is valid.
+
+Validation rules:
+
+1. Actor DID must be a current delegate at the event's parent journal state.
+2. Actor must hold the capability required by `event/kind`.
+3. `event/prev` must match the current journal head unless importing a fork as an explicit branch.
+4. `:ref.update` is fast-forward by default. Non-fast-forward requires policy
+   `{:ref/non-fast-forward true}` or a role with `:ref/force-update`.
+5. `:ref/new` must resolve to a Git commit object present in the `kotoba-git` projection.
+6. Every Git object reachable from the new head must have a `:git.object/cid` bridge.
+7. Private repos may gossip only encrypted objects or availability proofs to non-recipient peers.
+
+Invalid events generate `kotoba-dht` warrants:
+
+| Violation | Warrant rule |
+|---|---|
+| bad event signature | `InvalidSignature` |
+| broken journal sequence | `SeqBreak` |
+| bad `event/prev` | `PrevMismatch` |
+| actor lacks capability | `CacaoInvalid` or future `RadUnauthorizedRefUpdate` |
+| manifest claims missing objects | `ProllyInconsistent` |
+| revoked grant reused | `RekeyRevoked` |
+
+### Object Privacy
+
+Radicle-style selective replication is useful for availability control, but it is not the
+confidentiality boundary. `kotoba-rad` private repositories use object encryption.
+
+For private repos:
+
+- Git framed bytes are encrypted before untrusted replication.
+- The primary fetch key is `ciphertext-cid = hash(ciphertext)`.
+- `plaintext-git-oid` and `plaintext-cid` are authority-scoped metadata.
+- Recipient grants wrap epoch DEKs using `kotoba-crypto`.
+- Revocation is epoch rotation; already distributed ciphertext is assumed unrecoverable only if
+  the revoked party never received the epoch DEK.
+
+Current implementation can use X25519 HPKE-like wrapping from `kotoba-crypto`. The data model must
+carry algorithm tags so it can migrate to hybrid classical + post-quantum wrapping:
+
+```edn
+{:grant/epoch 3
+ :grant/recipient "did:key:z6Mk..."
+ :grant/kdf :hkdf-sha256
+ :grant/kem [:x25519 :ml-kem-768]
+ :grant/aead :aes-256-gcm
+ :grant/wrapped-key-cid "bafy..."}
+```
+
+### Maturity Model
+
+| Stage | Name | Deliverable | Status |
+|---|---|---|---|
+| R0 | Git object bridge | byte-exact objects, refs, pack import, snapshot manifest | implemented in `kotoba-git` |
+| R1 | Signed repo identity | RID, identity journal schema, delegate validation, ref authorization | design target |
+| R2 | Private object store | encrypted Git object blocks, recipient grants, epoch rotation | design target, uses `kotoba-crypto` primitives |
+| R3 | P2P accountability | Source Chain publication, warrants, reputation / replication policy | partial primitives in `kotoba-dht` |
+| R4 | PQ-ready suite | hybrid KEM/signatures, algorithm agility, migration tooling | future |
+
+R1 is the next maturity step. It is mostly schema + validation logic, not a new storage backend.
+
+### API Shape
+
+Proposed Rust facade:
+
+```rust
+pub struct RadRepo<'a> {
+    git: kotoba_git::GitStore<'a>,
+    auth: RadAuthority,
+}
+
+impl<'a> RadRepo<'a> {
+    pub async fn init(identity: RepoIdentity) -> Result<RepoRid>;
+    pub async fn apply_event(&self, event: RepoEvent) -> Result<RepoState>;
+    pub async fn authorize_ref_update(&self, update: RefUpdate) -> Result<()>;
+    pub async fn publish_manifest(&self) -> Result<KotobaCid>;
+    pub async fn import_git_dir(&self, git_dir: &Path, actor: Did) -> Result<ImportReport>;
+}
+```
+
+CLI shape:
+
+```bash
+kotoba rad init --name com-junkawasaki/kotoba --private
+kotoba rad import .git --actor "$KOTOBA_OPERATOR_DID"
+kotoba rad refs
+kotoba rad push --to peer --ref refs/heads/main
+kotoba rad grant add did:key:z6Mk...
+kotoba rad verify --rid bafy...
+```
+
+## Consequences
+
+- Git compatibility remains byte-exact because `kotoba-git` is the only layer that handles Git
+  object materialization.
+- Repository sovereignty moves out of mutable forge accounts and into signed identity journals.
+- Private repos can replicate encrypted bytes through untrusted transport.
+- The design is stricter than Radicle private repos: peer allow-lists are availability policy,
+  not the confidentiality boundary.
+- R1 can be implemented incrementally without changing `kotoba-git` object storage.
+
+## Open Questions
+
+- Whether `kotoba-rad` becomes a new Rust crate or starts as `kotoba-git::rad`.
+- Whether `RepoEvent` should reuse `kotoba-dht::ChainEntry` directly or wrap it with a narrower
+  repository event type.
+- Whether fast-forward validation should materialize commit ancestry through `kotoba-git::log` or
+  maintain a cached reachability index.
+- Which PQ implementation becomes the first production dependency for ML-KEM / ML-DSA.
+
+## References
+
+- `crates/kotoba-git`: Git object bridge and Datom projection.
+- `crates/kotoba-dht`: Source Chain, Warrant, Neighborhood primitives.
+- `crates/kotoba-auth`: DID and CACAO verification.
+- `crates/kotoba-crypto`: envelope, AEAD, HPKE-like X25519 wrapping.
+- `docs/ADR-kotoba-mesh-wasm-hosting.md`: mesh and no-central-master design.
+- `90-docs/adr/2606271600-kotoba-stack-equivalences.md`: Radicle role equivalence and security posture.


### PR DESCRIPTION
## Summary
- add the kotoba-rad crate as a Radicle-inspired sovereign repo layer over kotoba-git
- document kotoba-rad and kotoba-git boundaries for private, content-addressed repo design
- implement repo identity, delegates, capability validation, sequenced events, fast-forward ref updates, and private object publish validation

## Verification
- cargo test -p kotoba-rad