### PR TITLE
fix(kotoba-rad): avoid broken rustdoc link

### DIFF
--- a/crates/kotoba-rad/src/lib.rs
+++ b/crates/kotoba-rad/src/lib.rs
@@ -1,5 +1,5 @@
 //! kotoba-rad: sovereign repository identity and ref authorization over
-//! [`kotoba-git`].
+//! `kotoba-git`.
 //!
 //! This crate is the R1 layer from `docs/ADR-kotoba-rad-git-sovereign-repo.md`.
 //! It deliberately does **not** reimplement Git storage. `kotoba-git` remains


### PR DESCRIPTION
## Summary
- replace a crate-level rustdoc intra-doc link that cannot resolve for the hyphenated crate name

## Verification
- RUSTDOCFLAGS='-D warnings' cargo doc -p kotoba-rad --no-deps